### PR TITLE
Get all page loads under 500ms

### DIFF
--- a/web/db/migrations/001-fast-pages.sql
+++ b/web/db/migrations/001-fast-pages.sql
@@ -1,0 +1,49 @@
+-- Fast page loads: inverted fileset table, sortable build_date column, and a
+-- lower(name) index for the paginated /builds listing. Idempotent — safe to
+-- re-run. Apply to every curator DB (local curator / curator_wiki and the
+-- deployed ones):   psql -d <db> -f db/migrations/001-fast-pages.sql
+--
+-- fileset_entry is derived data (unnest of build_fileset.hashes); the backfill
+-- below fills it for builds that don't have rows yet, and ingest keeps it in
+-- step from then on.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS fileset_entry (
+    hash         BIGINT NOT NULL,
+    build_sha256 TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE
+);
+
+ALTER TABLE builds ADD COLUMN IF NOT EXISTS build_date TEXT;
+
+-- Backfill build_date from the record (detoasts every record — run-once cost).
+-- YYYYMMDD header dates are normalized to YYYY-MM-DD so mixed sources sort together.
+UPDATE builds SET build_date = sub.d
+FROM (
+  SELECT sha256,
+         COALESCE(
+           record->'info'->'volume'->>'creation_date',
+           CASE WHEN record->'info'->'header'->>'release_date' ~ '^\d{8}$'
+                THEN regexp_replace(record->'info'->'header'->>'release_date',
+                                    '^(\d{4})(\d{2})(\d{2})$', '\1-\2-\3')
+                ELSE record->'info'->'header'->>'release_date'
+           END) AS d
+  FROM builds
+) sub
+WHERE builds.sha256 = sub.sha256
+  AND builds.build_date IS DISTINCT FROM sub.d;
+
+INSERT INTO fileset_entry (hash, build_sha256)
+SELECT DISTINCT unnest(bf.hashes), bf.build_sha256
+FROM build_fileset bf
+WHERE NOT EXISTS (SELECT 1 FROM fileset_entry fe WHERE fe.build_sha256 = bf.build_sha256);
+
+COMMIT;
+
+-- Indexes after the bulk load (cheaper than maintaining them during it).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_fileset_entry_hash  ON fileset_entry(hash, build_sha256);
+CREATE INDEX IF NOT EXISTS idx_fileset_entry_build ON fileset_entry(build_sha256);
+CREATE INDEX IF NOT EXISTS idx_builds_name_lower   ON builds (lower(name));
+
+ANALYZE fileset_entry;
+ANALYZE builds;

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -33,11 +33,13 @@ CREATE TABLE builds (
     text_embedding        vector(384),              -- all-MiniLM-L6-v2, computed at ingest
     fingerprint_profile   TEXT NOT NULL,
     record                JSONB NOT NULL,           -- full canonical record
-    ingested_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+    ingested_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    build_date            TEXT                      -- volume creation date, else header release date (sortable copy)
 );
 CREATE INDEX idx_builds_content      ON builds(content_hash);
 CREATE INDEX idx_builds_filtered     ON builds(filtered_content_hash);
 CREATE INDEX idx_builds_system       ON builds(system);
+CREATE INDEX idx_builds_name_lower   ON builds (lower(name));
 CREATE INDEX idx_builds_name_trgm    ON builds USING gin (name gin_trgm_ops);
 CREATE INDEX idx_builds_textdoc_fts  ON builds USING gin (to_tsvector('simple', text_doc));
 CREATE INDEX idx_builds_embedding    ON builds USING hnsw (text_embedding vector_cosine_ops);
@@ -65,6 +67,19 @@ CREATE TABLE build_fileset (
     hashes       BIGINT[] NOT NULL
 );
 CREATE INDEX idx_fileset_gin ON build_fileset USING gin (hashes);
+
+-- Inverted copy of build_fileset (one row per (hash, build)). The shared-files
+-- similarity tier probes this by hash: Postgres never uses the GIN index for
+-- `hashes && $big_array` (its cost model prices arrayoverlap near zero and
+-- seq-scans), which made the tier O(|query| x |candidate|) per row — minutes
+-- for 40k-file builds. Probing (hash, build) pairs + counting is the same
+-- Jaccard (c / (|A|+|B|-c)) at index speed.
+CREATE TABLE fileset_entry (
+    hash         BIGINT NOT NULL,
+    build_sha256 TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX idx_fileset_entry_hash  ON fileset_entry(hash, build_sha256);
+CREATE INDEX idx_fileset_entry_build ON fileset_entry(build_sha256);
 
 -- ── chunk similarity (MinHash + LSH bands) ──────────────────────────────────
 CREATE TABLE build_chunk_signature (

--- a/web/src/app/api/build/[sha256]/tree/route.ts
+++ b/web/src/app/api/build/[sha256]/tree/route.ts
@@ -1,0 +1,43 @@
+import type { NextRequest } from "next/server";
+import { unstable_cache } from "next/cache";
+import { getPool } from "@/lib/db";
+import { buildTree, findByPath, stubChildren, type TreeNode } from "@/lib/filetree";
+import { getBuild } from "@/lib/queries";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// GET /api/build/<sha256>/tree?path=<dir path> — that directory's children,
+// one level deep (child dirs are stubs with subtree aggregates; the FileTree
+// client fetches each level on expand).
+// GET /api/build/<sha256>/tree — the full tree (the "Expand all" path).
+//
+// A build's tree only changes on re-ingest, so responses are safe to cache.
+const CACHE = "public, max-age=3600";
+
+// Expanding folder after folder of the same build would otherwise re-fetch and
+// re-parse the full record (8MB+ for the biggest builds) per click.
+const getTree = unstable_cache(
+  async (sha256: string): Promise<TreeNode[] | null> => {
+    const build = await getBuild(getPool(), sha256);
+    return build ? buildTree(build.record.contents) : null;
+  },
+  ["build-tree"],
+  { revalidate: 3600 }
+);
+
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const roots = await getTree(sha256);
+  if (!roots) return Response.json({ error: "not found" }, { status: 404 });
+  const path = request.nextUrl.searchParams.get("path");
+  if (path == null || path === "") {
+    return Response.json({ roots }, { headers: { "Cache-Control": CACHE } });
+  }
+
+  const node = findByPath(roots, path);
+  if (!node || !node.dir) return Response.json({ error: "no such directory" }, { status: 404 });
+  return Response.json({ children: stubChildren(node.children) }, { headers: { "Cache-Control": CACHE } });
+}

--- a/web/src/app/api/submissions/[sha256]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/route.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { submissionStatus, setSubmissionStatus } from "@/lib/queries";
 import { ingestRecord, refreshAudioIdf } from "@/lib/ingest";
@@ -74,5 +75,7 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
   } finally {
     c.release();
   }
+  // Build pages are cached (revalidate = 3600); make the new build visible now.
+  revalidatePath(`/builds/${sha256}`);
   return Response.json({ sha256, status: "accepted" });
 }

--- a/web/src/app/builds/BuildsBrowser.tsx
+++ b/web/src/app/builds/BuildsBrowser.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useDeferredValue, useMemo, useState } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import RowLink from "./RowLink";
-import type { BuildListItem } from "@/lib/queries";
-
-const DISPLAY_CAP = 500;
+import type { BuildListItem, BuildSortKey } from "@/lib/queries";
 
 function humanSize(bytes?: number): string {
   if (bytes == null) return "—";
@@ -25,60 +24,73 @@ function formatDate(date: string | null): string {
   return m ? m[1] : date;
 }
 
-type SortKey = "name" | "system" | "build_date" | "file_count" | "total_size";
+interface Props {
+  rows: BuildListItem[];
+  total: number;
+  systems: string[];
+  page: number; // 1-based
+  perPage: number;
+  q: string;
+  system: string;
+  sort: BuildSortKey;
+  dir: "asc" | "desc";
+}
 
-export default function BuildsBrowser({ builds }: { builds: BuildListItem[] }) {
-  const [query, setQuery] = useState("");
-  const [system, setSystem] = useState("");
-  const [sort, setSort] = useState<{ key: SortKey; dir: 1 | -1 }>({ key: "name", dir: 1 });
-  // Defer the query the filter reads so typing stays responsive on large lists.
-  const deferredQuery = useDeferredValue(query);
+// Thin URL-driven control: every filter/sort/page change updates the search
+// params and the server re-queries — the client only ever holds one page.
+export default function BuildsBrowser({ rows, total, systems, page, perPage, q, system, sort, dir }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+  const [input, setInput] = useState(q);
+  const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const toggleSort = (key: SortKey) =>
-    setSort((s) => (s.key === key ? { key, dir: (s.dir * -1) as 1 | -1 } : { key, dir: 1 }));
-
-  const systems = useMemo(
-    () => Array.from(new Set(builds.map((b) => b.system))).sort((a, b) => a.localeCompare(b)),
-    [builds]
-  );
-
-  const filtered = useMemo(() => {
-    const q = deferredQuery.trim().toLowerCase();
-    return builds.filter(
-      (b) => (!system || b.system === system) && (!q || b.name.toLowerCase().includes(q))
-    );
-  }, [builds, deferredQuery, system]);
-
-  const sorted = useMemo(() => {
-    const { key, dir } = sort;
-    return [...filtered].sort((a, b) => {
-      if (key === "file_count" || key === "total_size") return (a[key] - b[key]) * dir;
-      if (key === "build_date") {
-        // Missing dates always sort last, regardless of direction.
-        if (!a.build_date && !b.build_date) return 0;
-        if (!a.build_date) return 1;
-        if (!b.build_date) return -1;
-        return a.build_date.localeCompare(b.build_date) * dir;
-      }
-      return a[key].localeCompare(b[key]) * dir;
+  const navigate = (
+    next: Partial<{ q: string; system: string; sort: BuildSortKey; dir: "asc" | "desc"; page: number }>,
+    replace = false
+  ) => {
+    const state = { q, system, sort, dir, page, ...next };
+    const params = new URLSearchParams();
+    if (state.q) params.set("q", state.q);
+    if (state.system) params.set("system", state.system);
+    if (state.sort !== "name") params.set("sort", state.sort);
+    if (state.dir !== "asc") params.set("dir", state.dir);
+    if (state.page > 1) params.set("page", String(state.page));
+    const url = params.size ? `${pathname}?${params}` : pathname;
+    startTransition(() => {
+      if (replace) router.replace(url, { scroll: false });
+      else router.push(url, { scroll: false });
     });
-  }, [filtered, sort]);
+  };
 
-  const shown = sorted.slice(0, DISPLAY_CAP);
+  // Debounced live search; a new query always restarts from page 1.
+  const onInput = (value: string) => {
+    setInput(value);
+    if (debounce.current) clearTimeout(debounce.current);
+    debounce.current = setTimeout(() => navigate({ q: value, page: 1 }, true), 300);
+  };
+  useEffect(() => () => {
+    if (debounce.current) clearTimeout(debounce.current);
+  }, []);
+
+  const toggleSort = (key: BuildSortKey) =>
+    navigate(sort === key ? { dir: dir === "asc" ? "desc" : "asc", page: 1 } : { sort: key, dir: "asc", page: 1 });
+
+  const pages = Math.max(Math.ceil(total / perPage), 1);
 
   return (
     <>
       <div className="mt-4 flex flex-wrap items-center gap-2">
         <input
           type="search"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          value={input}
+          onChange={(e) => onInput(e.target.value)}
           placeholder="Search builds…"
           className="h-9 w-80 rounded-md border border-neutral-300 bg-transparent px-3 text-sm outline-none placeholder:text-neutral-400 focus:border-neutral-500 dark:border-neutral-700"
         />
         <select
           value={system}
-          onChange={(e) => setSystem(e.target.value)}
+          onChange={(e) => navigate({ system: e.target.value, page: 1 })}
           className="h-9 w-48 rounded-md border border-neutral-300 bg-transparent px-3 text-sm outline-none focus:border-neutral-500 dark:border-neutral-700"
         >
           <option value="">All systems</option>
@@ -89,27 +101,26 @@ export default function BuildsBrowser({ builds }: { builds: BuildListItem[] }) {
           ))}
         </select>
         <span className="text-xs text-neutral-400">
-          {filtered.length}
-          {filtered.length !== builds.length ? ` of ${builds.length}` : ""}
+          {total} match{total === 1 ? "" : "es"}
         </span>
       </div>
 
-      {filtered.length === 0 ? (
+      {rows.length === 0 ? (
         <p className="mt-6 text-sm text-neutral-500">No builds match.</p>
       ) : (
-        <table className="mt-4 w-full border-collapse text-sm">
+        <table className={`mt-4 w-full border-collapse text-sm ${isPending ? "opacity-60" : ""}`}>
           <thead>
             <tr className="border-b border-neutral-200/80 text-left text-xs font-medium text-neutral-400 dark:border-neutral-800/80">
-              <Th label="Name" sortKey="name" sort={sort} onSort={toggleSort} />
+              <Th label="Name" sortKey="name" sort={sort} dir={dir} onSort={toggleSort} />
               <th className="px-3 py-1.5">SHA-256</th>
-              <Th label="System" sortKey="system" sort={sort} onSort={toggleSort} />
-              <Th label="Date" sortKey="build_date" sort={sort} onSort={toggleSort} />
-              <Th label="Files" sortKey="file_count" sort={sort} onSort={toggleSort} align="right" />
-              <Th label="Size" sortKey="total_size" sort={sort} onSort={toggleSort} align="right" last />
+              <Th label="System" sortKey="system" sort={sort} dir={dir} onSort={toggleSort} />
+              <Th label="Date" sortKey="build_date" sort={sort} dir={dir} onSort={toggleSort} />
+              <Th label="Files" sortKey="file_count" sort={sort} dir={dir} onSort={toggleSort} align="right" />
+              <Th label="Size" sortKey="total_size" sort={sort} dir={dir} onSort={toggleSort} align="right" last />
             </tr>
           </thead>
           <tbody className="divide-y divide-neutral-100 dark:divide-neutral-900/60">
-            {shown.map((b) => (
+            {rows.map((b) => (
               <tr key={b.sha256} className="hover:bg-neutral-50 dark:hover:bg-neutral-900/40">
                 <td className="h-full p-0 font-medium first:[&>a]:pl-0">
                   <RowLink href={`/builds/${b.sha256}`} focusable className="px-3 hover:underline">{b.name}</RowLink>
@@ -136,10 +147,27 @@ export default function BuildsBrowser({ builds }: { builds: BuildListItem[] }) {
           </tbody>
         </table>
       )}
-      {filtered.length > DISPLAY_CAP && (
-        <p className="mt-2 text-xs text-neutral-400">
-          Showing first {DISPLAY_CAP} of {filtered.length} matches — refine your search.
-        </p>
+
+      {pages > 1 && (
+        <div className="mt-4 flex items-center gap-3 text-sm text-neutral-500">
+          <button
+            className="rounded-md border border-neutral-300 px-2.5 py-1 hover:border-neutral-500 disabled:opacity-40 disabled:hover:border-neutral-300 dark:border-neutral-700"
+            disabled={page <= 1 || isPending}
+            onClick={() => navigate({ page: page - 1 })}
+          >
+            ← Prev
+          </button>
+          <span className="text-xs">
+            page {page} of {pages}
+          </span>
+          <button
+            className="rounded-md border border-neutral-300 px-2.5 py-1 hover:border-neutral-500 disabled:opacity-40 disabled:hover:border-neutral-300 dark:border-neutral-700"
+            disabled={page >= pages || isPending}
+            onClick={() => navigate({ page: page + 1 })}
+          >
+            Next →
+          </button>
+        </div>
       )}
     </>
   );
@@ -149,21 +177,23 @@ function Th({
   label,
   sortKey,
   sort,
+  dir,
   onSort,
   align,
   last,
 }: {
   label: string;
-  sortKey: SortKey;
-  sort: { key: SortKey; dir: 1 | -1 };
-  onSort: (k: SortKey) => void;
+  sortKey: BuildSortKey;
+  sort: BuildSortKey;
+  dir: "asc" | "desc";
+  onSort: (k: BuildSortKey) => void;
   align?: "right";
   last?: boolean;
 }) {
-  const active = sort.key === sortKey;
+  const active = sort === sortKey;
   return (
     <th
-      aria-sort={active ? (sort.dir === 1 ? "ascending" : "descending") : "none"}
+      aria-sort={active ? (dir === "asc" ? "ascending" : "descending") : "none"}
       className={`p-0 ${align === "right" ? "text-right" : ""}`}
     >
       <button
@@ -174,7 +204,7 @@ function Th({
         } ${last ? "pr-0" : ""} ${sortKey === "name" ? "pl-0" : ""}`}
       >
         {label}
-        <span className={`relative top-px text-[8px] leading-none ${active ? "" : "invisible"}`}>{sort.dir === 1 ? "▲" : "▼"}</span>
+        <span className={`relative top-px text-[8px] leading-none ${active ? "" : "invisible"}`}>{dir === "asc" ? "▲" : "▼"}</span>
       </button>
     </th>
   );

--- a/web/src/app/builds/[sha256]/FileTree.tsx
+++ b/web/src/app/builds/[sha256]/FileTree.tsx
@@ -1,18 +1,13 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import type { Node } from "@/lib/types";
-
-interface TreeNode {
-  name: string; // basename, or "a/b/c" for a compressed single-child chain
-  path: string; // full path from root
-  dir: boolean;
-  size?: number;
-  date?: string;
-  children: TreeNode[];
-  fileCount: number; // directories: total files in the subtree
-  totalSize: number; // directories: total bytes in the subtree
-}
+import { useCallback, useState } from "react";
+import {
+  collectDirPaths,
+  findByPath,
+  fullyLoaded,
+  graftChildren,
+  type TreeNode,
+} from "@/lib/filetree";
 
 function humanSize(bytes?: number): string {
   if (bytes == null) return "—";
@@ -37,67 +32,6 @@ function formatDate(date?: string): string {
 const ROW_H = 28;
 const HEADER_H = 28;
 
-const join = (a: string, b: string) => `${a}/${b}`.replace(/\/+/g, "/");
-
-// Directories sort first, then alphabetically (case-insensitive), like a file browser.
-function compareNodes(a: Node, b: Node): number {
-  if ((a.type === "dir") !== (b.type === "dir")) return a.type === "dir" ? -1 : 1;
-  return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
-}
-
-function buildTree(nodes: Node[], prefix: string): TreeNode[] {
-  return [...nodes].sort(compareNodes).map((n) => {
-    const path = join(prefix, n.name);
-    if (n.type !== "dir") {
-      return { name: n.name, path, dir: false, size: n.size, date: n.date, children: [], fileCount: 0, totalSize: n.size ?? 0 };
-    }
-    // Collapse chains of single-child directories into one row (a/b/c).
-    let name = n.name;
-    let cur = path;
-    let date = n.date;
-    let children = n.children;
-    while (children.length === 1 && children[0].type === "dir") {
-      const only = children[0];
-      name = join(name, only.name);
-      cur = join(cur, only.name);
-      date = only.date ?? date;
-      children = only.children;
-    }
-    const built = buildTree(children, cur);
-    const fileCount = built.reduce((acc, c) => acc + (c.dir ? c.fileCount : 1), 0);
-    const totalSize = built.reduce((acc, c) => acc + (c.dir ? c.totalSize : c.size ?? 0), 0);
-    return { name, path: cur, dir: true, date, children: built, fileCount, totalSize };
-  });
-}
-
-// Expand greedily, depth-first, until roughly `budget` rows would be visible — so small
-// builds open fully while huge ones start mostly collapsed.
-function initialExpanded(roots: TreeNode[], budget = 200): Set<string> {
-  const set = new Set<string>();
-  let count = 0;
-  const visit = (nodes: TreeNode[]) => {
-    for (const n of nodes) {
-      if (count++ > budget) return;
-      if (n.dir && n.children.length) {
-        set.add(n.path);
-        visit(n.children);
-      }
-    }
-  };
-  visit(roots);
-  return set;
-}
-
-function collectDirPaths(nodes: TreeNode[], out: string[] = []): string[] {
-  for (const n of nodes) {
-    if (n.dir) {
-      out.push(n.path);
-      collectDirPaths(n.children, out);
-    }
-  }
-  return out;
-}
-
 interface Row {
   node: TreeNode;
   depth: number;
@@ -111,30 +45,98 @@ function visibleRows(nodes: TreeNode[], expanded: Set<string>, depth = 0, out: R
   return out;
 }
 
-export default function FileTree({ nodes }: { nodes: Node[] }) {
-  const tree = useMemo(() => buildTree(nodes, ""), [nodes]);
-  const allDirs = useMemo(() => collectDirPaths(tree), [tree]);
-  const [expanded, setExpanded] = useState<Set<string>>(() => initialExpanded(tree));
+// The server ships only the initially-visible subtree (collapsed dirs are
+// stubs carrying their aggregates); expanding a stub fetches its children from
+// /api/build/<sha256>/tree. "Expand all" fetches the full tree once.
+export default function FileTree({
+  sha256,
+  roots,
+  initiallyExpanded,
+}: {
+  sha256: string;
+  roots: TreeNode[];
+  initiallyExpanded: string[];
+}) {
+  const [tree, setTree] = useState<TreeNode[]>(roots);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(initiallyExpanded));
+  const [loading, setLoading] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
 
-  const rows = useMemo(() => visibleRows(tree, expanded), [tree, expanded]);
+  const rows = visibleRows(tree, expanded);
 
-  const toggle = (path: string) =>
-    setExpanded((prev) => {
+  const setBusy = (path: string, busy: boolean) =>
+    setLoading((prev) => {
       const next = new Set(prev);
-      if (next.has(path)) next.delete(path);
-      else next.add(path);
+      if (busy) next.add(path);
+      else next.delete(path);
       return next;
     });
+
+  const toggle = useCallback(
+    async (path: string) => {
+      if (expanded.has(path)) {
+        setExpanded((prev) => {
+          const next = new Set(prev);
+          next.delete(path);
+          return next;
+        });
+        return;
+      }
+      const node = findByPath(tree, path);
+      if (!node || !node.dir) return;
+      if (!node.loaded) {
+        if (loading.has(path)) return;
+        setBusy(path, true);
+        try {
+          const res = await fetch(`/api/build/${sha256}/tree?path=${encodeURIComponent(path)}`);
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const data: { children: TreeNode[] } = await res.json();
+          setTree((prev) => graftChildren(prev, path, data.children));
+          setError(null);
+        } catch {
+          setError("Failed to load folder contents — try again.");
+          return;
+        } finally {
+          setBusy(path, false);
+        }
+      }
+      setExpanded((prev) => new Set(prev).add(path));
+    },
+    [expanded, tree, loading, sha256]
+  );
+
+  const [expandingAll, setExpandingAll] = useState(false);
+  const expandAll = useCallback(async () => {
+    let full = tree;
+    if (!fullyLoaded(tree)) {
+      setExpandingAll(true);
+      try {
+        const res = await fetch(`/api/build/${sha256}/tree`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: { roots: TreeNode[] } = await res.json();
+        full = data.roots;
+        setTree(full);
+        setError(null);
+      } catch {
+        setError("Failed to load the full tree — try again.");
+        return;
+      } finally {
+        setExpandingAll(false);
+      }
+    }
+    setExpanded(new Set(collectDirPaths(full)));
+  }, [tree, sha256]);
 
   return (
     <>
       <div className="mt-3 flex gap-3 text-xs text-neutral-500">
-        <button className="hover:underline" onClick={() => setExpanded(new Set(allDirs))}>
-          Expand all
+        <button className="hover:underline disabled:opacity-50" onClick={() => void expandAll()} disabled={expandingAll}>
+          {expandingAll ? "Expanding…" : "Expand all"}
         </button>
         <button className="hover:underline" onClick={() => setExpanded(new Set())}>
           Collapse all
         </button>
+        {error && <span className="text-red-500">{error}</span>}
       </div>
       <div className="mt-2">
         <div
@@ -147,6 +149,7 @@ export default function FileTree({ nodes }: { nodes: Node[] }) {
         </div>
         {rows.map(({ node, depth }) => {
           const open = expanded.has(node.path);
+          const busy = loading.has(node.path);
           return (
             <div
               key={node.path}
@@ -165,10 +168,10 @@ export default function FileTree({ nodes }: { nodes: Node[] }) {
               >
                 {node.dir ? (
                   <button
-                    onClick={() => toggle(node.path)}
+                    onClick={() => void toggle(node.path)}
                     className="flex w-full min-w-0 items-center gap-1 text-left text-neutral-600 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-neutral-100"
                   >
-                    <span className="w-3 shrink-0 text-[10px]">{open ? "▾" : "▸"}</span>
+                    <span className="w-3 shrink-0 text-[10px]">{busy ? "⋯" : open ? "▾" : "▸"}</span>
                     <span className="truncate">{node.name}/</span>
                     <span className="shrink-0 text-xs text-neutral-400">({node.fileCount})</span>
                   </button>

--- a/web/src/app/builds/[sha256]/page.tsx
+++ b/web/src/app/builds/[sha256]/page.tsx
@@ -3,34 +3,21 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
+import { buildTree, initialExpanded, pruneToExpanded, treeCounts } from "@/lib/filetree";
 import { getBuild, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities } from "@/lib/queries";
-import type { BuildRecord, Node } from "@/lib/types";
+import type { BuildRecord } from "@/lib/types";
 import SimilarBuilds from "./SimilarBuilds";
 import FileTree from "./FileTree";
 
 export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
-
-interface FlatFile {
-  path: string;
-  size?: number;
-  sha1?: string;
-  date?: string;
-  dir: boolean;
-}
-
-function flatten(nodes: Node[], prefix = ""): FlatFile[] {
-  const out: FlatFile[] = [];
-  for (const n of nodes) {
-    const path = `${prefix}/${n.name}`.replace(/\/+/g, "/");
-    if (n.type === "dir") {
-      out.push({ path, dir: true, date: n.date });
-      out.push(...flatten(n.children, path));
-    } else {
-      out.push({ path, dir: false, size: n.size, sha1: n.sha1, date: n.date });
-    }
-  }
-  return out;
+// The corpus only changes at ingest; render once and serve cached for an hour
+// (the moderation accept endpoint revalidates the affected paths immediately).
+// The empty generateStaticParams is load-bearing: without it a dynamic route
+// is rendered per-request and `revalidate` never engages — with it, pages are
+// ISR-cached on first visit and refreshed in the background.
+export const revalidate = 3600;
+export function generateStaticParams(): Array<{ sha256: string }> {
+  return [];
 }
 
 function humanSize(bytes?: number): string {
@@ -103,9 +90,11 @@ export default async function BuildPage({ params }: { params: Promise<{ sha256: 
 
   const q = deriveQueryFeatures(build.record);
   // Pull a wide candidate set per tier so the fused top-50 is well-populated.
-  const similar = await findSimilar(pool, q, 100);
   // Text neighbors use this build's already-stored embedding — no re-embedding per load.
-  const textNeighbors = await findByEmbeddingOf(pool, sha256, 100);
+  const [similar, textNeighbors] = await Promise.all([
+    findSimilar(pool, q, 100),
+    findByEmbeddingOf(pool, sha256, 100),
+  ]);
   const fused = fuseSimilar(similar, textNeighbors);
 
   // A tier only counts when both builds have its data — attach each build's capabilities
@@ -114,8 +103,10 @@ export default async function BuildPage({ params }: { params: Promise<{ sha256: 
   const queryCaps = caps.get(sha256) ?? [];
   for (const f of fused) f.caps = caps.get(f.sha256) ?? [];
 
-  const files = flatten(build.record.contents);
-  const dirCount = files.filter((f) => f.dir).length;
+  // Ship only the initially-visible subtree; FileTree lazily fetches the rest.
+  const tree = buildTree(build.record.contents);
+  const expanded = initialExpanded(tree);
+  const counts = treeCounts(tree);
   const meta = metaSections(build.record);
   const filteredContentHash = build.record.composites?.filtered_content_hash;
 
@@ -168,9 +159,9 @@ export default async function BuildPage({ params }: { params: Promise<{ sha256: 
 
       <section className="mt-8">
         <h2 className="text-lg font-medium">
-          Files <span className="text-sm font-normal text-neutral-400">({files.length - dirCount} files, {dirCount} dirs)</span>
+          Files <span className="text-sm font-normal text-neutral-400">({counts.files} files, {counts.dirs} dirs)</span>
         </h2>
-        <FileTree nodes={build.record.contents} />
+        <FileTree sha256={sha256} roots={pruneToExpanded(tree, expanded)} initiallyExpanded={[...expanded]} />
       </section>
     </main>
   );

--- a/web/src/app/builds/page.tsx
+++ b/web/src/app/builds/page.tsx
@@ -1,28 +1,57 @@
 import Link from "next/link";
 import { getPool } from "@/lib/db";
-import { listBuilds } from "@/lib/queries";
+import { listBuildsPage, type BuildSortKey } from "@/lib/queries";
 import BuildsBrowser from "./BuildsBrowser";
 
 export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
 
-export default async function BuildsPage() {
-  const pool = getPool();
-  const builds = await listBuilds(pool);
+const PER_PAGE = 100;
+
+const SORT_KEYS: BuildSortKey[] = ["name", "system", "build_date", "file_count", "total_size"];
+
+// Search/filter/sort/pagination all resolve in SQL — the old version shipped
+// every build (a 6MB payload at 16k builds) and filtered client-side.
+export default async function BuildsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const str = (v: string | string[] | undefined) => (typeof v === "string" ? v : "");
+  const q = str(sp.q);
+  const system = str(sp.system);
+  const sort = (SORT_KEYS as string[]).includes(str(sp.sort)) ? (str(sp.sort) as BuildSortKey) : "name";
+  const dir = str(sp.dir) === "desc" ? "desc" : "asc";
+  const page = Math.max(parseInt(str(sp.page), 10) || 1, 1);
+
+  const { rows, total, systems } = await listBuildsPage(getPool(), {
+    q,
+    system,
+    sort,
+    dir,
+    offset: (page - 1) * PER_PAGE,
+    limit: PER_PAGE,
+  });
 
   return (
     <main className="mx-auto max-w-none px-8 py-10">
       <Link href="/" className="text-sm text-neutral-500 hover:underline">&larr; Search</Link>
 
       <h1 className="mt-3 text-2xl font-semibold tracking-tight">
-        Builds <span className="text-sm font-normal text-neutral-400">({builds.length})</span>
+        Builds <span className="text-sm font-normal text-neutral-400">({total})</span>
       </h1>
 
-      {builds.length === 0 ? (
-        <p className="mt-6 text-sm text-neutral-500">No builds in the library yet.</p>
-      ) : (
-        <BuildsBrowser builds={builds} />
-      )}
+      <BuildsBrowser
+        rows={rows}
+        total={total}
+        systems={systems}
+        page={page}
+        perPage={PER_PAGE}
+        q={q}
+        system={system}
+        sort={sort}
+        dir={dir}
+      />
     </main>
   );
 }

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -11,6 +11,10 @@ export function getPool(): Pool {
     }
     pool = new Pool({
       connectionString: url || "postgres:///curator_test",
+      // No page/API query should run longer than this — a runaway query used to
+      // pin a Postgres backend at 100% CPU for minutes per request. The bulk
+      // ingest CLI builds its own pool and is not capped by this.
+      statement_timeout: 15_000,
     });
   }
   return pool;

--- a/web/src/lib/filetree.ts
+++ b/web/src/lib/filetree.ts
@@ -1,0 +1,150 @@
+// Display-tree logic for a build's contents, shared by the build page (server),
+// the lazy subtree API route, and the FileTree client component. Pure data +
+// tree walks — no DB, no React.
+//
+// The server builds the full tree, decides the initially-expanded set, and
+// ships only the nodes needed to render that (collapsed dirs become stubs that
+// keep their subtree aggregates but drop their children). The client fetches a
+// stub's children on first expand. This keeps the RSC payload proportional to
+// what's on screen — a 48k-file build's raw contents is ~13MB of JSON, which
+// used to ride along in full as client-component props.
+
+import type { Node } from "./types";
+
+export interface TreeNode {
+  name: string; // basename, or "a/b/c" for a compressed single-child chain
+  path: string; // full path from root
+  dir: boolean;
+  size?: number;
+  date?: string;
+  children: TreeNode[];
+  fileCount: number; // directories: total files in the subtree
+  totalSize: number; // directories: total bytes in the subtree
+  /** Directories: children present. False = stub; fetch children on expand. */
+  loaded: boolean;
+}
+
+const join = (a: string, b: string) => `${a}/${b}`.replace(/\/+/g, "/");
+
+// Directories sort first, then alphabetically (case-insensitive), like a file browser.
+function compareNodes(a: Node, b: Node): number {
+  if ((a.type === "dir") !== (b.type === "dir")) return a.type === "dir" ? -1 : 1;
+  return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+}
+
+export function buildTree(nodes: Node[], prefix = ""): TreeNode[] {
+  return [...nodes].sort(compareNodes).map((n) => {
+    const path = join(prefix, n.name);
+    if (n.type !== "dir") {
+      return { name: n.name, path, dir: false, size: n.size, date: n.date, children: [], fileCount: 0, totalSize: n.size ?? 0, loaded: true };
+    }
+    // Collapse chains of single-child directories into one row (a/b/c).
+    let name = n.name;
+    let cur = path;
+    let date = n.date;
+    let children = n.children;
+    while (children.length === 1 && children[0].type === "dir") {
+      const only = children[0];
+      name = join(name, only.name);
+      cur = join(cur, only.name);
+      date = only.date ?? date;
+      children = only.children;
+    }
+    const built = buildTree(children, cur);
+    const fileCount = built.reduce((acc, c) => acc + (c.dir ? c.fileCount : 1), 0);
+    const totalSize = built.reduce((acc, c) => acc + (c.dir ? c.totalSize : c.size ?? 0), 0);
+    return { name, path: cur, dir: true, date, children: built, fileCount, totalSize, loaded: true };
+  });
+}
+
+// Expand greedily, depth-first, until roughly `budget` rows would be visible — so small
+// builds open fully while huge ones start mostly collapsed.
+export function initialExpanded(roots: TreeNode[], budget = 200): Set<string> {
+  const set = new Set<string>();
+  let count = 0;
+  const visit = (nodes: TreeNode[]) => {
+    for (const n of nodes) {
+      if (count++ > budget) return;
+      if (n.dir && n.children.length) {
+        set.add(n.path);
+        visit(n.children);
+      }
+    }
+  };
+  visit(roots);
+  return set;
+}
+
+/** Total files/dirs in the (fully-loaded) tree — for the section header. */
+export function treeCounts(roots: TreeNode[]): { files: number; dirs: number } {
+  let files = 0;
+  let dirs = 0;
+  const visit = (nodes: TreeNode[]) => {
+    for (const n of nodes) {
+      if (n.dir) {
+        dirs++;
+        visit(n.children);
+      } else files++;
+    }
+  };
+  visit(roots);
+  return { files, dirs };
+}
+
+/** A dir's children with grandchildren stripped: child dirs keep their
+ *  aggregates but become stubs (one fetch per expand). */
+export function stubChildren(children: TreeNode[]): TreeNode[] {
+  return children.map((c) => (c.dir ? { ...c, children: [], loaded: false } : c));
+}
+
+/** The subtree needed to render `expanded`: expanded dirs keep (recursively
+ *  pruned) children; collapsed dirs become stubs. Input is not mutated. */
+export function pruneToExpanded(roots: TreeNode[], expanded: Set<string>): TreeNode[] {
+  return roots.map((n) => {
+    if (!n.dir) return n;
+    if (!expanded.has(n.path)) return { ...n, children: [], loaded: false };
+    return { ...n, children: pruneToExpanded(n.children, expanded) };
+  });
+}
+
+/** Find a node by its display path (paths embed collapsed chains, so exact
+ *  match against node.path with prefix descent). */
+export function findByPath(roots: TreeNode[], path: string): TreeNode | null {
+  for (const n of roots) {
+    if (n.path === path) return n;
+    if (n.dir && path.startsWith(n.path + "/")) {
+      const hit = findByPath(n.children, path);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+/** New tree with `children` grafted onto the dir at `path` (marks it loaded).
+ *  Structural sharing everywhere else — safe for React state. */
+export function graftChildren(roots: TreeNode[], path: string, children: TreeNode[]): TreeNode[] {
+  return roots.map((n) => {
+    if (!n.dir) return n;
+    if (n.path === path) return { ...n, children, loaded: true };
+    if (path.startsWith(n.path + "/")) return { ...n, children: graftChildren(n.children, path, children) };
+    return n;
+  });
+}
+
+export function collectDirPaths(nodes: TreeNode[], out: string[] = []): string[] {
+  for (const n of nodes) {
+    if (n.dir) {
+      out.push(n.path);
+      collectDirPaths(n.children, out);
+    }
+  }
+  return out;
+}
+
+/** True when every dir in the tree has its children present. */
+export function fullyLoaded(roots: TreeNode[]): boolean {
+  for (const n of roots) {
+    if (n.dir && (!n.loaded || !fullyLoaded(n.children))) return false;
+  }
+  return true;
+}

--- a/web/src/lib/ingest.ts
+++ b/web/src/lib/ingest.ts
@@ -33,6 +33,24 @@ function stripNulls<T>(value: T): T {
   return value;
 }
 
+// Disc mastering date for the sortable builds.build_date column — volume
+// creation date, else the header release date (YYYYMMDD normalized to
+// YYYY-MM-DD so mixed sources sort together). Mirrors the backfill in
+// db/migrations/001-fast-pages.sql.
+function buildDate(rec: BuildRecord): string | null {
+  const info = (rec.info ?? {}) as Record<string, unknown>;
+  const pick = (section: unknown, key: string): string | null => {
+    const v = section && typeof section === "object" ? (section as Record<string, unknown>)[key] : null;
+    if (typeof v === "string" && v) return v;
+    if (typeof v === "number") return String(v);
+    return null;
+  };
+  const raw = pick(info.volume, "creation_date") ?? pick(info.header, "release_date");
+  if (!raw) return null;
+  const m = raw.match(/^(\d{4})(\d{2})(\d{2})$/);
+  return m ? `${m[1]}-${m[2]}-${m[3]}` : raw;
+}
+
 export async function ingestRecord(db: Queryable, rec: BuildRecord): Promise<void> {
   rec = stripNulls(rec);
   const sha = rec.image.sha256;
@@ -55,12 +73,12 @@ export async function ingestRecord(db: Queryable, rec: BuildRecord): Promise<voi
 
   await db.query(
     `INSERT INTO builds (sha256,name,system,size,md5,sha1,content_hash,filtered_content_hash,
-        file_count,total_size,max_depth,ext_histogram,text_doc,fingerprint_profile,record)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
-     ON CONFLICT (sha256) DO UPDATE SET record=excluded.record`,
+        file_count,total_size,max_depth,ext_histogram,text_doc,fingerprint_profile,record,build_date)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+     ON CONFLICT (sha256) DO UPDATE SET record=excluded.record, build_date=excluded.build_date`,
     [sha, rec.image.name, rec.info?.system ?? "", rec.image.size, rec.image.md5, rec.image.sha1,
      comp.content_hash ?? null, comp.filtered_content_hash ?? null, st.file_count, st.total_size, st.max_depth,
-     JSON.stringify(st.ext_histogram ?? {}), rec.text_doc ?? "", rec.fingerprint_profile, rec]
+     JSON.stringify(st.ext_histogram ?? {}), rec.text_doc ?? "", rec.fingerprint_profile, rec, buildDate(rec)]
   );
 
   // Semantic embedding from the build's identity (see semanticDoc), not the
@@ -98,6 +116,12 @@ export async function ingestRecord(db: Queryable, rec: BuildRecord): Promise<voi
   await db.query(
     `INSERT INTO build_fileset (build_sha256,hashes) VALUES ($1,$2)
      ON CONFLICT (build_sha256) DO UPDATE SET hashes=excluded.hashes`,
+    [sha, arrayLit([...fileset])]
+  );
+  // Inverted copy for the shared-files tier (see fileset_entry in schema.sql).
+  await db.query("DELETE FROM fileset_entry WHERE build_sha256=$1", [sha]);
+  await db.query(
+    "INSERT INTO fileset_entry (hash, build_sha256) SELECT unnest($2::bigint[]), $1",
     [sha, arrayLit([...fileset])]
   );
 

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -1,7 +1,7 @@
 // Search + similarity queries (the data layer behind the API routes).
 
 import type { Pool } from "pg";
-import { minhashJaccard, setJaccard, arrayLit, type QueryFeatures, type AudioTrack } from "./fingerprint";
+import { minhashJaccard, arrayLit, type QueryFeatures, type AudioTrack } from "./fingerprint";
 import { tlshDiff } from "./tlsh";
 import type { BuildRecord, SimilarityResult } from "./types";
 import type { FusedBuild, TierKey } from "./tiers";
@@ -189,112 +189,130 @@ export async function logCheck(pool: Pool, sha256: string | null): Promise<void>
   await pool.query("INSERT INTO similarity_log (sha256) VALUES ($1)", [sha256]);
 }
 
-/** Fuse all-tier neighbors for a query build's derived features. */
+/** Fuse all-tier neighbors for a query build's derived features. The tiers are
+ *  independent queries, so they run concurrently (bounded by the pool size). */
 export async function findSimilar(pool: Pool, q: QueryFeatures, limit = 20): Promise<SimilarityResult> {
   const exclude = q.sha256 || "";
   const out: SimilarityResult = {
     identical_content: [], shared_files: [], similar_chunks: [], resemblance: [], exe_imports: [], exe_similar: [], audio_neighbors: [],
   };
+  const tiers: Promise<void>[] = [];
 
   if (q.content_hash) {
-    const r = await pool.query(
+    tiers.push(pool.query(
       "SELECT sha256, name, system FROM builds WHERE content_hash=$1 AND sha256<>$2",
       [q.content_hash, exclude]
-    );
-    out.identical_content = r.rows;
+    ).then((r) => { out.identical_content = r.rows; }));
   }
 
+  // Shared files: exact Jaccard over the file-hash sets, computed from the
+  // inverted fileset_entry table — |A∩B| by indexed probe + count, and
+  // |A∪B| = |A| + |B| − |A∩B| from the stored cardinalities. Identical scores
+  // to intersecting the arrays pairwise, without the seq-scan-per-candidate
+  // arrayoverlap that took minutes on 40k-file builds.
   if (q.fileset.length) {
-    const r = await pool.query(
-      `WITH q AS (SELECT $1::bigint[] AS h)
+    tiers.push(pool.query(
+      `WITH q AS (SELECT DISTINCT h FROM unnest($1::bigint[]) AS u(h)),
+            qn AS (SELECT count(*)::float AS n FROM q),
+            inter AS (
+              SELECT fe.build_sha256, count(*)::float AS c
+              FROM fileset_entry fe JOIN q ON q.h = fe.hash
+              WHERE fe.build_sha256 <> $2
+              GROUP BY fe.build_sha256
+            )
        SELECT b.sha256, b.name, b.system,
-         cardinality(ARRAY(SELECT unnest(f.hashes) INTERSECT SELECT unnest(q.h)))::float
-           / NULLIF(cardinality(ARRAY(SELECT unnest(f.hashes) UNION SELECT unnest(q.h))),0) AS jaccard
-       FROM build_fileset f
-       CROSS JOIN q
-       JOIN builds b ON b.sha256=f.build_sha256
-       WHERE f.build_sha256<>$2 AND f.hashes && q.h
+              i.c / (qn.n + cardinality(f.hashes) - i.c) AS jaccard
+       FROM inter i
+       CROSS JOIN qn
+       JOIN build_fileset f ON f.build_sha256 = i.build_sha256
+       JOIN builds b ON b.sha256 = i.build_sha256
        ORDER BY jaccard DESC LIMIT $3`,
       [arrayLit(q.fileset), exclude, limit]
-    );
-    out.shared_files = r.rows.map((x) => ({ ...x, jaccard: Number(x.jaccard) }));
+    ).then((r) => {
+      out.shared_files = r.rows.map((x) => ({ ...x, jaccard: Number(x.jaccard) }));
+    }));
   }
 
   if (q.bands?.length && q.minhash?.length) {
-    const cand = await pool.query(
+    const mine = q.minhash;
+    tiers.push(pool.query(
       `SELECT s.build_sha256 AS sha256, b.name, b.system, s.minhash
        FROM build_chunk_signature s JOIN builds b ON b.sha256=s.build_sha256
        WHERE s.build_sha256<>$2 AND s.lsh_bands && $1::bigint[]`,
       [arrayLit(q.bands), exclude]
-    );
-    const mine = q.minhash;
-    out.similar_chunks = cand.rows
-      .map((r) => ({
-        sha256: r.sha256 as string,
-        name: r.name as string,
-        system: r.system as string,
-        jaccard: minhashJaccard(mine, r.minhash as string[]),
-      }))
-      .sort((a, b) => b.jaccard - a.jaccard)
-      .slice(0, limit);
+    ).then((cand) => {
+      out.similar_chunks = cand.rows
+        .map((r) => ({
+          sha256: r.sha256 as string,
+          name: r.name as string,
+          system: r.system as string,
+          jaccard: minhashJaccard(mine, r.minhash as string[]),
+        }))
+        .sort((a, b) => b.jaccard - a.jaccard)
+        .slice(0, limit);
+    }));
   }
 
   // Resemblance: byte-shingle — candidates by shared LSH bands, ranked by
   // OPH slot agreement. Catches builds whose big files differ only by scattered small
   // edits (where chunk hashes collapse).
   if (q.resemblanceBands?.length && q.resemblanceMinhash?.length) {
-    const cand = await pool.query(
+    const mine = q.resemblanceMinhash;
+    tiers.push(pool.query(
       `SELECT s.build_sha256 AS sha256, b.name, b.system, s.minhash
        FROM build_resemblance s JOIN builds b ON b.sha256=s.build_sha256
        WHERE s.build_sha256<>$2 AND s.lsh_bands && $1::bigint[]`,
       [arrayLit(q.resemblanceBands), exclude]
-    );
-    const mine = q.resemblanceMinhash;
-    out.resemblance = cand.rows
-      .map((r) => ({
-        sha256: r.sha256 as string,
-        name: r.name as string,
-        system: r.system as string,
-        jaccard: minhashJaccard(mine, r.minhash as string[]),
-      }))
-      .sort((a, b) => b.jaccard - a.jaccard)
-      .slice(0, limit);
+    ).then((cand) => {
+      out.resemblance = cand.rows
+        .map((r) => ({
+          sha256: r.sha256 as string,
+          name: r.name as string,
+          system: r.system as string,
+          jaccard: minhashJaccard(mine, r.minhash as string[]),
+        }))
+        .sort((a, b) => b.jaccard - a.jaccard)
+        .slice(0, limit);
+    }));
   }
 
   // Exe imports: same boot-exe imports (PE imphash equality). TLSH-distance ranking is a
   // future refinement (needs a TLSH compare in the web stack).
   if (q.imphash) {
-    const r = await pool.query(
+    tiers.push(pool.query(
       `SELECT e.build_sha256 AS sha256, b.name, b.system
        FROM exe_fp e JOIN builds b ON b.sha256=e.build_sha256
        WHERE e.imphash=$1 AND e.build_sha256<>$2`,
       [q.imphash, exclude]
-    );
-    out.exe_imports = r.rows;
+    ).then((r) => { out.exe_imports = r.rows; }));
   }
 
   // Exe TLSH: rank stored exe digests by distance (linear scan; small corpus).
   // A TLSH forest would index this at scale.
   if (q.tlsh) {
-    const r = await pool.query(
+    tiers.push(pool.query(
       // Cap the linear TLSH scan to bound work on large corpora.
       `SELECT e.build_sha256 AS sha256, b.name, b.system, e.tlsh
        FROM exe_fp e JOIN builds b ON b.sha256=e.build_sha256
        WHERE e.tlsh IS NOT NULL AND e.build_sha256<>$1
        LIMIT 5000`,
       [exclude]
-    );
-    out.exe_similar = r.rows
-      .map((row) => ({ sha256: row.sha256, name: row.name, system: row.system, distance: tlshDiff(q.tlsh!, row.tlsh) ?? Infinity }))
-      .filter((x) => x.distance <= TLSH_MAX_DISTANCE)
-      .sort((a, b) => a.distance - b.distance)
-      .slice(0, limit);
+    ).then((r) => {
+      out.exe_similar = r.rows
+        .map((row) => ({ sha256: row.sha256, name: row.name, system: row.system, distance: tlshDiff(q.tlsh!, row.tlsh) ?? Infinity }))
+        .filter((x) => x.distance <= TLSH_MAX_DISTANCE)
+        .sort((a, b) => a.distance - b.distance)
+        .slice(0, limit);
+    }));
   }
 
   if (q.audioTracks.length) {
-    out.audio_neighbors = await findAudioSimilar(pool, q.audioTracks, exclude, limit);
+    tiers.push(findAudioSimilar(pool, q.audioTracks, exclude, limit).then((r) => {
+      out.audio_neighbors = r;
+    }));
   }
 
+  await Promise.all(tiers);
   return out;
 }
 
@@ -308,18 +326,20 @@ export interface EmbeddingHit {
 /**
  * Text neighbors for a build already in the corpus — uses its stored embedding
  * (no re-embedding at query time). Empty if the build has no embedding.
+ *
+ * Two steps on purpose: fetching the vector first lets the neighbor query
+ * order by `<=> $param`, which the HNSW index can serve. Joining the vector in
+ * (`ORDER BY b.emb <=> me.emb`) forces a full seq scan + sort over every
+ * embedding in the corpus (~1.9s at 16k builds vs ~40ms indexed).
  */
 export async function findByEmbeddingOf(pool: Pool, sha256: string, limit = 20): Promise<EmbeddingHit[]> {
   const r = await pool.query(
-    `WITH me AS (SELECT text_embedding FROM builds WHERE sha256=$1)
-     SELECT b.sha256, b.name, b.system, 1 - (b.text_embedding <=> me.text_embedding) AS cosine
-     FROM builds b CROSS JOIN me
-     WHERE b.sha256<>$1 AND b.text_embedding IS NOT NULL AND me.text_embedding IS NOT NULL
-     ORDER BY b.text_embedding <=> me.text_embedding
-     LIMIT $2`,
-    [sha256, limit]
+    "SELECT text_embedding::text AS v FROM builds WHERE sha256=$1 AND text_embedding IS NOT NULL",
+    [sha256]
   );
-  return r.rows.map((x) => ({ ...x, cosine: Number(x.cosine) }));
+  const v = r.rows[0]?.v as string | undefined;
+  if (!v) return [];
+  return findByEmbedding(pool, v, sha256, limit);
 }
 
 /** Text: nearest builds by text-embedding cosine (pgvector). For a query vector
@@ -330,15 +350,31 @@ export async function findByEmbedding(
   exclude: string,
   limit = 20
 ): Promise<EmbeddingHit[]> {
-  const r = await pool.query(
-    `SELECT sha256, name, system, 1 - (text_embedding <=> $1::vector) AS cosine
-     FROM builds
-     WHERE sha256<>$2 AND text_embedding IS NOT NULL
-     ORDER BY text_embedding <=> $1::vector
-     LIMIT $3`,
-    [vectorLiteral, exclude, limit]
-  );
-  return r.rows.map((x) => ({ ...x, cosine: Number(x.cosine) }));
+  const c = await pool.connect();
+  try {
+    await c.query("BEGIN");
+    // The HNSW scan yields at most hnsw.ef_search candidates (default 40),
+    // which would silently cap the result below `limit` (and the self row eats
+    // one more). SET LOCAL scopes the raise to this transaction.
+    await c.query("SELECT set_config('hnsw.ef_search', $1, true)", [
+      String(Math.min(Math.max(limit + 20, 40), 1000)),
+    ]);
+    const r = await c.query(
+      `SELECT sha256, name, system, 1 - (text_embedding <=> $1::vector) AS cosine
+       FROM builds
+       WHERE sha256<>$2 AND text_embedding IS NOT NULL
+       ORDER BY text_embedding <=> $1::vector
+       LIMIT $3`,
+      [vectorLiteral, exclude, limit]
+    );
+    await c.query("COMMIT");
+    return r.rows.map((x) => ({ ...x, cosine: Number(x.cosine) }));
+  } catch (e) {
+    await c.query("ROLLBACK").catch(() => {});
+    throw e;
+  } finally {
+    c.release();
+  }
 }
 
 export interface SearchResult {
@@ -411,19 +447,78 @@ export interface BuildListItem {
   build_date: string | null;
 }
 
-/// List stored builds alphabetically (for the /builds index, which filters client-side).
-// No default cap: the /builds page filters/searches this set CLIENT-side, so a
-// LIMIT here silently hides builds past the cut (and the in-page search misses
-// them). Pass an explicit limit only where a bounded set is actually wanted.
-export async function listBuilds(pool: Pool, limit?: number): Promise<BuildListItem[]> {
-  const r = await pool.query(
-    `SELECT sha256, name, system, file_count, total_size, ingested_at,
-            COALESCE(record->'info'->'volume'->>'creation_date',
-                     record->'info'->'header'->>'release_date') AS build_date
-     FROM builds ORDER BY lower(name)${limit != null ? " LIMIT $1" : ""}`,
-    limit != null ? [limit] : []
-  );
-  return r.rows as BuildListItem[];
+export type BuildSortKey = "name" | "system" | "build_date" | "file_count" | "total_size";
+
+export interface BuildsPageOpts {
+  q?: string;
+  system?: string;
+  sort?: BuildSortKey;
+  dir?: "asc" | "desc";
+  offset?: number;
+  limit?: number;
+}
+
+export interface BuildsPageResult {
+  rows: BuildListItem[];
+  /** Builds matching the filter (not just this page). */
+  total: number;
+  /** All systems in the corpus (for the filter dropdown). */
+  systems: string[];
+}
+
+// Whitelist of sortable columns — `sort` is interpolated into ORDER BY, so it
+// must map through this table, never straight from user input.
+const BUILD_SORT: Record<BuildSortKey, string> = {
+  name: "lower(name)",
+  system: "system",
+  build_date: "build_date",
+  file_count: "file_count",
+  total_size: "total_size",
+};
+
+/// One page of the /builds index, filtered and sorted in SQL. Replaces the
+/// old ship-everything listBuilds: 16k+ rows made a 6MB payload and multi-second
+/// renders; the browser now only ever gets one page.
+export async function listBuildsPage(pool: Pool, opts: BuildsPageOpts = {}): Promise<BuildsPageResult> {
+  const conds: string[] = [];
+  const params: unknown[] = [];
+  if (opts.q?.trim()) {
+    // Escape LIKE metacharacters so a user's "100%" searches literally.
+    params.push("%" + opts.q.trim().replace(/[\\%_]/g, "\\$&") + "%");
+    conds.push(`name ILIKE $${params.length}`);
+  }
+  if (opts.system) {
+    params.push(opts.system);
+    conds.push(`system = $${params.length}`);
+  }
+  const where = conds.length ? `WHERE ${conds.join(" AND ")}` : "";
+
+  const key = opts.sort && BUILD_SORT[opts.sort] ? opts.sort : "name";
+  const dir = opts.dir === "desc" ? "DESC" : "ASC";
+  // Missing dates always sort last regardless of direction; lower(name) breaks ties.
+  const order =
+    key === "name"
+      ? `lower(name) ${dir}`
+      : `${BUILD_SORT[key]} ${dir}${key === "build_date" ? " NULLS LAST" : ""}, lower(name)`;
+
+  const limit = Math.min(Math.max(opts.limit ?? 100, 1), 500);
+  const offset = Math.max(opts.offset ?? 0, 0);
+
+  const [rows, count, systems] = await Promise.all([
+    pool.query(
+      `SELECT sha256, name, system, file_count, total_size, ingested_at, build_date
+       FROM builds ${where} ORDER BY ${order}
+       LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+      [...params, limit, offset]
+    ),
+    pool.query(`SELECT count(*)::int AS n FROM builds ${where}`, params),
+    pool.query("SELECT DISTINCT system FROM builds ORDER BY system"),
+  ]);
+  return {
+    rows: rows.rows as BuildListItem[],
+    total: count.rows[0].n as number,
+    systems: systems.rows.map((r) => r.system as string),
+  };
 }
 
 /// Fetch one stored build (with its full canonical record) by sha256.


### PR DESCRIPTION
## Summary

The build pages and `/builds` index were slow to unusable — the worst build page (48k files) exceeded Cloudflare's 100s origin timeout and returned a 524. This PR fixes all five causes; every page now serves at the network floor (~145ms TTFB) once cached.

| page | before | after (cached) | after (first visit) |
|---|---|---|---|
| 48k-file build page | >100s → **524 error** | **143ms** | 3.9s, once |
| 4,535-file build | 71.8s | 145ms | 0.87s |
| 1,073-file build | 21.5s | 152ms | 0.54s |
| 1-file build | 1.9s | 143ms | 0.17s |
| `/builds` index | 5.4s / 1.4MB gz | **117ms / 21KB** | — |

## The five fixes

1. **Shared-files tier: inverted index instead of array intersection.** Postgres never uses the GIN index for `hashes && $param` (its cost model prices arrayoverlap near zero), so the tier seq-scanned all filesets doing O(|query|×|candidate|) work per row — 10.5+ minutes for 44k-file builds. The new `fileset_entry` (hash → build) table computes the identical Jaccard (`c/(|A|+|B|−c)`, verified bit-identical on real data) by indexed probe: 240ms warm on the worst build. Ingest maintains the table; `db/migrations/001-fast-pages.sql` backfills existing DBs.
2. **Embedding neighbors: HNSW-friendly query shape.** `ORDER BY b.text_embedding <=> me.text_embedding` (joined column) forced a seq scan over every embedding (~1.9s on *every* build page). Fetching the stored vector and ordering by `<=> $param` uses the index (~40ms), with `hnsw.ef_search` raised per-transaction so the limit isn't silently capped.
3. **ISR page caching.** Build pages were `force-dynamic`; the corpus only changes at ingest. Now `revalidate = 3600` + an empty `generateStaticParams()` (load-bearing in Next 16 — without it dynamic routes never enter the ISR cache). Moderation-accept revalidates the new build's path.
4. **Lazy file tree.** The page shipped the full `record.contents` (12.7MB JSON for 48k files) as client-component props. The server now sends only the ~200 initially-visible rows plus folder stubs carrying subtree aggregates (`lib/filetree.ts`); children load on expand via `/api/build/[sha256]/tree`.
5. **`/builds` pagination.** The index shipped every build (6.1MB) and filtered client-side. Search/filter/sort/pagination now resolve in SQL (100/page) against a new backfilled `build_date` column.

Plus: `findSimilar` tiers run concurrently, and the pool gets a 15s `statement_timeout` so no request can pin a Postgres backend for minutes again.

## Deployment notes

- Run `web/db/migrations/001-fast-pages.sql` on each DB **before** deploying this code (additive; the site stays up). Applied to local `curator`/`curator_wiki` and hpwiki. **phobos still needs it.**
- deploy.sh's `load-db` merge list now includes `fileset_entry`.
- A redeploy resets the ISR cache; re-crawl the big build pages afterwards to hide the one-time first render.

## Testing

- Unit tests pass (12/12), `tsc --noEmit` clean, `next build` succeeds on this branch.
- Original vs. new fileset query compared on real data: same 188 candidates, max Jaccard divergence 0.0.
- Deployed to hpwiki and measured live (table above); all 500+ builds with ≥3k files prewarmed.