### PR TITLE
Add ps2exe adapter

### DIFF
--- a/ps2exe-adapter/curator-adapter.spec
+++ b/ps2exe-adapter/curator-adapter.spec
@@ -1,0 +1,83 @@
+# -*- mode: python ; coding: utf-8 -*-
+# PyInstaller spec: freeze the curator adapter into one self-contained binary.
+#   pyinstaller curator-adapter.spec        (run from ps2exe-adapter/)
+# Replaces the old bundle.py (which copied a whole CPython tree + ran get-pip):
+# this is ~60 MB vs ~180 MB, needs no network bootstrap, and is a single file the
+# GUIs invoke directly (adapter/curator-adapter[.exe]).
+import sys
+from pathlib import Path
+from PyInstaller.utils.hooks import collect_submodules, collect_all
+
+here = Path(SPECPATH)
+ps2exe = (here.parent / "lib" / "ps2exe").resolve()
+
+# ps2exe's modules are top-level (common/, cdi/, dreamcast/, ...). Its factory imports
+# every console handler statically, so collecting these packages freezes them all.
+ps2exe_pkgs = [
+    "common", "cdi", "dreamcast", "gamecube", "p3do", "cd32", "pc", "ps3",
+    "psx", "psp", "saturn", "megacd", "wii", "xbox", "utils", "post_psx", "lzxd",
+]
+hiddenimports = ["patches", "iso_accessor", "dates", "exceptions", "iso_dir"]
+for pkg in ps2exe_pkgs:
+    hiddenimports += collect_submodules(pkg)
+
+datas, binaries = [], []
+for dep in ("pycdlib", "pyisotools"):
+    d, b, h = collect_all(dep)
+    datas += d
+    binaries += b
+    hiddenimports += h
+
+# ps2exe (utils/archives.py) loads libarchive from <ps2exe>/lib/libarchive/<os>/ via the
+# LIBARCHIVE env var when `import libarchive` can't find a system copy. When frozen,
+# __file__ resolves under sys._MEIPASS, so placing the lib at the same relative path lets
+# that logic find it. macOS is deliberately excluded: it ships a native libarchive that
+# libarchive-c finds via find_library('archive'), and the vendored macosx dylib is
+# x86_64-only — bundling it would force a load that fails on Apple Silicon (arm64).
+_osdir = {"win32": "win64", "linux": "linux"}.get(sys.platform)
+if _osdir:
+    # Bundle the whole dir, not just libarchive.* — it ships the sibling libraries
+    # (libcrypto, liblzma, libzstd, libbz2, …) that libarchive dlopen's at load time.
+    # rthook_libarchive.py then points $LIBARCHIVE at the main lib in this dir.
+    _libdir = ps2exe / "lib" / "libarchive" / _osdir
+    for _f in sorted(_libdir.glob("*")):
+        if _f.is_file():
+            binaries.append((str(_f), f"lib/libarchive/{_osdir}"))
+
+# rarfile (utils/archives.py) shells out to a bundled UnRAR tool when no system
+# 7-Zip/unrar is found, via lib/unrar/<bitness>/UnRAR.exe at the same _MEIPASS-relative
+# path. Only Windows ships a bundled tool (win64, matching our 64-bit builds); off-Windows
+# rarfile finds a system tool. Added as data (an invoked exe, not a linked library).
+if sys.platform == "win32":
+    _unrar = ps2exe / "lib" / "unrar" / "win64"
+    for _f in sorted(_unrar.glob("*")):
+        if _f.is_file():
+            datas.append((str(_f), "lib/unrar/win64"))
+
+a = Analysis(
+    ["pyinstaller_entry.py"],
+    pathex=[str(here), str(ps2exe)],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    # Set $LIBARCHIVE to the bundled lib before the first import. ps2exe's lazy
+    # fallback (catch TypeError, set env, retry) breaks when frozen because the
+    # bootloader's ctypes hook re-raises that TypeError as PyInstallerImportError.
+    runtime_hooks=["rthook_libarchive.py", "rthook_rarfile.py"],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="curator-adapter",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    runtime_tmpdir=None,
+    console=True,
+)

--- a/ps2exe-adapter/curator_adapter/__init__.py
+++ b/ps2exe-adapter/curator_adapter/__init__.py
@@ -1,0 +1,5 @@
+"""Curator adapter — the JSON boundary over ps2exe.
+
+Emits a single canonical-raw JSON document on stdout and NDJSON progress events on
+stderr. See PLAN.md → "The adapter contract".
+"""

--- a/ps2exe-adapter/curator_adapter/__init__.py
+++ b/ps2exe-adapter/curator_adapter/__init__.py
@@ -1,5 +1,5 @@
 """Curator adapter — the JSON boundary over ps2exe.
 
 Emits a single canonical-raw JSON document on stdout and NDJSON progress events on
-stderr. See PLAN.md → "The adapter contract".
+stderr.
 """

--- a/ps2exe-adapter/curator_adapter/audio.py
+++ b/ps2exe-adapter/curator_adapter/audio.py
@@ -1,0 +1,166 @@
+"""Self-contained acoustic fingerprint for CD audio.
+
+A Shazam-style **constellation** fingerprint: pick spectral peaks in the
+time–frequency plane, then hash *pairs* of nearby peaks keyed by their frequencies
+and the time delta between them. Because the hash encodes Δt (not absolute time), a
+constant time offset between two rips — different pregap, leading silence, a shifted
+`.cue` INDEX — cancels out, so the fingerprints still match. The output is a *set* of
+integer hashes, so similarity is still Jaccard (reuses the set-similarity machinery).
+
+No libchromaprint dependency — just numpy. Hash values stay < 2**26 (JSON-number safe).
+
+Part of fingerprint_profile "v1" — changing these constants is a re-scan.
+"""
+
+import re
+
+import numpy as np
+
+_CUE_FILE = re.compile(r'FILE\s+"?(.+?)"?\s+(\w+)\s*$', re.I)
+_CUE_TRACK = re.compile(r"TRACK\s+(\d+)\s+(\S+)", re.I)
+_CUE_INDEX1 = re.compile(r"INDEX\s+01\s+(\d+):(\d+):(\d+)", re.I)
+
+
+def parse_cue(text):
+    """Parse a .cue sheet into [{file, tracks:[{num, type, start_frame}]}]."""
+    files = []
+    cur = None
+    track = None
+    for line in text.splitlines():
+        mf = _CUE_FILE.search(line)
+        if mf:
+            cur = {"file": mf.group(1), "tracks": []}
+            files.append(cur)
+            track = None
+            continue
+        mt = _CUE_TRACK.search(line)
+        if mt and cur is not None:
+            track = {"num": int(mt.group(1)), "type": mt.group(2).upper(), "start_frame": None}
+            cur["tracks"].append(track)
+            continue
+        mi = _CUE_INDEX1.search(line)
+        if mi and track is not None:
+            mm, ss, ff = int(mi.group(1)), int(mi.group(2)), int(mi.group(3))
+            track["start_frame"] = (mm * 60 + ss) * 75 + ff
+    return files
+
+
+SR0 = 44100          # Red Book sample rate
+DECIM = 4            # crude decimation -> ~11025 Hz
+SR = SR0 // DECIM
+FRAME = 1024         # STFT window (~93 ms at 11025 Hz)
+HOP = 512            # ~46 ms hop
+NBINS = FRAME // 2 + 1
+
+# Peak picking / pairing.
+N_BANDS = 6          # log-spaced bands; one candidate peak per band per frame
+FAN = 3              # target peaks paired with each anchor
+FQ_SHIFT = 2         # coarsen peak freq bins (>>2): absorbs sub-frame STFT jitter,
+                     # big robustness win to offset/re-encode with no loss of discrimination
+DT_MIN = 1           # frames (skip same-frame pairs)
+DT_MAX = 63          # frames (~2.9 s target zone); fits Δt in 6 bits
+MAX_PEAKS = 6000     # cap landmarks (bounds set size on dense/noisy audio)
+MAX_HASHES = 12000   # hard cap on the emitted set
+_MASK = (1 << 63) - 1
+
+# raw CDDA sector = 2352 bytes of 16-bit stereo PCM (no sync/header)
+SECTOR = 2352
+# fingerprint at most the first ~90s of a track (90 * 75 sectors) for speed;
+# a deterministic prefix still matches the same track across builds.
+MAX_FP_BYTES = 90 * 75 * SECTOR
+# data-track sectors start with this 12-byte sync pattern
+DATA_SYNC = b"\x00" + b"\xff" * 10 + b"\x00"
+
+# Log-spaced band edges (bin indices) over the musically useful 55–4000 Hz range.
+_LO_BIN = max(1, int(55 * FRAME / SR))
+_HI_BIN = min(NBINS - 1, int(4000 * FRAME / SR))
+_BAND_EDGES = np.unique(
+    np.geomspace(_LO_BIN, _HI_BIN, N_BANDS + 1).astype(int)
+)
+
+
+def is_audio_track(head: bytes, size: int) -> bool:
+    """Heuristic: raw CDDA track = whole sectors and no data-track sync pattern."""
+    if size <= 0 or size % SECTOR != 0:
+        return False
+    return not head.startswith(DATA_SYNC)
+
+
+def _spectrogram(x: np.ndarray) -> np.ndarray:
+    """Magnitude STFT, shape (frames, NBINS)."""
+    nf = 1 + (len(x) - FRAME) // HOP
+    if nf <= 0:
+        return np.empty((0, NBINS), np.float32)
+    win = np.hanning(FRAME).astype(np.float32)
+    out = np.empty((nf, NBINS), np.float32)
+    for i in range(nf):
+        out[i] = np.abs(np.fft.rfft(x[i * HOP : i * HOP + FRAME] * win))
+    return out
+
+
+def _peaks(S: np.ndarray):
+    """Constellation points as a time-ordered list of (frame, freq_bin)."""
+    nf = S.shape[0]
+    edges = _BAND_EDGES
+    nb = len(edges) - 1
+    if nf == 0 or nb <= 0:
+        return []
+
+    peak_bin = np.zeros((nf, nb), np.int32)
+    peak_val = np.zeros((nf, nb), np.float32)
+    for b in range(nb):
+        lo, hi = int(edges[b]), int(edges[b + 1])
+        if hi <= lo:
+            continue
+        seg = S[:, lo:hi]
+        am = seg.argmax(axis=1)
+        peak_bin[:, b] = am + lo
+        peak_val[:, b] = seg[np.arange(nf), am]
+
+    # Keep the stronger half of each frame's band peaks, and drop near-silent frames.
+    frame_mean = peak_val.mean(axis=1, keepdims=True)
+    floor = peak_val.mean() * 0.1
+    mask = (peak_val >= frame_mean) & (peak_val > floor)
+
+    ti, bi = np.nonzero(mask)  # row-major => already sorted by frame, then band
+    fb = peak_bin[ti, bi]
+    pts = list(zip(ti.tolist(), fb.tolist()))
+    if len(pts) > MAX_PEAKS:
+        pts = pts[:MAX_PEAKS]  # earliest-in-time prefix (deterministic)
+    return pts
+
+
+def fingerprint_pcm(raw: bytes) -> list[int]:
+    """Return the constellation sub-fingerprint set for raw 16-bit stereo 44.1kHz PCM."""
+    raw = raw[: len(raw) // 4 * 4]  # whole 4-byte stereo frames only
+    if len(raw) < FRAME * DECIM * 4:
+        return []
+    x = np.frombuffer(raw, dtype="<i2").astype(np.float32)
+    x = x.reshape(-1, 2).mean(axis=1)[::DECIM]  # stereo -> mono, decimate
+    pts = _peaks(_spectrogram(x))
+    if len(pts) < 2:
+        return []
+
+    hashes = set()
+    n = len(pts)
+    for i in range(n):
+        t1, f1 = pts[i]
+        fan = 0
+        j = i + 1
+        while j < n and fan < FAN:
+            t2, f2 = pts[j]
+            dt = t2 - t1
+            if dt < DT_MIN:
+                j += 1
+                continue
+            if dt > DT_MAX:
+                break
+            # (f1>>2) | (f2>>2) | Δt  — translation-invariant via Δt, freq coarsened.
+            q1, q2 = (f1 >> FQ_SHIFT) & 0x3FF, (f2 >> FQ_SHIFT) & 0x3FF
+            h = (q1 << 16) | (q2 << 6) | (dt & 0x3F)
+            hashes.add(h & _MASK)
+            fan += 1
+            j += 1
+        if len(hashes) >= MAX_HASHES:
+            break
+    return sorted(hashes)

--- a/ps2exe-adapter/curator_adapter/cli.py
+++ b/ps2exe-adapter/curator_adapter/cli.py
@@ -250,10 +250,11 @@ def _safe_processor(processor_class, reader, name, system, manager, mods):
         return proc
 
 
-def _process_streaming(path, basename, parent_dir, locator, vtype, mods, manager):
-    """Fingerprint the already-chosen volume by reopening straight to it. Used for
-    every disc whose game lives in a single self-contained volume (PS1/2/3, Saturn,
-    Mega CD, 3DO, combined Dreamcast images, …)."""
+def _process_streaming(path, basename, parent_dir, locator, vtype, mods, manager, work):
+    """Run `work(processor, reader, system)` on the already-chosen volume by
+    reopening straight to it. Used for every disc whose game lives in a single
+    self-contained volume (PS1/2/3, Saturn, Mega CD, 3DO, combined Dreamcast
+    images, …)."""
     factory, base, generic = mods["factory"], mods["base"], mods["generic"]
     with open(path, "rb") as fp:
         parent = mods["directory"](parent_dir)
@@ -263,10 +264,7 @@ def _process_streaming(path, basename, parent_dir, locator, vtype, mods, manager
         system = base.get_system_type(reader) or "unknown"
         processor_class = factory.get_iso_processor_class(system) or generic
         processor = _safe_processor(processor_class, reader, basename, system, manager, mods)
-        info = _gather_info(processor, reader, system, mods)
-        files = _hash_files(reader, manager)
-        exe_fp = _exe_fp_for(info, reader)
-    return info, files, exe_fp, system
+        return work(processor, reader, system)
 
 
 def _has_boot_exe(processor, reader):
@@ -295,8 +293,8 @@ def _has_boot_exe(processor, reader):
         return 0
 
 
-def _process_gdrom(path, basename, parent_dir, mods, manager):
-    """Fingerprint a Dreamcast GD-ROM whose game spans the high-density area.
+def _process_gdrom(path, basename, parent_dir, mods, manager, work):
+    """Run `work` on a Dreamcast GD-ROM whose game spans the high-density area.
 
     The boot volume's files can straddle several tracks, so we let the Dreamcast
     processor reassemble the image from the .cue/.gdi. That assembly reopens sibling
@@ -346,10 +344,7 @@ def _process_gdrom(path, basename, parent_dir, mods, manager):
         if best is None:
             raise _NoHighDensityVolume(path)
         _score, processor, reader, system = best
-        info = _gather_info(processor, reader, system, mods)
-        files = _hash_files(reader, manager)
-        exe_fp = _exe_fp_for(info, reader)
-    return info, files, exe_fp, system
+        return work(processor, reader, system)
 
 
 def _gather_info(processor, reader, system, mods):
@@ -619,20 +614,13 @@ class _ShingleSignature:
             del buf[: len(buf) - (_SHINGLE_W - 1)]
 
 
-def analyze(path):
-    mods = _import_ps2exe()
-    factory, base, generic = mods["factory"], mods["base"], mods["generic"]
-    manager = ProgressManager()
-
-    basename = os.path.basename(path)
-    parent_dir = pathlib.Path(path).resolve().parent
-
-    # Selection pass: enumerate every candidate volume (directory level only — a
-    # one-pass archive can't seek back to member *content* later) and choose the
-    # richest. This is what rescues Dreamcast GD-ROMs: the boot game lives in the
-    # high-density volume, not the first (low-density) one the old "first readable"
-    # pick returned. A non-zero start sector marks that high-density volume, whose
-    # files may span several tracks needing .cue/.gdi reassembly.
+def _select_volume(path, basename, parent_dir, mods, manager):
+    """Selection pass: enumerate every candidate volume (directory level only — a
+    one-pass archive can't seek back to member *content* later) and choose the
+    richest. This is what rescues Dreamcast GD-ROMs: the boot game lives in the
+    high-density volume, not the first (low-density) one the old "first readable"
+    pick returned. A non-zero start sector marks that high-density volume, whose
+    files may span several tracks needing .cue/.gdi reassembly."""
     with open(path, "rb") as fp:
         parent = mods["directory"](parent_dir)
         candidates = _enumerate_volumes(fp, basename, parent, mods, manager)
@@ -648,21 +636,39 @@ def analyze(path):
         needs_assembly = any(
             getattr(getattr(r, "fp", None), "starting_sector", 0) for _loc, r in candidates
         )
+    return locator, vtype, needs_assembly
 
-    # Processing pass: read the chosen volume's bytes. GD-ROM high-density volumes go
-    # through track reassembly; everything else reopens straight to its volume.
+
+def _process(path, basename, parent_dir, mods, manager, work):
+    """Select the disc's primary volume, then run `work(processor, reader, system)`
+    on it. GD-ROM high-density volumes go through track reassembly; everything else
+    reopens straight to its volume. Both analyze and extract funnel through here so
+    an extracted asset always comes from the same volume its record describes."""
+    locator, vtype, needs_assembly = _select_volume(path, basename, parent_dir, mods, manager)
     if needs_assembly:
         try:
-            info, files, exe_fp, system = _process_gdrom(path, basename, parent_dir, mods, manager)
+            return _process_gdrom(path, basename, parent_dir, mods, manager, work)
         except _NoHighDensityVolume:
             # Non-standard disc: assembly found nothing. Read the chosen volume plainly.
-            info, files, exe_fp, system = _process_streaming(
-                path, basename, parent_dir, locator, vtype, mods, manager
-            )
-    else:
-        info, files, exe_fp, system = _process_streaming(
-            path, basename, parent_dir, locator, vtype, mods, manager
-        )
+            pass
+    return _process_streaming(path, basename, parent_dir, locator, vtype, mods, manager, work)
+
+
+def analyze(path):
+    mods = _import_ps2exe()
+    factory = mods["factory"]
+    manager = ProgressManager()
+
+    basename = os.path.basename(path)
+    parent_dir = pathlib.Path(path).resolve().parent
+
+    def work(processor, reader, system):
+        info = _gather_info(processor, reader, system, mods)
+        files = _hash_files(reader, manager)
+        exe_fp = _exe_fp_for(info, reader)
+        return info, files, exe_fp, system
+
+    info, files, exe_fp, system = _process(path, basename, parent_dir, mods, manager, work)
 
     # Audio pass: CDDA scan over the container, on its own fresh pass since processing
     # consumed the stream. Only CD/GD-ROM systems carry red-book audio worth
@@ -676,6 +682,89 @@ def analyze(path):
             media = _scan_audio_tracks(audio_readers, mods, manager)
 
     return {"info": info, "files": files, "media": media, "exe_fp": exe_fp}
+
+
+def extract(path, out_dir):
+    """Copy the image's browser-viewable files (see viewable.py) into the
+    content-addressed store at `out_dir`, returning their metadata. Runs on the
+    same volume analyze() chooses, so asset paths match the record's contents."""
+    mods = _import_ps2exe()
+    manager = ProgressManager()
+
+    basename = os.path.basename(path)
+    parent_dir = pathlib.Path(path).resolve().parent
+
+    def work(processor, reader, system):
+        return _extract_assets(reader, out_dir, manager)
+
+    return {"assets": _process(path, basename, parent_dir, mods, manager, work)}
+
+
+def _extract_assets(reader, out_dir, manager):
+    from . import viewable
+
+    # Candidate list first, bytes second — the same two-step the hashing pass
+    # uses, so one-pass archive streams see opens in iterator order only.
+    entries = []
+    for f in reader.iso_iterator(reader.get_root_dir(), recursive=True, include_dirs=False):
+        path = _clean_path(reader.get_file_path(f))
+        classified = viewable.classify(path)
+        if classified is None:
+            continue
+        try:
+            size = int(reader.get_file_size(f))
+        except Exception:  # noqa: BLE001
+            size = None
+        if size is not None and (size == 0 or size > viewable.MAX_ASSET_SIZE):
+            continue
+        entries.append((f, path, classified))
+
+    out = []
+    with manager.counter(total=len(entries), desc="Extracting assets", unit="files") as pbar:
+        for f, path, (kind, mime) in entries:
+            data = _read_capped(reader, f, viewable.MAX_ASSET_SIZE)
+            pbar.update()
+            if not data or not viewable.sniff(data[: viewable.SNIFF_BYTES], mime):
+                continue
+            sha = hashlib.sha256(data).hexdigest()
+            _store_blob(out_dir, sha, data)
+            out.append({"path": path, "sha256": sha, "size": len(data), "mime": mime, "kind": kind})
+    return out
+
+
+def _read_capped(reader, f, cap):
+    """The file's bytes, or None when unreadable or larger than `cap` (a size
+    the directory record understated must not smuggle an oversized asset in)."""
+    buf = bytearray()
+    try:
+        fh = reader.open_file(f)
+        is_ctx = hasattr(fh, "__enter__")
+        if is_ctx:
+            fh.__enter__()
+        try:
+            while chunk := fh.read(65536):
+                buf.extend(chunk)
+                if len(buf) > cap:
+                    return None
+        finally:
+            with contextlib.suppress(Exception):
+                fh.__exit__(None, None, None) if is_ctx else fh.close()
+    except Exception as e:  # noqa: BLE001
+        logging.getLogger("curator-adapter").debug("asset read failed: %s", e)
+        return None
+    return bytes(buf)
+
+
+def _store_blob(out_dir, sha, data):
+    """Write `data` as `<out_dir>/<sha[:2]>/<sha>`, atomically, once."""
+    final = os.path.join(out_dir, sha[:2], sha)
+    if os.path.exists(final):
+        return
+    os.makedirs(os.path.dirname(final), exist_ok=True)
+    tmp = f"{final}.tmp{os.getpid()}"
+    with open(tmp, "wb") as fh:
+        fh.write(data)
+    os.replace(tmp, final)
 
 
 def _exe_fingerprint(reader, exe_path):
@@ -860,21 +949,26 @@ def main():
     sub = parser.add_subparsers(dest="command", required=True)
     p_an = sub.add_parser("analyze", help="analyze a disc image/container")
     p_an.add_argument("--path", required=True)
+    p_ex = sub.add_parser("extract", help="extract browser-viewable assets into a store")
+    p_ex.add_argument("--path", required=True)
+    p_ex.add_argument("--out", required=True)
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
 
-    if args.command == "analyze":
-        # Force any ps2exe stdout chatter to stderr; stdout is reserved for the result.
-        real_stdout = sys.stdout
-        sys.stdout = sys.stderr
-        try:
+    # Force any ps2exe stdout chatter to stderr; stdout is reserved for the result.
+    real_stdout = sys.stdout
+    sys.stdout = sys.stderr
+    try:
+        if args.command == "analyze":
             result = analyze(args.path)
-        finally:
-            sys.stdout = real_stdout
-        json.dump(result, real_stdout)
-        real_stdout.write("\n")
-        real_stdout.flush()
+        else:
+            result = extract(args.path, args.out)
+    finally:
+        sys.stdout = real_stdout
+    json.dump(result, real_stdout)
+    real_stdout.write("\n")
+    real_stdout.flush()
 
 
 if __name__ == "__main__":

--- a/ps2exe-adapter/curator_adapter/cli.py
+++ b/ps2exe-adapter/curator_adapter/cli.py
@@ -1,0 +1,881 @@
+"""Analyze a disc image/container with ps2exe and emit canonical-raw JSON on stdout.
+
+Progress is streamed as NDJSON on stderr (see progress.ProgressManager). All ps2exe
+logging/prints are forced to stderr so stdout carries only the final JSON document.
+"""
+
+import argparse
+import contextlib
+import datetime as _dt
+import hashlib
+import json
+import logging
+import os
+import pathlib
+import re
+import sys
+
+import blake3
+import numpy as np
+from fastcdc import fastcdc
+
+from .progress import ProgressManager
+
+# FastCDC parameters — part of fingerprint_profile "v1". Changing these is a re-scan.
+_CDC_MIN = 16 * 1024
+_CDC_AVG = 64 * 1024
+_CDC_MAX = 256 * 1024
+# Streaming chunker flush threshold: process once the buffer comfortably exceeds one
+# max-size chunk, so every committed boundary is decided by bytes already in hand.
+# Bounds chunker memory regardless of file size (no whole-file buffering / size cap).
+_CHUNK_FLUSH = 8 * 1024 * 1024
+_HASH63 = (1 << 63) - 1
+
+# Byte-shingle resemblance — One Permutation Hashing over w-byte shingles.
+# Where exact CDC chunk hashes collapse under many small *scattered* edits, this stays
+# high: each edit only perturbs the ~w shingles spanning it. A new RawBytes component
+# (slated for the next fingerprint_profile bump); changing w/k/the hash is a re-scan.
+_SHINGLE_W = 16                          # shingle window (bytes)
+_SHINGLE_K = 128                         # OPH bins == signature length (power of two)
+_SHINGLE_MIN_SIZE = 1 * 1024 * 1024      # only signature files this big (all bins fill)
+_SHINGLE_FLUSH = 2 * 1024 * 1024         # vectorize this many buffered bytes at a time
+_SHINGLE_POLY = np.uint64(1099511628211)            # Rabin–Karp base (odd)
+_SHINGLE_BINSHIFT = np.uint64(63 - _SHINGLE_K.bit_length() + 1)  # top bits → bin index
+_U64 = np.uint64
+_MASK63_NP = np.uint64(_HASH63)
+
+# ps2exe's modules are top-level (common/, cdi/, ...); put its root on sys.path.
+_DEFAULT_PS2EXE = pathlib.Path(__file__).resolve().parents[2] / "lib" / "ps2exe"
+_PS2EXE_DIR = pathlib.Path(os.environ.get("CURATOR_PS2EXE_DIR", _DEFAULT_PS2EXE))
+
+
+def _import_ps2exe():
+    sys.path.insert(0, str(_PS2EXE_DIR))
+    from common.factory import IsoProcessorFactory  # noqa: E402
+    from common.processor import BaseIsoProcessor, GenericIsoProcessor  # noqa: E402
+    from common.iso_path_reader.methods.compressed import CompressedPathReader  # noqa: E402
+    from common.iso_path_reader.methods.directory import DirectoryPathReader  # noqa: E402
+    from patches import apply_patches  # noqa: E402
+
+    apply_patches()
+    return {
+        "factory": IsoProcessorFactory,
+        "base": BaseIsoProcessor,
+        "generic": GenericIsoProcessor,
+        "compressed": CompressedPathReader,
+        "directory": DirectoryPathReader,
+    }
+
+
+_VOLUME_PRIORITY = {
+    "udf": 6,
+    "rock_ridge": 5,
+    "joliet": 4,
+    "iso9660 (HD)": 3,
+    "iso9660 (LD)": 2,
+    "iso9660": 1,
+}
+
+_VERSION_SUFFIX = re.compile(r";\d+$")
+
+
+def _clean_component(c):
+    return _VERSION_SUFFIX.sub("", c)
+
+
+def _clean_path(p):
+    parts = [_clean_component(c) for c in p.strip("/").split("/") if c]
+    return "/" + "/".join(parts)
+
+
+# Fixed-width disc-header fields are NUL/garbage-padded: ps2exe decodes the
+# whole field, so trailing (or embedded) control bytes ride along. Strip C0
+# controls and DEL — they carry no meaning here and a literal NUL cannot even
+# be stored in the downstream Postgres jsonb/text columns.
+_CONTROL_CHARS = {c: None for c in range(0x20)}
+_CONTROL_CHARS[0x7F] = None
+
+
+def _nullify(v):
+    # These header/volume/SFO fields are string-typed in the consumer's schema,
+    # but ps2exe hands a few back as ints (e.g. SFO parental_level). Coerce any
+    # non-None, non-str scalar to a string so a numeric value can't break the
+    # consumer's string deserialization; None stays None.
+    if v is None:
+        return None
+    if not isinstance(v, str):
+        v = str(v)
+    v = v.translate(_CONTROL_CHARS).strip()
+    return v or None
+
+
+def _fmt_date(d):
+    if not isinstance(d, _dt.datetime):
+        return None
+    try:
+        if d.tzinfo is not None:
+            d = d.astimezone(_dt.timezone.utc)
+        return d.strftime("%Y-%m-%d %H:%M:%S")
+    except (ValueError, OverflowError):
+        return None
+
+
+def _safe_dict(fn):
+    try:
+        result = fn()
+        return result if isinstance(result, dict) else {}
+    except Exception as e:  # noqa: BLE001 — ps2exe raises a wide variety
+        logging.getLogger("curator-adapter").warning("metadata step failed: %s", e)
+        return {}
+
+
+# Capped so ranking never walks a whole multi-thousand-file DVD tree; any real
+# game clears it, while a Dreamcast low-density track tops out at its 3 boilerplate
+# files — enough to lose the tiebreaker to the high-density game volume.
+_SCORE_FILE_CAP = 256
+
+
+def _score_volume(reader):
+    """Rank a candidate volume for selection as the disc's primary filesystem.
+
+    Richer volume types win first (UDF/Joliet over bare ISO 9660); ties break on
+    file count. The tiebreaker is what rescues Dreamcast GD-ROMs: the low-density
+    track holds only three boilerplate ISO files, while the high-density track —
+    same `iso9660` type — carries the actual game, so it wins on count."""
+    priority = _VOLUME_PRIORITY.get(getattr(reader, "volume_type", ""), 0)
+    count = 0
+    try:
+        for _ in reader.iso_iterator(reader.get_root_dir(), recursive=True):
+            count += 1
+            if count >= _SCORE_FILE_CAP:
+                break
+    except Exception:  # noqa: BLE001
+        pass
+    return (priority, count)
+
+
+def _enumerate_volumes(fp, basename, parent, mods, manager):
+    """Every leaf filesystem volume reachable from `fp`, paired with the list of
+    archive-member names ('locator') needed to re-reach it (empty = top level).
+
+    Reading member *directories* in a single archive pass is fine; reading member
+    *content* is not, on a one-pass stream. So callers select a volume here, then
+    reopen it via `_open_volume` to actually read bytes."""
+    factory = mods["factory"]
+    readers, _exc = factory.get_iso_path_readers(fp, basename, parent, manager)
+    found = []
+
+    def walk(reader, locator, depth):
+        if not isinstance(reader, mods["compressed"]):
+            found.append((locator, reader))
+            return
+        if depth > 4:
+            return
+        for entry in reader.iso_iterator(reader.get_root_dir(), recursive=True, include_dirs=False):
+            name = os.path.basename(reader.get_file_path(entry))
+            try:
+                fh = reader.open_file(entry)
+                if hasattr(fh, "__enter__"):
+                    fh.__enter__()
+                sub_readers, _e = factory.get_iso_path_readers(fh, name, reader, manager)
+            except Exception:  # noqa: BLE001
+                continue
+            for sr in sub_readers:
+                walk(sr, locator + [name], depth + 1)
+
+    for r in readers:
+        walk(r, [], 0)
+    return found
+
+
+def _open_volume(fp, basename, parent, locator, vtype, mods, manager):
+    """Reopen the volume identified by (`locator`, `vtype`) on a fresh `fp`, opening
+    *only* the members along `locator`. Touching sibling members first would strand
+    a Dreamcast high-density track's content on a single-pass archive stream."""
+    factory = mods["factory"]
+    readers, _exc = factory.get_iso_path_readers(fp, basename, parent, manager)
+
+    def pick(candidates):
+        if not candidates:
+            return None
+        match = [r for r in candidates if getattr(r, "volume_type", None) == vtype]
+        return (match or candidates)[0]
+
+    if not locator:
+        fs = [r for r in readers if not isinstance(r, mods["compressed"])]
+        return pick(fs or readers)
+
+    current = readers
+    for name in locator:
+        container = next((r for r in current if isinstance(r, mods["compressed"])), None)
+        if container is None:
+            return None
+        target = next(
+            (e for e in container.iso_iterator(container.get_root_dir(), recursive=True, include_dirs=False)
+             if os.path.basename(container.get_file_path(e)) == name),
+            None,
+        )
+        if target is None:
+            return None
+        fh = container.open_file(target)
+        if hasattr(fh, "__enter__"):
+            fh.__enter__()
+        current, _e = factory.get_iso_path_readers(fh, name, container, manager)
+    return pick(current)
+
+
+class _NoHighDensityVolume(Exception):
+    """Raised when a disc flagged for GD-ROM assembly exposes no high-density volume
+    on the processing pass — the caller falls back to a plain streaming read."""
+
+
+def _exe_fp_for(info, reader):
+    exe = info.get("exe")
+    if exe and exe.get("filename"):
+        return _exe_fingerprint(reader, exe["filename"])
+    return None
+
+
+def _safe_processor(processor_class, reader, name, system, manager, mods):
+    """Build the processor, falling back to the base initializer if the subclass one
+    raises. Dreamcast's __init__ reassembles GD-ROM tracks from the .cue/.gdi; on
+    non-standard discs (MIL-CD, cheat carts, demos) whose data track sits outside the
+    expected slot that assembly can throw, and a plain read of the chosen volume is
+    the best we can still do."""
+    try:
+        return processor_class(reader, name, system, manager)
+    except Exception:  # noqa: BLE001
+        proc = processor_class.__new__(processor_class)
+        mods["base"].__init__(proc, reader, name, system, manager)
+        return proc
+
+
+def _process_streaming(path, basename, parent_dir, locator, vtype, mods, manager):
+    """Fingerprint the already-chosen volume by reopening straight to it. Used for
+    every disc whose game lives in a single self-contained volume (PS1/2/3, Saturn,
+    Mega CD, 3DO, combined Dreamcast images, …)."""
+    factory, base, generic = mods["factory"], mods["base"], mods["generic"]
+    with open(path, "rb") as fp:
+        parent = mods["directory"](parent_dir)
+        reader = _open_volume(fp, basename, parent, locator, vtype, mods, manager)
+        if reader is None:
+            raise SystemExit(f"could not reopen chosen volume in {path!r}")
+        system = base.get_system_type(reader) or "unknown"
+        processor_class = factory.get_iso_processor_class(system) or generic
+        processor = _safe_processor(processor_class, reader, basename, system, manager, mods)
+        info = _gather_info(processor, reader, system, mods)
+        files = _hash_files(reader, manager)
+        exe_fp = _exe_fp_for(info, reader)
+    return info, files, exe_fp, system
+
+
+def _has_boot_exe(processor, reader):
+    """1 if this volume's filesystem holds the boot executable IP.BIN names, else 0.
+
+    Dreamcast's IP.BIN bootstrap (shared across every high-density volume) records
+    the boot filename at offset 0x60; the volume that actually *boots* is the one
+    whose filesystem contains that file. Ranking on this is deterministic — the
+    chosen volume is, by construction, the one hash_exe() can read the date from.
+    File count stays only as a tiebreaker/fallback (see _process_gdrom), so a
+    multi-partition disc's asset volume no longer outvotes the boot volume on sheer
+    file count, and demos with no resolvable boot file still fall through cleanly."""
+    get_name = getattr(processor, "get_exe_filename", None)
+    if get_name is None:
+        return 0
+    try:
+        boot = get_name()
+    except Exception:  # noqa: BLE001 — garbage IP.BIN region on a non-boot volume
+        return 0
+    if not boot:
+        return 0
+    try:
+        reader.get_file(boot.strip())
+        return 1
+    except Exception:  # noqa: BLE001 — boot file is not in this volume's filesystem
+        return 0
+
+
+def _process_gdrom(path, basename, parent_dir, mods, manager):
+    """Fingerprint a Dreamcast GD-ROM whose game spans the high-density area.
+
+    The boot volume's files can straddle several tracks, so we let the Dreamcast
+    processor reassemble the image from the .cue/.gdi. That assembly reopens sibling
+    tracks, which a single-pass archive only permits while we are still on the
+    triggering member — so the processor must be built in the same pass that opens
+    the high-density track (no prior enumeration of this stream). The reassembled
+    reader is seekable (its tracks are mmapped), so we rank candidates by file count
+    and hash only the richest."""
+    factory, base, generic = mods["factory"], mods["base"], mods["generic"]
+    with open(path, "rb") as fp:
+        parent = mods["directory"](parent_dir)
+        readers, _exc = factory.get_iso_path_readers(fp, basename, parent, manager)
+        container = next((r for r in readers if isinstance(r, mods["compressed"])), None)
+        members = (
+            list(container.iso_iterator(container.get_root_dir(), recursive=True, include_dirs=False))
+            if container else [None]
+        )
+        best = None  # (score, processor, reader, system); score = (has_boot_exe, file_count)
+        for entry in members:
+            if container is not None:
+                name = os.path.basename(container.get_file_path(entry))
+                try:
+                    fh = container.open_file(entry)
+                    if hasattr(fh, "__enter__"):
+                        fh.__enter__()
+                    volumes, _e = factory.get_iso_path_readers(fh, name, container, manager)
+                except Exception:  # noqa: BLE001
+                    continue
+            else:
+                name, volumes = basename, readers
+            for vol in volumes:
+                # Only high-density volumes carry the boot game and trigger assembly.
+                if not getattr(getattr(vol, "fp", None), "starting_sector", 0):
+                    continue
+                system = base.get_system_type(vol) or "dreamcast"
+                processor_class = factory.get_iso_processor_class(system) or generic
+                try:
+                    processor = _safe_processor(processor_class, vol, name, system, manager, mods)
+                except Exception:  # noqa: BLE001 — a later HD volume can't reopen consumed tracks
+                    continue
+                reader = processor.iso_path_reader  # reassembled (or the raw volume on fallback)
+                # Prefer the volume that holds the IP.BIN-named boot exe (deterministic);
+                # break ties / fall back on file count for discs with no resolvable boot.
+                score = (_has_boot_exe(processor, reader), _score_volume(reader)[1])
+                if best is None or score > best[0]:
+                    best = (score, processor, reader, system)
+        if best is None:
+            raise _NoHighDensityVolume(path)
+        _score, processor, reader, system = best
+        info = _gather_info(processor, reader, system, mods)
+        files = _hash_files(reader, manager)
+        exe_fp = _exe_fp_for(info, reader)
+    return info, files, exe_fp, system
+
+
+def _gather_info(processor, reader, system, mods):
+    disc = _safe_dict(processor.get_disc_type)
+    pvd = _safe_dict(processor.get_pvd_info)
+    if not pvd:
+        pvd = _safe_dict(reader.get_pvd_info)
+    extra = _safe_dict(processor.get_extra_fields)
+    exe = _safe_dict(processor.hash_exe)
+
+    header = {
+        "title": _nullify(extra.get("header_title")),
+        "product_number": _nullify(extra.get("header_product_number")),
+        "product_version": _nullify(extra.get("header_product_version")),
+        "release_date": _nullify(extra.get("header_release_date")),
+        "maker_id": _nullify(extra.get("header_maker_id")),
+        "device_info": _nullify(extra.get("header_device_info")),
+        "regions": _nullify(extra.get("header_regions")),
+    }
+    volume = {
+        "identifier": _nullify(pvd.get("volume_identifier")),
+        "set_identifier": _nullify(pvd.get("volume_set_identifier")),
+        "creation_date": _fmt_date(pvd.get("volume_creation_date")),
+        "modification_date": _fmt_date(pvd.get("volume_modification_date")),
+        "expiration_date": _fmt_date(pvd.get("volume_expiration_date")),
+        "effective_date": _fmt_date(pvd.get("volume_effective_date")),
+    }
+
+    # Boot executable. `exe_signing_type`/`exe_num_symbols` ride in get_extra_fields, so
+    # the block can exist even when hash_exe() found no filename (e.g. Xbox).
+    exe_filename = _nullify(exe.get("exe_filename"))
+    signing_type = _nullify(extra.get("exe_signing_type"))
+    num_symbols = extra.get("exe_num_symbols")
+    if not isinstance(num_symbols, int):
+        num_symbols = None
+    exe_out = None
+    if exe_filename or signing_type or num_symbols is not None:
+        exe_out = {
+            "filename": _clean_path(exe_filename) if exe_filename else None,
+            "date": _fmt_date(exe.get("exe_date")),
+            "signing_type": signing_type,
+            "num_symbols": num_symbols,
+        }
+
+    # Alternate/decrypted boot executable: PSP BOOT.BIN, PS3 decrypted EBOOT, Xbox(360)
+    # decrypted PE. md5 is the stable identity since the on-disc exe is encrypted.
+    alt_filename = _nullify(extra.get("alt_exe_filename"))
+    alt_md5 = _nullify(extra.get("alt_md5"))
+    alt_exe = None
+    if alt_filename or alt_md5:
+        alt_exe = {
+            "filename": _clean_path(alt_filename) if alt_filename else None,
+            "date": _fmt_date(extra.get("alt_exe_date")),
+            "md5": alt_md5,
+        }
+
+    # PARAM.SFO metadata — PSP/PS3 carry this instead of a header_* block.
+    sfo = {
+        "title": _nullify(extra.get("sfo_title")),
+        "disc_id": _nullify(extra.get("sfo_disc_id")),
+        "disc_version": _nullify(extra.get("sfo_disc_version")),
+        "category": _nullify(extra.get("sfo_category")),
+        "parental_level": _nullify(extra.get("sfo_parental_level")),
+        "system_version": _nullify(extra.get("sfo_psp_system_version")),
+    }
+    if not any(sfo.values()):
+        sfo = None
+
+    return {
+        "system": system,
+        "system_identifier": _nullify(pvd.get("system_identifier")),
+        "header": header,
+        "volume": volume,
+        "exe": exe_out,
+        "alt_exe": alt_exe,
+        "sfo": sfo,
+        "disc_type": _nullify(disc.get("disc_type")),
+    }
+
+
+def _hash_files(reader, manager):
+    files = []
+    file_list = list(reader.iso_iterator(reader.get_root_dir(), recursive=True, include_dirs=True))
+    with manager.counter(total=len(file_list), desc="Hashing files", unit="files") as pbar, \
+            manager.counter(total=0, unit="B", file_name="") as hbar:
+        for f in file_list:
+            path = reader.get_file_path(f)
+            is_dir = bool(reader.is_directory(f))
+            rec = {"path": _clean_path(path), "is_dir": is_dir}
+            date = None
+            try:
+                date = reader.get_file_date(f)
+            except Exception:  # noqa: BLE001
+                pass
+            d = _fmt_date(date)
+            if d:
+                rec["date"] = d
+            size = None
+            try:
+                size = int(reader.get_file_size(f))
+                rec["size"] = size
+            except Exception:  # noqa: BLE001
+                pass
+
+            if not is_dir:
+                _hash_one(reader, f, rec, size, hbar)
+
+            files.append(rec)
+            pbar.update()
+    return files
+
+
+def _hash_one(reader, f, rec, size, hbar):
+    md5 = hashlib.md5(usedforsecurity=False)
+    sha1 = hashlib.sha1(usedforsecurity=False)
+    sha256 = hashlib.sha256()
+    read = 0
+    # Content-defined chunks, streamed so even multi-GB files are chunked
+    # without buffering them whole.
+    chunker = _StreamingChunker()
+    # Byte-shingle resemblance signature for large files only — the big blobs
+    # where scattered small edits matter; tiny files lean on their whole-file hash.
+    shingler = _ShingleSignature() if size is not None and size >= _SHINGLE_MIN_SIZE else None
+    hbar.total = float(size or 0)
+    hbar.count = 0.0
+    hbar.update(incr=0, file_name=os.path.basename(rec["path"]))
+    try:
+        fh = reader.open_file(f)
+        is_ctx = hasattr(fh, "__enter__")
+        if is_ctx:
+            fh.__enter__()
+        try:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                md5.update(chunk)
+                sha1.update(chunk)
+                sha256.update(chunk)
+                chunker.update(chunk)
+                if shingler is not None:
+                    shingler.update(chunk)
+                read += len(chunk)
+                hbar.update(len(chunk))
+        finally:
+            with contextlib.suppress(Exception):
+                fh.__exit__(None, None, None) if is_ctx else fh.close()
+    except Exception as e:  # noqa: BLE001
+        logging.getLogger("curator-adapter").debug("hash failed for %s: %s", rec["path"], e)
+        rec["unreadable"] = True
+        return
+
+    if read:
+        rec["md5"] = md5.hexdigest()
+        rec["sha1"] = sha1.hexdigest()
+        rec["sha256"] = sha256.hexdigest()
+        if size is not None and read != size:
+            rec["unreadable"] = True
+        chunks = chunker.finish()
+        if chunks:
+            rec["chunks"] = chunks
+        if shingler is not None:
+            sig = shingler.finish()
+            if sig is not None:
+                rec["shingle"] = sig
+    elif size:
+        rec["unreadable"] = True
+
+
+def _chunk_pair(data):
+    """One content-defined chunk → [blake3_63bit, length] pair."""
+    h = int.from_bytes(blake3.blake3(data).digest()[:8], "little") & _HASH63
+    return [h, len(data)]
+
+
+class _StreamingChunker:
+    """Feed file bytes incrementally; collect content-defined [hash63, len] chunks
+    without ever holding the whole file in memory.
+
+    FastCDC's boundaries are stateless across chunks (the gear pattern resets at each
+    cut) and depend only on the <= max_size bytes following a cut. So we buffer, and
+    once the buffer holds well over one max-size chunk we run fastcdc and commit every
+    chunk *except the last* — the last may extend past the current buffer, so we defer
+    it and re-cut it together with the next bytes. The committed stream is therefore
+    byte-identical to chunking the whole file at once, but memory stays bounded.
+    """
+
+    def __init__(self):
+        self._buf = bytearray()
+        self.chunks = []
+
+    def update(self, data):
+        self._buf.extend(data)
+        if len(self._buf) >= _CHUNK_FLUSH:
+            self._flush(final=False)
+
+    def finish(self):
+        self._flush(final=True)
+        return self.chunks
+
+    def _flush(self, final):
+        if not self._buf:
+            return
+        cuts = list(
+            fastcdc(bytes(self._buf), min_size=_CDC_MIN, avg_size=_CDC_AVG, max_size=_CDC_MAX, fat=True)
+        )
+        if not cuts:
+            return
+        # Defer the trailing chunk unless this is EOF — it may still grow.
+        keep = cuts if final else cuts[:-1]
+        for c in keep:
+            self.chunks.append(_chunk_pair(c.data))
+        if final:
+            self._buf.clear()
+        else:
+            tail = cuts[-1].length
+            del self._buf[: len(self._buf) - tail]
+
+
+class _ShingleSignature:
+    """Streaming One-Permutation-Hashing resemblance signature over w-byte shingles.
+
+    Slides a w-byte window one byte at a time, hashes each window (Rabin–Karp + an
+    avalanche mix), buckets the hashes into K bins by their top bits, and keeps the
+    minimum per bin. The K-slot result is MinHash-comparable: the fraction of slots two
+    files agree on estimates the Jaccard of their shingle sets — which stays ~1.0 even
+    when edits are sprinkled across the file, because each edit only disturbs the ~w
+    shingles spanning it.
+
+    Bytes are fed incrementally and processed a buffer at a time (carrying a (w-1)-byte
+    tail so every window is hashed exactly once), so even multi-GB files are summarized
+    without being held in memory.
+    """
+
+    def __init__(self):
+        self._sig = np.full(_SHINGLE_K, _HASH63, dtype=_U64)
+        self._buf = bytearray()
+        self._any = False
+
+    def update(self, data):
+        self._buf.extend(data)
+        if len(self._buf) >= _SHINGLE_FLUSH:
+            self._flush()
+
+    def finish(self):
+        self._flush(final=True)
+        return [int(x) for x in self._sig] if self._any else None
+
+    def _flush(self, final=False):
+        buf = self._buf
+        if len(buf) >= _SHINGLE_W:
+            arr = np.frombuffer(bytes(buf), dtype=np.uint8).astype(_U64)
+            nwin = len(arr) - _SHINGLE_W + 1
+            # Horner over the window: h = b0·P^(w-1) + … + b_{w-1}  (mod 2^64).
+            h = arr[:nwin].copy()
+            for j in range(1, _SHINGLE_W):
+                h *= _SHINGLE_POLY
+                h += arr[j : j + nwin]
+            # Avalanche-mix so overlapping windows decorrelate; keep low 63 bits.
+            h ^= h >> _U64(33)
+            h *= _U64(0xFF51AFD7ED558CCD)
+            h ^= h >> _U64(33)
+            h &= _MASK63_NP
+            np.minimum.at(self._sig, (h >> _SHINGLE_BINSHIFT).astype(np.intp), h)
+            self._any = True
+        # Carry the trailing (w-1) bytes — they can't start a full window yet.
+        if final:
+            buf.clear()
+        else:
+            del buf[: len(buf) - (_SHINGLE_W - 1)]
+
+
+def analyze(path):
+    mods = _import_ps2exe()
+    factory, base, generic = mods["factory"], mods["base"], mods["generic"]
+    manager = ProgressManager()
+
+    basename = os.path.basename(path)
+    parent_dir = pathlib.Path(path).resolve().parent
+
+    # Selection pass: enumerate every candidate volume (directory level only — a
+    # one-pass archive can't seek back to member *content* later) and choose the
+    # richest. This is what rescues Dreamcast GD-ROMs: the boot game lives in the
+    # high-density volume, not the first (low-density) one the old "first readable"
+    # pick returned. A non-zero start sector marks that high-density volume, whose
+    # files may span several tracks needing .cue/.gdi reassembly.
+    with open(path, "rb") as fp:
+        parent = mods["directory"](parent_dir)
+        candidates = _enumerate_volumes(fp, basename, parent, mods, manager)
+        if not candidates:
+            raise SystemExit(f"no readable volume found in {path!r} (unsupported format?)")
+        locator, chosen = max(candidates, key=lambda c: _score_volume(c[1]))
+        vtype = getattr(chosen, "volume_type", None)
+        # Route to GD-ROM assembly whenever ANY high-density volume exists — the
+        # Dreamcast boot game always lives there. Keying on the richest volume's start
+        # sector (old behaviour) mis-routes discs whose LOW-density area is a fat
+        # PC/asset partition (jpg/bmp galleries) that outweighs the few-file boot
+        # track: they got streamed from the wrong volume and lost the exe date.
+        needs_assembly = any(
+            getattr(getattr(r, "fp", None), "starting_sector", 0) for _loc, r in candidates
+        )
+
+    # Processing pass: read the chosen volume's bytes. GD-ROM high-density volumes go
+    # through track reassembly; everything else reopens straight to its volume.
+    if needs_assembly:
+        try:
+            info, files, exe_fp, system = _process_gdrom(path, basename, parent_dir, mods, manager)
+        except _NoHighDensityVolume:
+            # Non-standard disc: assembly found nothing. Read the chosen volume plainly.
+            info, files, exe_fp, system = _process_streaming(
+                path, basename, parent_dir, locator, vtype, mods, manager
+            )
+    else:
+        info, files, exe_fp, system = _process_streaming(
+            path, basename, parent_dir, locator, vtype, mods, manager
+        )
+
+    # Audio pass: CDDA scan over the container, on its own fresh pass since processing
+    # consumed the stream. Only CD/GD-ROM systems carry red-book audio worth
+    # fingerprinting; gating here also avoids the DVD/UMD/Blu-ray/STFS systems whose
+    # content packages trip ps2exe's re-iteration bug (ConsumedArchiveEntry).
+    media = []
+    if system in AUDIO_SYSTEMS:
+        with open(path, "rb") as fp:
+            parent = mods["directory"](parent_dir)
+            audio_readers, _exc = factory.get_iso_path_readers(fp, basename, parent, manager)
+            media = _scan_audio_tracks(audio_readers, mods, manager)
+
+    return {"info": info, "files": files, "media": media, "exe_fp": exe_fp}
+
+
+def _exe_fingerprint(reader, exe_path):
+    """Boot-exe fingerprint: TLSH (any bytes) + imphash (PE only)."""
+    import tlsh
+
+    target = None
+    for f in reader.iso_iterator(reader.get_root_dir(), recursive=True, include_dirs=False):
+        if _clean_path(reader.get_file_path(f)) == exe_path:
+            target = f
+            break
+    if target is None:
+        return None
+    try:
+        fh = reader.open_file(target)
+        is_ctx = hasattr(fh, "__enter__")
+        if is_ctx:
+            fh.__enter__()
+        try:
+            data = fh.read()
+        finally:
+            with contextlib.suppress(Exception):
+                fh.__exit__(None, None, None) if is_ctx else fh.close()
+    except Exception:  # noqa: BLE001
+        return None
+
+    if not data or len(data) < 256:
+        return None
+
+    th = tlsh.hash(data)
+    if th in ("", "TNULL"):
+        th = None
+
+    imphash = None
+    if data[:2] == b"MZ":  # PE
+        try:
+            import pefile
+
+            pe = pefile.PE(data=data, fast_load=True)
+            pe.parse_data_directories(
+                directories=[pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_IMPORT"]]
+            )
+            imphash = pe.get_imphash() or None
+        except Exception:  # noqa: BLE001
+            imphash = None
+
+    if not th and not imphash:
+        return None
+    return {"tlsh": th, "imphash": imphash}
+
+
+# CD/GD-ROM systems whose dumps can carry red-book (CDDA) audio tracks. Other
+# detected systems are DVD/UMD/Blu-ray/digital (no CDDA), so the audio scan is
+# skipped for them — see analyze(). ps2exe system ids; ps2 is deliberately out
+# (DVD-era, CDDA vanishingly rare, and its content packages trip the scan bug).
+AUDIO_SYSTEMS = frozenset({"megacd", "saturn", "ps1", "3do", "cdi", "cd32", "dreamcast"})
+
+
+def _scan_audio_tracks(readers, mods, manager):
+    """Fingerprint raw CDDA audio tracks.
+
+    Two layouts: a single combined .bin described by a .cue (Redump), or one .bin per
+    track sitting beside the data track."""
+    media = []
+    containers = [r for r in readers if isinstance(r, mods["compressed"])]
+    for r in containers:
+        cue_media = _scan_cue_audio(r)
+        if cue_media is not None:
+            media.extend(cue_media)
+        else:
+            media.extend(_scan_member_audio(r))
+    return media
+
+
+def _read_entry(reader, entry, length=None):
+    fh = reader.open_file(entry)
+    is_ctx = hasattr(fh, "__enter__")
+    if is_ctx:
+        fh.__enter__()
+    try:
+        return fh.read() if length is None else fh.read(length)
+    finally:
+        with contextlib.suppress(Exception):
+            fh.__exit__(None, None, None) if is_ctx else fh.close()
+
+
+def _scan_member_audio(r):
+    """Per-member: separate raw-CDDA .bin tracks beside the data track."""
+    from . import audio
+
+    out = []
+    for entry in r.iso_iterator(r.get_root_dir(), recursive=True, include_dirs=False):
+        path = r.get_file_path(entry)
+        try:
+            size = int(r.get_file_size(entry))
+        except Exception:  # noqa: BLE001
+            continue
+        try:
+            fh = r.open_file(entry)
+            is_ctx = hasattr(fh, "__enter__")
+            if is_ctx:
+                fh.__enter__()
+            try:
+                head = fh.read(16)
+                if not audio.is_audio_track(head, size):
+                    continue
+                raw = head + fh.read(audio.MAX_FP_BYTES - 16)
+            finally:
+                with contextlib.suppress(Exception):
+                    fh.__exit__(None, None, None) if is_ctx else fh.close()
+        except Exception as e:  # noqa: BLE001
+            logging.getLogger("curator-adapter").debug("audio read failed for %s: %s", path, e)
+            continue
+        fp = audio.fingerprint_pcm(raw)
+        if fp:
+            out.append({"path": _clean_path(path), "kind": "audio", "audio_fp": fp})
+    return out
+
+
+def _scan_cue_audio(r):
+    """Single combined .bin + .cue: split audio tracks by cue offsets and fingerprint.
+
+    Returns None (not a single-bin+cue layout) so the caller can fall back."""
+    from . import audio
+
+    cue_text = None
+    bins = {}
+    for entry in r.iso_iterator(r.get_root_dir(), recursive=True, include_dirs=False):
+        base = os.path.basename(r.get_file_path(entry))
+        low = base.lower()
+        if low.endswith(".cue"):
+            try:
+                cue_text = _read_entry(r, entry).decode("utf-8", "replace")
+            except Exception:  # noqa: BLE001
+                return None
+        elif low.endswith(".bin"):
+            bins[base.lower()] = entry
+
+    if not cue_text:
+        return None
+    files = audio.parse_cue(cue_text)
+    if len(files) != 1:
+        return None  # per-track files -> member scan handles it
+
+    spec = files[0]
+    bin_entry = bins.get(os.path.basename(spec["file"]).lower())
+    if bin_entry is None and len(bins) == 1:
+        bin_entry = next(iter(bins.values()))
+    if bin_entry is None:
+        return None
+
+    tracks = spec["tracks"]
+    out = []
+    for i, t in enumerate(tracks):
+        if t["type"] != "AUDIO" or t["start_frame"] is None:
+            continue
+        start = t["start_frame"]
+        nxt = tracks[i + 1]["start_frame"] if i + 1 < len(tracks) else None
+        length = (nxt - start) * audio.SECTOR if nxt else audio.MAX_FP_BYTES
+        if length <= 0:  # malformed cue with non-monotonic INDEX
+            length = audio.MAX_FP_BYTES
+        fh = r.open_file(bin_entry)
+        is_ctx = hasattr(fh, "__enter__")
+        if is_ctx:
+            fh.__enter__()
+        try:
+            fh.seek(start * audio.SECTOR)
+            raw = fh.read(min(length, audio.MAX_FP_BYTES))
+        finally:
+            with contextlib.suppress(Exception):
+                fh.__exit__(None, None, None) if is_ctx else fh.close()
+        fp = audio.fingerprint_pcm(raw)
+        if fp:
+            out.append(
+                {"path": f"{_clean_path(spec['file'])}#{t['num']:02d}", "kind": "audio", "audio_fp": fp}
+            )
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="curator-adapter")
+    sub = parser.add_subparsers(dest="command", required=True)
+    p_an = sub.add_parser("analyze", help="analyze a disc image/container")
+    p_an.add_argument("--path", required=True)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+
+    if args.command == "analyze":
+        # Force any ps2exe stdout chatter to stderr; stdout is reserved for the result.
+        real_stdout = sys.stdout
+        sys.stdout = sys.stderr
+        try:
+            result = analyze(args.path)
+        finally:
+            sys.stdout = real_stdout
+        json.dump(result, real_stdout)
+        real_stdout.write("\n")
+        real_stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/ps2exe-adapter/curator_adapter/progress.py
+++ b/ps2exe-adapter/curator_adapter/progress.py
@@ -1,0 +1,99 @@
+"""A duck-typed stand-in for enlighten's Manager/Counter that emits NDJSON progress
+events on stderr instead of drawing terminal bars.
+
+ps2exe constructs counters via ``manager.counter(total=, desc=, unit=, file_name=, ...)``
+and drives them with ``counter.update(incr=1, **fields)``; ``HashProgressWrapper``
+increments by ``len(data)`` for byte-level hashing progress. We reproduce only that
+surface. Output is throttled so byte updates don't flood the pipe.
+"""
+
+import json
+import sys
+import time
+
+_THROTTLE_SECONDS = 0.05
+
+
+def _emit(obj):
+    sys.stderr.write(json.dumps(obj))
+    sys.stderr.write("\n")
+    sys.stderr.flush()
+
+
+class _Counter:
+    def __init__(self, manager, total=None, unit="", desc=None, file_name=None, **_kw):
+        self.manager = manager
+        self.id = manager._next_id()
+        self._total = float(total) if total is not None else None
+        self.count = 0.0
+        self.unit = unit or ""
+        self.label = desc or file_name or ""
+        self._last_emit = 0.0
+        # ps2exe's ArchiveWrapper inspects `counter._closed` during cleanup.
+        self._closed = False
+        self._emit_open()
+
+    # ps2exe sets `.total` and `.count` directly between files; re-announce on retotal.
+    @property
+    def total(self):
+        return self._total
+
+    @total.setter
+    def total(self, value):
+        self._total = float(value) if value is not None else None
+        self._emit_open()
+
+    def _emit_open(self):
+        _emit({
+            "ev": "counter_open",
+            "id": self.id,
+            "label": self.label,
+            "unit": self.unit,
+            "total": self._total,
+        })
+
+    def update(self, incr=1, **fields):
+        relabel = False
+        if "file_name" in fields:
+            self.label = fields["file_name"] or ""
+            relabel = True
+        if "desc" in fields:
+            self.label = fields["desc"] or ""
+            relabel = True
+        if relabel:
+            self._emit_open()
+        self.count += incr
+        now = time.monotonic()
+        if now - self._last_emit >= _THROTTLE_SECONDS or (
+            self._total is not None and self.count >= self._total
+        ):
+            self._last_emit = now
+            _emit({"ev": "progress", "id": self.id, "count": self.count})
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        _emit({"ev": "counter_close", "id": self.id})
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        self.close()
+        return False
+
+
+class ProgressManager:
+    """Minimal enlighten.Manager replacement."""
+
+    def __init__(self):
+        self._id = 0
+        self.counters = {}
+
+    def _next_id(self):
+        self._id += 1
+        return self._id
+
+    def counter(self, **kwargs):
+        return _Counter(self, **kwargs)

--- a/ps2exe-adapter/curator_adapter/viewable.py
+++ b/ps2exe-adapter/curator_adapter/viewable.py
@@ -1,0 +1,108 @@
+"""Classify build files that a stock browser can display inline.
+
+Extension names the candidate type; the header bytes confirm it (a binary
+renamed to README.TXT must not ship as a text asset). Everything text-like is
+served as text/plain — never text/html — so a crafted HTML file in a dump
+can't script against the web origin.
+"""
+
+# Hard cap on extracted asset size. Files past this are skipped outright.
+MAX_ASSET_SIZE = 20 * 1024 * 1024
+
+# How many leading bytes sniffing needs (SVG tag scan is the long pole).
+SNIFF_BYTES = 4096
+
+_IMAGE = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "bmp": "image/bmp",
+    "webp": "image/webp",
+    "ico": "image/x-icon",
+    "svg": "image/svg+xml",
+}
+
+_AUDIO = {
+    "wav": "audio/wav",
+    "mp3": "audio/mpeg",
+    "ogg": "audio/ogg",
+    "oga": "audio/ogg",
+    "flac": "audio/flac",
+    "m4a": "audio/mp4",
+}
+
+_VIDEO = {
+    "mp4": "video/mp4",
+    "m4v": "video/mp4",
+    "webm": "video/webm",
+}
+
+# Docs, configs, sources — the formats prototype discs actually carry. All are
+# served as text/plain regardless of what they'd mean to a browser (html, js).
+_TEXT = frozenset(
+    """
+    txt nfo diz me 1st doc readme md log ini cfg conf inf cue gdi lst csv tsv
+    json xml htm html css js mjs h c cc cpp hpp hh s asm inc mak mk bat cmd sh
+    py pl bas yml yaml toml srt
+    """.split()
+)
+
+_KINDS = (
+    [(_IMAGE, "image")] + [(_AUDIO, "audio")] + [(_VIDEO, "video")]
+)
+
+
+def classify(path):
+    """(kind, mime) a browser could render for this filename, else None.
+
+    Extension-only guess — callers must confirm with sniff() on real bytes.
+    """
+    name = path.rsplit("/", 1)[-1]
+    ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+    if not ext:
+        return None
+    for table, kind in _KINDS:
+        mime = table.get(ext)
+        if mime:
+            return kind, mime
+    if ext in _TEXT:
+        return "text", "text/plain"
+    return None
+
+
+def _looks_text(head):
+    if not head:
+        return False
+    if b"\x00" in head:
+        return False
+    # Legacy encodings (Shift-JIS, Latin-1) live above 0x7f — only bare C0
+    # control characters (not the whitespace/escape family) mark binary data.
+    weird = sum(1 for b in head if b < 0x20 and b not in (0x09, 0x0A, 0x0D, 0x0C, 0x1B))
+    return weird <= len(head) // 20
+
+
+_MAGIC = {
+    "image/png": lambda h: h.startswith(b"\x89PNG\r\n\x1a\n"),
+    "image/jpeg": lambda h: h.startswith(b"\xff\xd8\xff"),
+    "image/gif": lambda h: h.startswith((b"GIF87a", b"GIF89a")),
+    "image/bmp": lambda h: h.startswith(b"BM"),
+    "image/webp": lambda h: h[:4] == b"RIFF" and h[8:12] == b"WEBP",
+    "image/x-icon": lambda h: h.startswith((b"\x00\x00\x01\x00", b"\x00\x00\x02\x00")),
+    "image/svg+xml": lambda h: _looks_text(h) and b"<svg" in h.lower(),
+    "audio/wav": lambda h: h[:4] == b"RIFF" and h[8:12] == b"WAVE",
+    "audio/mpeg": lambda h: h.startswith(b"ID3")
+    or (len(h) >= 2 and h[0] == 0xFF and (h[1] & 0xE0) == 0xE0),
+    "audio/ogg": lambda h: h.startswith(b"OggS"),
+    "audio/flac": lambda h: h.startswith(b"fLaC"),
+    "audio/mp4": lambda h: h[4:8] == b"ftyp",
+    "video/mp4": lambda h: h[4:8] == b"ftyp",
+    "video/webm": lambda h: h.startswith(b"\x1aE\xdf\xa3"),
+    "text/plain": _looks_text,
+}
+
+
+def sniff(head, mime):
+    """True when the leading bytes are plausibly the claimed mime."""
+    check = _MAGIC.get(mime)
+    return bool(check and check(head))

--- a/ps2exe-adapter/pyinstaller_entry.py
+++ b/ps2exe-adapter/pyinstaller_entry.py
@@ -1,0 +1,6 @@
+"""PyInstaller entry point: freeze the curator adapter CLI into one binary."""
+
+from curator_adapter.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/ps2exe-adapter/pyproject.toml
+++ b/ps2exe-adapter/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "curator-adapter"
+version = "0.1.0"
+description = "Curator's JSON boundary over ps2exe: parse a disc image, emit canonical-raw JSON + NDJSON progress."
+requires-python = ">=3.10,<3.11"
+dependencies = [
+    "pycdlib==1.14.0",
+    "pyisotools==2.4.7",
+    "methodtools==0.4.7",
+    "pefile==2024.8.26",
+    "pycryptodome==3.23.0",
+    "libarchive-c==5.3",
+    "numpy==2.2.6",
+    "pathlab==0.2",
+    "xxhash==3.7.0",
+    "machfs==1.3",
+    "rarfile==4.2",
+    "psutil==7.2.2",
+    "bitarray==3.8.1",
+    "inflate64==1.0.4",
+    "fastcdc==1.7.0",
+    "blake3==1.0.8",
+    "py-tlsh==5.0.0",
+]
+
+[project.scripts]
+curator-adapter = "curator_adapter.cli:main"
+
+[dependency-groups]
+dev = ["pytest>=8", "pyinstaller==6.20.0"]
+
+[tool.pytest.ini_options]
+# Put the adapter root on sys.path so `import curator_adapter` resolves from the
+# source tree without installing the project (CI runs numpy-only, --no-project).
+pythonpath = ["."]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv]
+# ps2exe itself is loaded from ../lib/ps2exe at runtime via sys.path (its module
+# layout is top-level, not a pip-installable package), so it is not a dependency here.

--- a/ps2exe-adapter/rthook_libarchive.py
+++ b/ps2exe-adapter/rthook_libarchive.py
@@ -1,0 +1,33 @@
+# PyInstaller runtime hook: point libarchive-c at the bundled libarchive before
+# anything imports it.
+#
+# ps2exe (utils/archives.py) normally discovers the bundled libarchive lazily: it
+# does `try: import libarchive except TypeError:` and, on the TypeError that
+# libarchive-c's ffi.py raises when `ctypes.cdll.LoadLibrary(None)` is called with
+# no library found, sets $LIBARCHIVE and retries. That works unfrozen — but in a
+# PyInstaller build the bootloader's ctypes hook (pyimod03_ctypes) wraps CDLL and
+# re-raises that TypeError as a PyInstallerImportError (an OSError subclass). The
+# `except TypeError` no longer matches, so the env var is never set and the adapter
+# crashes at startup with "argument of type 'NoneType' is not iterable".
+#
+# Setting $LIBARCHIVE here, before the first import, makes the load deterministic and
+# sidesteps the swallowed-exception dance entirely. The spec bundles the matching DLL
+# at lib/libarchive/<osdir>/ under sys._MEIPASS.
+import os
+import sys
+
+# macOS is intentionally absent: it ships a native libarchive that libarchive-c loads via
+# find_library('archive'), so no env var is needed — and the spec doesn't bundle one there
+# (the vendored macosx dylib is x86_64-only and would crash on Apple Silicon).
+if hasattr(sys, "_MEIPASS") and not os.environ.get("LIBARCHIVE"):
+    if sys.platform == "win32":
+        _osdir = "win64" if sys.maxsize > 2**32 else "win32"
+        _oslib = "libarchive.dll"
+    elif sys.platform == "linux":
+        _osdir, _oslib = "linux", "libarchive.so"
+    else:
+        _osdir = _oslib = None
+    if _osdir:
+        _path = os.path.join(sys._MEIPASS, "lib", "libarchive", _osdir, _oslib)
+        if os.path.exists(_path):
+            os.environ["LIBARCHIVE"] = _path

--- a/ps2exe-adapter/rthook_rarfile.py
+++ b/ps2exe-adapter/rthook_rarfile.py
@@ -1,0 +1,32 @@
+# PyInstaller runtime hook: let rarfile fall back to the system bsdtar on macOS.
+#
+# ps2exe (utils/archives.py) eagerly runs, at import time:
+#     rarfile.tool_setup(sevenzip=True, sevenzip2=True, unrar=True, unar=False, bsdtar=False)
+# which demands a system 7-Zip/unrar on PATH. Its except handler points rarfile at a
+# bundled UnRAR for Windows/Linux but has NO macOS branch, so it just re-runs the same
+# call. On a frozen Curator.app — where no Homebrew 7z/unrar is on PATH — both calls
+# raise rarfile.RarCannotExec and the adapter dies at import, before any RAR is touched.
+#
+# RAR extraction itself doesn't need that external tool: the primary path decodes RARs
+# through libarchive (macOS ships a system libarchive with rar/rar5 read support), the
+# same way the bundled libarchive.dll handles them on Windows. rarfile's tool is only the
+# recovery fallback for archives libarchive can't decode. So we just stop the eager setup
+# from crashing: when the strict call finds nothing, retry permissively so /usr/bin/bsdtar
+# — always present on macOS, linking that same libarchive — satisfies it.
+import sys
+
+if hasattr(sys, "_MEIPASS") and sys.platform == "darwin":
+    import rarfile
+
+    _orig_tool_setup = rarfile.tool_setup
+
+    def _tool_setup(*args, **kwargs):
+        try:
+            return _orig_tool_setup(*args, **kwargs)
+        except rarfile.RarCannotExec:
+            # The strict call (bsdtar disabled) found no tool. Retry with rarfile's
+            # permissive defaults so system bsdtar qualifies; force=True bypasses the
+            # negative cache left by the failed call above.
+            return _orig_tool_setup(force=True)
+
+    rarfile.tool_setup = _tool_setup

--- a/ps2exe-adapter/tests/test_audio.py
+++ b/ps2exe-adapter/tests/test_audio.py
@@ -1,0 +1,106 @@
+"""Tests for the constellation audio fingerprint (curator_adapter.audio).
+
+Synthesizes deterministic PCM (no real disc needed) and asserts the key properties:
+identical match, offset tolerance (the whole point of the constellation design), and
+discrimination against unrelated audio.
+"""
+
+import numpy as np
+import pytest
+
+from curator_adapter import audio
+
+SR = audio.SR0
+
+
+def jaccard(a, b):
+    A, B = set(a), set(b)
+    return len(A & B) / len(A | B) if (A or B) else 1.0
+
+
+def song(seconds=25, seed=0, notes=None):
+    rng = np.random.default_rng(seed)
+    n = int(seconds * SR)
+    t = np.arange(n) / SR
+    x = np.zeros(n, np.float32)
+    notes = notes or [220, 247, 262, 294, 330, 349, 392]
+    seg = int(0.5 * SR)
+    for s0 in range(0, n, seg):
+        base = notes[rng.integers(len(notes))]
+        sl = slice(s0, min(s0 + seg, n))
+        tt = t[sl]
+        chord = sum(np.sin(2 * np.pi * base * m * tt) for m in (1.0, 1.25, 1.5))
+        x[sl] += (chord * np.hanning(len(tt))).astype(np.float32)
+    x += 0.02 * rng.standard_normal(n).astype(np.float32)
+    x /= np.max(np.abs(x)) + 1e-9
+    return x
+
+
+def to_pcm(x, prepend=0):
+    if prepend:
+        pad = 0.001 * np.random.default_rng(9).standard_normal(prepend).astype(np.float32)
+        x = np.concatenate([pad, x])
+    i16 = np.clip(x * 30000, -32768, 32767).astype("<i2")
+    return np.repeat(i16[:, None], 2, axis=1).reshape(-1).tobytes()
+
+
+@pytest.fixture(scope="module")
+def base_fp():
+    return audio.fingerprint_pcm(to_pcm(song(seed=1)))
+
+
+def test_identical_is_one(base_fp):
+    again = audio.fingerprint_pcm(to_pcm(song(seed=1)))
+    assert jaccard(base_fp, again) == 1.0
+
+
+def test_integer_frame_offset_is_invariant(base_fp):
+    # an exact whole-frame shift must barely change the fingerprint
+    shifted = audio.fingerprint_pcm(to_pcm(song(seed=1), prepend=audio.HOP * audio.DECIM * 3))
+    assert jaccard(base_fp, shifted) > 0.9
+
+
+def test_sub_frame_and_sector_offsets_tolerated(base_fp):
+    arb = audio.fingerprint_pcm(to_pcm(song(seed=1), prepend=5000))
+    sector = audio.fingerprint_pcm(to_pcm(song(seed=1), prepend=588))  # 1 CD sector
+    assert jaccard(base_fp, arb) > 0.45
+    assert jaccard(base_fp, sector) > 0.5
+
+
+def test_different_songs_discriminated(base_fp):
+    other = audio.fingerprint_pcm(to_pcm(song(seed=99, notes=[523, 587, 659, 698, 784, 880, 988])))
+    assert jaccard(base_fp, other) < 0.4
+
+
+def test_hashes_are_json_number_safe_sorted_unique(base_fp):
+    assert base_fp == sorted(base_fp)
+    assert len(base_fp) == len(set(base_fp))
+    assert all(0 <= h < (1 << 26) for h in base_fp)  # fit a JSON number comfortably
+
+
+def test_silence_and_short_input_empty():
+    assert audio.fingerprint_pcm(b"") == []
+    assert audio.fingerprint_pcm((b"\x00" * 1000)) == []  # below the minimum length
+
+
+def test_is_audio_track():
+    assert audio.is_audio_track(b"\x01" * 32, audio.SECTOR * 4)       # whole sectors, no sync
+    assert not audio.is_audio_track(audio.DATA_SYNC + b"\x00" * 20, audio.SECTOR)  # data sync
+    assert not audio.is_audio_track(b"\x01" * 32, audio.SECTOR + 1)   # not a sector multiple
+
+
+def test_parse_cue():
+    cue = (
+        'FILE "game.bin" BINARY\n'
+        "  TRACK 01 MODE1/2352\n"
+        "    INDEX 01 00:00:00\n"
+        "  TRACK 02 AUDIO\n"
+        "    INDEX 01 03:30:00\n"
+    )
+    files = audio.parse_cue(cue)
+    assert len(files) == 1
+    assert files[0]["file"] == "game.bin"
+    tracks = files[0]["tracks"]
+    assert [t["num"] for t in tracks] == [1, 2]
+    assert tracks[1]["type"] == "AUDIO"
+    assert tracks[1]["start_frame"] == (3 * 60 + 30) * 75  # mm:ss:ff -> frames

--- a/ps2exe-adapter/tests/test_chunking.py
+++ b/ps2exe-adapter/tests/test_chunking.py
@@ -1,0 +1,68 @@
+"""Tests for the streaming content-defined chunker (curator_adapter.cli).
+
+The streaming chunker must produce byte-identical output to running fastcdc() over the
+whole file at once (so files no longer need to fit in memory), and it must localize a
+mid-file insertion to a few chunks — the byte-shift independence that lets successive
+game builds still match via chunk similarity.
+"""
+
+import random
+
+import pytest
+
+from curator_adapter.cli import (
+    _CDC_AVG,
+    _CDC_MAX,
+    _CDC_MIN,
+    _CHUNK_FLUSH,
+    _StreamingChunker,
+    _chunk_pair,
+    fastcdc,
+)
+
+
+def _oneshot(data):
+    return [
+        _chunk_pair(c.data)
+        for c in fastcdc(bytes(data), min_size=_CDC_MIN, avg_size=_CDC_AVG, max_size=_CDC_MAX, fat=True)
+    ]
+
+
+def _streamed(data, read_size):
+    ch = _StreamingChunker()
+    for i in range(0, len(data), read_size):
+        ch.update(data[i : i + read_size])
+    return ch.finish()
+
+
+def _blob(size, seed):
+    # Genuinely non-repeating bytes — periodic data would give FastCDC too few distinct
+    # chunks to be a realistic stand-in for file content.
+    return random.Random(seed).randbytes(size)
+
+
+# Sizes straddling chunk bounds and the flush threshold; read granularities that don't
+# align to any boundary.
+@pytest.mark.parametrize(
+    "size",
+    [0, 1, 100, _CDC_MIN, _CDC_AVG, _CDC_MAX, _CDC_MAX + 1, _CHUNK_FLUSH - 1, _CHUNK_FLUSH, _CHUNK_FLUSH + 5000, 3 * _CHUNK_FLUSH + 12345],
+)
+@pytest.mark.parametrize("read_size", [65536, 1000, 7])
+def test_streaming_matches_oneshot(size, read_size):
+    data = _blob(size, seed=1234)
+    assert _streamed(data, read_size) == _oneshot(data)
+
+
+def test_no_size_cap_and_shift_tolerant():
+    # A blob larger than the old 256 MB cap (which yielded zero chunks) still chunks,
+    # and a mid-file insertion stays highly similar instead of missing entirely.
+    base = _blob(20 * 1024 * 1024 + 7, seed=99)
+    ins = _blob(5000, seed=5)
+    cut = 8 * 1024 * 1024
+    v2 = base[:cut] + ins + base[cut:]
+
+    a = {h for h, _ in _streamed(base, 65536)}
+    b = {h for h, _ in _streamed(v2, 65536)}
+    assert a, "large file must produce chunks (no cap)"
+    jaccard = len(a & b) / len(a | b)
+    assert jaccard > 0.9, jaccard

--- a/ps2exe-adapter/tests/test_nullify.py
+++ b/ps2exe-adapter/tests/test_nullify.py
@@ -1,0 +1,33 @@
+"""Tests for _nullify (curator_adapter.cli).
+
+_nullify normalizes header/volume/SFO metadata fields to a clean string or None.
+The consumer's schema types these fields as strings, so _nullify must coerce the
+non-string values ps2exe occasionally returns (notably the integer SFO
+parental_level) rather than passing them through — see the regression below.
+"""
+
+from curator_adapter.cli import _nullify
+
+
+def test_strings_are_stripped_and_emptied_to_none():
+    assert _nullify("  BESLES-12345  ") == "BESLES-12345"
+    assert _nullify("") is None
+    assert _nullify("   ") is None
+    # C0 control bytes and DEL are stripped (NUL cannot reach Postgres jsonb).
+    assert _nullify("AB\x00\x07C\x7f") == "ABC"
+
+
+def test_none_stays_none():
+    assert _nullify(None) is None
+
+
+def test_integer_is_coerced_to_string():
+    # Regression: SFO parental_level arrives as an int; the consumer expects a
+    # string, so a bare integer broke adapter-output deserialization. Coerce it.
+    assert _nullify(0) == "0"
+    assert _nullify(5) == "5"
+    assert _nullify(101) == "101"
+
+
+def test_non_string_scalars_are_coerced():
+    assert _nullify(1.5) == "1.5"

--- a/ps2exe-adapter/tests/test_shingle.py
+++ b/ps2exe-adapter/tests/test_shingle.py
@@ -1,0 +1,101 @@
+"""Tests for the byte-shingle resemblance signature (curator_adapter.cli).
+
+Validates the vectorized OPH against an independent pure-Python reference, that the
+streaming feed matches a one-shot feed, and the defining property: resemblance stays
+~1.0 under many small *scattered* edits (where exact CDC chunks collapse) while unrelated
+data scores ~0.
+"""
+
+import random
+
+import pytest
+
+from curator_adapter.cli import (
+    _SHINGLE_K,
+    _SHINGLE_W,
+    _ShingleSignature,
+)
+
+_POLY = 1099511628211
+_M64 = (1 << 64) - 1
+_M63 = (1 << 63) - 1
+_BINSHIFT = 63 - _SHINGLE_K.bit_length() + 1
+
+
+def _ref(data, w=_SHINGLE_W, k=_SHINGLE_K):
+    """Plain-Python OPH over w-shingles — the spec the numpy version must match."""
+    if len(data) < w:
+        return None
+    sig = [_M63] * k
+    for i in range(len(data) - w + 1):
+        h = 0
+        for b in data[i : i + w]:
+            h = (h * _POLY + b) & _M64
+        h ^= h >> 33
+        h = (h * 0xFF51AFD7ED558CCD) & _M64
+        h ^= h >> 33
+        h &= _M63
+        b = h >> _BINSHIFT
+        if h < sig[b]:
+            sig[b] = h
+    return sig
+
+
+def _oneshot(data):
+    s = _ShingleSignature()
+    s.update(data)
+    return s.finish()
+
+
+def _streamed(data, read_size):
+    s = _ShingleSignature()
+    for i in range(0, len(data), read_size):
+        s.update(data[i : i + read_size])
+    return s.finish()
+
+
+def _agree(a, b):
+    return sum(1 for x, y in zip(a, b) if x == y) / len(a)
+
+
+def test_matches_pure_python_reference():
+    data = random.Random(1).randbytes(300 * 1024)
+    assert _oneshot(data) == _ref(data)
+
+
+@pytest.mark.parametrize("read_size", [65536, 4096, 1, _SHINGLE_W - 1, _SHINGLE_W + 1])
+def test_streaming_matches_oneshot(read_size):
+    data = random.Random(2).randbytes(257 * 1024)
+    assert _streamed(data, read_size) == _oneshot(data)
+
+
+def test_too_small_returns_none():
+    assert _ShingleSignature().finish() is None
+    assert _oneshot(b"\x00" * (_SHINGLE_W - 1)) is None
+
+
+def test_resembles_under_scattered_edits_but_not_unrelated():
+    rnd = random.Random(7)
+    base = rnd.randbytes(2 * 1024 * 1024)
+
+    # 200 single-byte edits sprinkled across the file (dense — one per ~10KB).
+    ba = bytearray(base)
+    for _ in range(200):
+        ba[rnd.randrange(len(ba))] ^= 0x5A
+    scattered = _oneshot(bytes(ba))
+
+    # A handful of multi-byte insertions (shifts everything downstream).
+    parts, pos = [], 0
+    for _ in range(5):
+        nxt = pos + len(base) // 6
+        parts.append(base[pos:nxt] + rnd.randbytes(40))
+        pos = nxt
+    parts.append(base[pos:])
+    inserted = _oneshot(b"".join(parts))
+
+    unrelated = _oneshot(rnd.randbytes(2 * 1024 * 1024))
+    ref = _oneshot(base)
+
+    assert _agree(ref, scattered) > 0.95, _agree(ref, scattered)
+    assert _agree(ref, inserted) > 0.95, _agree(ref, inserted)
+    assert _agree(ref, unrelated) < 0.05, _agree(ref, unrelated)

--- a/ps2exe-adapter/tests/test_viewable.py
+++ b/ps2exe-adapter/tests/test_viewable.py
@@ -1,0 +1,34 @@
+from curator_adapter import viewable
+
+
+def test_classify_by_extension():
+    assert viewable.classify("/DATA/TITLE.PNG") == ("image", "image/png")
+    assert viewable.classify("/readme.txt") == ("text", "text/plain")
+    assert viewable.classify("/BGM/track.ogg") == ("audio", "audio/ogg")
+    assert viewable.classify("/movie.mp4") == ("video", "video/mp4")
+    # Served as text/plain, never text/html (see viewable.py docstring).
+    assert viewable.classify("/docs/index.html") == ("text", "text/plain")
+
+
+def test_classify_rejects_unknown_and_extensionless():
+    assert viewable.classify("/SLPS_123.45") is None
+    assert viewable.classify("/GAME.TIM") is None
+    assert viewable.classify("/README") is None
+
+
+def test_sniff_confirms_magic():
+    assert viewable.sniff(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8, "image/png")
+    assert not viewable.sniff(b"MZ\x90\x00", "image/png")
+    assert viewable.sniff(b"RIFF\x24\x08\x00\x00WAVEfmt ", "audio/wav")
+    assert not viewable.sniff(b"RIFF\x24\x08\x00\x00WEBP", "audio/wav")
+    assert viewable.sniff(b'<?xml version="1.0"?><svg xmlns="x">', "image/svg+xml")
+
+
+def test_sniff_text_accepts_legacy_encodings_rejects_binary():
+    # Shift-JIS bytes are >= 0x80 — must pass the text heuristic.
+    assert viewable.sniff("日本語のテキスト".encode("shift_jis"), "text/plain")
+    assert viewable.sniff(b"plain ascii\r\nwith lines\r\n", "text/plain")
+    # A renamed binary: NUL bytes or dense C0 controls mark it non-text.
+    assert not viewable.sniff(b"MZ\x00\x01\x02\x03binary", "text/plain")
+    assert not viewable.sniff(bytes(range(1, 32)) * 4, "text/plain")
+    assert not viewable.sniff(b"", "text/plain")

--- a/ps2exe-adapter/uv.lock
+++ b/ps2exe-adapter/uv.lock
@@ -1,0 +1,1025 @@
+version = 1
+revision = 3
+requires-python = "==3.10.*"
+
+[[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "bitarray"
+version = "3.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/47/b5da717e7bbe97a6dc4c986f053ca55fd3276078d78f68f9e8b417d1425a/bitarray-3.8.1.tar.gz", hash = "sha256:f90bb3c680804ec9630bcf8c0965e54b4de84d33b17d7da57c87c30f0c64c6f5", size = 152471, upload-time = "2026-04-02T16:29:01.712Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/fc/4352b1dd55a50c85f7b502c011d40279a66a05eb0c6a5d3d44160838d9a4/bitarray-3.8.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:30d42c34da2974a5e2e0b51c57ecf89892c1e83ed67e1084d1e27eefc27add91", size = 149074, upload-time = "2026-04-02T16:26:16.319Z" },
+    { url = "https://files.pythonhosted.org/packages/34/06/104c9ff50e5230f6581056d6f4b0d1e0db14aba41549cae4b0541be0369c/bitarray-3.8.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0793c51d3b1c7410bde1f7254fff71fabff1bc0cdeba1fa51319ac4e7931df3d", size = 146031, upload-time = "2026-04-02T16:26:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0b/99d65fa6ceb3616c4b96ab9fef2dcd4994ad05fa48f595706ba001f13ba7/bitarray-3.8.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133648c3405564e7fef9103f1768cb018de1b4976f3d8beff09cd4acea73bfe4", size = 325129, upload-time = "2026-04-02T16:26:19.77Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/e0913c6b15fbd1e6b4d60a541a6784eb5d8f1fddcbcbb8c076240f665f2e/bitarray-3.8.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4fd3399eaf6f1c77ea3132611efbc3d7a8c0eb899793387b3266be221dc75fd", size = 353126, upload-time = "2026-04-02T16:26:21.274Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1b/0fd86dece4eca8078a99e54ca01183d5b660195dea8f2c8ad5740b190e9f/bitarray-3.8.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3b9790ae107fc8648155f120e80a58ef8e94424efefff5b355de84061de6a18b", size = 363588, upload-time = "2026-04-02T16:26:22.638Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/2d/e62ddf9e52a0124a19f2cd83be5dfa256c6c1f20722fb0bb4b0aed51bb0b/bitarray-3.8.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:af01133e78e5528ee282ceb1cf4bc54aecb937c2001913e751452ad7dffbbeb1", size = 331725, upload-time = "2026-04-02T16:26:24.296Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/fc/ea1c532169d56747c128f4e0256a3ad1f0c91ed00ca83cdf93964a60fec3/bitarray-3.8.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2da2ca9495668ab77132a911f6bd530d2bfe686d10467584894efc3b66e9ffb5", size = 322939, upload-time = "2026-04-02T16:26:25.904Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/01/8fe68993779f077c713fc4c21c0d9ba2719beeea596bcdc37f9660b6f181/bitarray-3.8.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:72a0e87b2196120523fc6194ca6b580fcffa12d7daa4d57a16d7838e60f82d0e", size = 351084, upload-time = "2026-04-02T16:26:27.396Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c5/f5cb62b60e0da428ef9457e7e1d9a3d3d8874b4f0f925adfff4b9ab3a319/bitarray-3.8.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:defa3c12cb06b2fd2066a9e21bf00aab96465be84d9585c8c05195f080510506", size = 347489, upload-time = "2026-04-02T16:26:28.935Z" },
+    { url = "https://files.pythonhosted.org/packages/88/71/bb9baadbdd305f80def4220ce38266f53404433661492fc2c3d894129bfb/bitarray-3.8.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7eae9e763fbd32f19f2a66dfc2e37906f8422e0c4ad4a6c9dcf9d3246740812e", size = 328394, upload-time = "2026-04-02T16:26:30.585Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1a/c4d487b029488bebef38a4c04df34294d27f313b5ab3491aa3a051394f24/bitarray-3.8.1-cp310-cp310-win32.whl", hash = "sha256:3b9358f6437a5fa0c765ffae5810c9830547baf4bcf469438b82845c3f33f998", size = 143245, upload-time = "2026-04-02T16:26:32.414Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ae/adadedf7cdd49fb8d81b8013d3471c193d6208035a0748205c808b1709cd/bitarray-3.8.1-cp310-cp310-win_amd64.whl", hash = "sha256:6f92d12a46b2a67d56194bb5d226dabf586b386d1f1a5e25be5b745a3080dbba", size = 149976, upload-time = "2026-04-02T16:26:33.868Z" },
+    { url = "https://files.pythonhosted.org/packages/26/de/2a7a8c2868d85e671a6cdb5282bbb299d98cdc0b4c4ade0cfa9a2a21d91d/bitarray-3.8.1-cp310-cp310-win_arm64.whl", hash = "sha256:8e12d50d4d65c74bd877e15c276992263b878456a7cfcf72521e7205a553557f", size = 146729, upload-time = "2026-04-02T16:26:35.216Z" },
+]
+
+[[package]]
+name = "blake3"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/aa/abcd75e9600987a0bc6cfe9b6b2ff3f0e2cb08c170addc6e76035b5c4cb3/blake3-1.0.8.tar.gz", hash = "sha256:513cc7f0f5a7c035812604c2c852a0c1468311345573de647e310aca4ab165ba", size = 117308, upload-time = "2025-10-14T06:47:48.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a0/fbe66cf17f72cab1600246b90db6cb39b52a88335b9bd2821688379d8dde/blake3-1.0.8-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:8956bb9aec47b6c37ccce935a943588f1f5e6e2e85d43bb7cb76a574238f8a9b", size = 350634, upload-time = "2025-10-14T06:45:09.621Z" },
+    { url = "https://files.pythonhosted.org/packages/20/bc/f4b88873054aa87b8c36398775713bf674807e7449a9c7fefe35d3cf1dc5/blake3-1.0.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7adbbee5dd0c302218eb8acdfd82b7006930eb5798f56f79f9cca89f6f192662", size = 328382, upload-time = "2025-10-14T06:45:11.137Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e5/4c37ced9358cece71f2f380a57f77a449f6e87cc6d9f450613237b7a3078/blake3-1.0.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:859cd57bac097a2cd63cb36d64c2f6f16c9edece5590f929e70157478e46dc9e", size = 371337, upload-time = "2025-10-14T06:45:12.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/df/0825da1cde7ca63a8bcdc785ca7f8647b025e9497eef18c75bb9754dbd26/blake3-1.0.8-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9e1d70bf76c02846d0868a3d413eb6c430b76a315e12f1b2e59b5cf56c1f62a3", size = 374945, upload-time = "2025-10-14T06:45:13.99Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/a3/43f10c623179dce789ca9e3b8f4064fb6312e99f05c1aae360d07ad95bb0/blake3-1.0.8-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d3fe26f145fcb82931d1820b55c0279f72f8f8e49450dd9d74efbfd409b28423", size = 448766, upload-time = "2025-10-14T06:45:15.471Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/9431bf5fe0eedeb2aadb4fe81fb18945cf8d49adad98e7988fb3cdac76c2/blake3-1.0.8-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:97c076d58ee37eb5b2d8d91bb9db59c5a008fd59c71845dc57fe438aeeabaf10", size = 507107, upload-time = "2025-10-14T06:45:17.055Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/55/3712cdaebaefa8d5acec46f8df7861ba1832e1e188bc1333dd5acd31f760/blake3-1.0.8-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:78731ce7fca46f776ae45fb5271a2a76c4a92c9687dd4337e84b2ae9a174b28f", size = 393955, upload-time = "2025-10-14T06:45:18.718Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d0/add0441e7aaa6b358cac0ddc9246f0799b60d25f06bd542b554afe19fd85/blake3-1.0.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c65e373c8b47174b969ee61a89ee56922f722972eb650192845c8546df8d9db9", size = 387577, upload-time = "2025-10-14T06:45:20.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/9a/e4a61f5c0cad4d51a886e8f4367e590caaead8a4809892292bf724c4421d/blake3-1.0.8-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:db54946792d2b8c6fa4be73e6e334519f13c1b52e7ff346b3e2ec8ad3eb59401", size = 550515, upload-time = "2025-10-14T06:45:21.867Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c7/90c01091465628acff96534e82d4b3bc16ca22c515f69916d2715273c0e3/blake3-1.0.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:67d9c42c42eb1c7aedcf901591c743266009fcf48babf6d6f8450f567cb94a84", size = 554650, upload-time = "2025-10-14T06:45:23.047Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/11/812d7125c6e99e5e0e841a9af2c4161ac811c027e08886353df76eae7b96/blake3-1.0.8-cp310-cp310-win32.whl", hash = "sha256:444215a1e5201f8fa4e5c7352e938a7070cd33d66aeb1dd9b1103a64b6920f9e", size = 228695, upload-time = "2025-10-14T06:45:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/7e/ab9b5c4b650ff397d347451bfb1ad7e6e53dc06c945e2fd091f27a76422e/blake3-1.0.8-cp310-cp310-win_amd64.whl", hash = "sha256:725c52c4d393c7bd1a10682df322d480734002a1389b320366c660568708846b", size = 215660, upload-time = "2025-10-14T06:45:25.381Z" },
+]
+
+[[package]]
+name = "bs4"
+version = "0.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/aa/4acaf814ff901145da37332e05bb510452ebed97bc9602695059dd46ef39/bs4-0.0.2.tar.gz", hash = "sha256:a48685c58f50fe127722417bae83fe6badf500d54b55f7e39ffe43b798653925", size = 698, upload-time = "2024-01-17T18:15:47.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/bb/bf7aab772a159614954d84aa832c129624ba6c32faa559dfb200a534e50b/bs4-0.0.2-py2.py3-none-any.whl", hash = "sha256:abf8742c0805ef7f662dce4b51cca104cffe52b835238afc169142ab9b3fbccc", size = 1189, upload-time = "2024-01-17T18:15:48.613Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "7.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/b6/9df434a8eeba2e6628c465a1dfa31034228ef79b26f76f46278f4ef7e49d/chardet-7.4.3.tar.gz", hash = "sha256:cc1d4eb92a4ec1c2df3b490836ffa46922e599d34ce0bb75cf41fd2bf6303d56", size = 784800, upload-time = "2026-04-13T21:33:39.803Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/1b/7f73766c119a1344eb69e31890ede7c5825ce03d69a9d29292d1bd1cfa1b/chardet-7.4.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0c79b13c9908ac7dfe0a74116ebc9a0f28b2319d23c32f3dfcdfbe1279c7eaf", size = 874121, upload-time = "2026-04-13T21:32:47.065Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/02/b677c8203d34dad6c2af48287bb1f8c5dff63db2094636fbe634b555b7fb/chardet-7.4.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bba8bea1b28d927b3e99e47deafe53658d34497c0a891d95ff1ba8ff6663f01c", size = 856900, upload-time = "2026-04-13T21:32:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/4b/1361a485a999d97cac4c895e615326f69a639532a52ef365a468bd09bad1/chardet-7.4.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23163921dccf3103ce59540b0443c106d2c0a0ff2e0503e05196f5e6fdea453f", size = 876634, upload-time = "2026-04-13T21:32:50.238Z" },
+    { url = "https://files.pythonhosted.org/packages/87/23/e31c8ad33aa448f0845fd58af5fc22da1626407616d09df4973b2b34f477/chardet-7.4.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cfb54563fe5f130da17c44c6a4e2e8052ba628e5ab4eab7ef8190f736f0f8f72", size = 886497, upload-time = "2026-04-13T21:32:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ef/ea4edec8c87f7e6eda02673acc68fe48725e564fc5a1865782efb53d5598/chardet-7.4.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3990fffcc6a6045f2234ab72752ad037e3b2d48c72037f244d42738db397eb75", size = 881061, upload-time = "2026-04-13T21:32:53.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/fc10600da98541777d720ad9e6bc040c0e0af1adb92e27142e35158957cb/chardet-7.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:c7116b0452994734ccff35e154b44240090eb0f4f74b9106292668133557c175", size = 942533, upload-time = "2026-04-13T21:32:55.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/0a40afdb50a0fe041ab95553b835a8160b6cf0e81edf2ae2fe9f5224cbf9/chardet-7.4.3-py3-none-any.whl", hash = "sha256:1173b74051570cf08099d7429d92e4882d375ad4217f92a6e5240ccfb26f231e", size = 626562, upload-time = "2026-04-13T21:33:38.559Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "click-default-group"
+version = "1.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/ce/edb087fb53de63dad3b36408ca30368f438738098e668b78c87f93cd41df/click_default_group-1.2.4.tar.gz", hash = "sha256:eb3f3c99ec0d456ca6cd2a7f08f7d4e91771bef51b01bdd9580cc6450fe1251e", size = 3505, upload-time = "2023-08-04T07:54:58.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/1a/aff8bb287a4b1400f69e09a53bd65de96aa5cee5691925b38731c67fc695/click_default_group-1.2.4-py2.py3-none-any.whl", hash = "sha256:9b60486923720e7fc61731bdb32b617039aba820e22e1c88766b1125592eaa5f", size = 4123, upload-time = "2023-08-04T07:54:56.875Z" },
+]
+
+[[package]]
+name = "codetiming"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/4e/c40bf151af20ba2748bd6ea24e484d7b6196b1056ba3a1a4ee33b6939c37/codetiming-1.4.0.tar.gz", hash = "sha256:4937bf913a2814258b87eaaa43d9a1bb24711ffd3557a9ab6934fa1fe3ba0dbc", size = 14899, upload-time = "2022-11-08T07:12:29.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/91/e4a2b7c64e738beefddfa24b409d6eecb16c378bde01578918b6ea722a09/codetiming-1.4.0-py3-none-any.whl", hash = "sha256:3b80f409bef00941a9755c5524071ce2f72eaa4520f4bc35b33869cde024ccbd", size = 7165, upload-time = "2022-11-08T07:12:23.553Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
+name = "curator-adapter"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "bitarray" },
+    { name = "blake3" },
+    { name = "fastcdc" },
+    { name = "inflate64" },
+    { name = "libarchive-c" },
+    { name = "machfs" },
+    { name = "methodtools" },
+    { name = "numpy" },
+    { name = "pathlab" },
+    { name = "pefile" },
+    { name = "psutil" },
+    { name = "py-tlsh" },
+    { name = "pycdlib" },
+    { name = "pycryptodome" },
+    { name = "pyisotools" },
+    { name = "rarfile" },
+    { name = "xxhash" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyinstaller" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "bitarray", specifier = "==3.8.1" },
+    { name = "blake3", specifier = "==1.0.8" },
+    { name = "fastcdc", specifier = "==1.7.0" },
+    { name = "inflate64", specifier = "==1.0.4" },
+    { name = "libarchive-c", specifier = "==5.3" },
+    { name = "machfs", specifier = "==1.3" },
+    { name = "methodtools", specifier = "==0.4.7" },
+    { name = "numpy", specifier = "==2.2.6" },
+    { name = "pathlab", specifier = "==0.2" },
+    { name = "pefile", specifier = "==2024.8.26" },
+    { name = "psutil", specifier = "==7.2.2" },
+    { name = "py-tlsh", specifier = "==5.0.0" },
+    { name = "pycdlib", specifier = "==1.14.0" },
+    { name = "pycryptodome", specifier = "==3.23.0" },
+    { name = "pyisotools", specifier = "==2.4.7" },
+    { name = "rarfile", specifier = "==4.2" },
+    { name = "xxhash", specifier = "==3.7.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyinstaller", specifier = "==6.20.0" },
+    { name = "pytest", specifier = ">=8" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "dolreader"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/f1/36b4de418ca5aa5d17521ed4b3b6e923148022feed5c45c8264ccb68d145/dolreader-1.1.1.tar.gz", hash = "sha256:9926f682f3179989402651ce8338e5ca70b36d88b34db4fa6b69bcb7018966fb", size = 6023, upload-time = "2021-07-08T05:55:13.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/60/33d0ce770cf546ad1b49f0521054984342503c69361b6b7a6dee619a49c8/dolreader-1.1.1-py3-none-any.whl", hash = "sha256:d2532c209873fc5f7fcce72977b59e867f9f134e4a6572c6975a250fdc30a9f2", size = 11181, upload-time = "2021-07-08T05:55:11.05Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastcdc"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "click-default-group" },
+    { name = "codetiming" },
+    { name = "humanize" },
+    { name = "py-cpuinfo" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b8/b4c03fea1cc6e5573e571304e248571669a5fe76b2c234cbe02dd00b2163/fastcdc-1.7.0.tar.gz", hash = "sha256:634b4fbea85296484e896b6ff70e43bcd94724989530c8639a6e5b253105eed2", size = 17628, upload-time = "2024-06-27T15:55:34.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/37/ab0e02775b19bcdaa772230999aa4352205f665dc8fa0abae07ce5692bb8/fastcdc-1.7.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:d8a42fae96173c3f1c6215288b1b7d82ae36e0f12bd137c2cdbe5f5a866c96cf", size = 280954, upload-time = "2024-06-27T15:54:20.549Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7c/71332c1cd20b1a58a0107be1ad66cffa4d0d49f6f498841d0625d3d84b1c/fastcdc-1.7.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:a20eb410c13805931bf16f2c16994fead4d67b8129c8cf84c7a3dbd35b58d863", size = 280801, upload-time = "2024-06-27T15:54:23.341Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/c7/f35997deb842c1591610618c2a77f572a91099453d75eb2598211dc0d13d/fastcdc-1.7.0-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:2244c0baa50b242e78b3ef0ead3fdff52d77a65e61315ff2c5b6412bfebb39e3", size = 279967, upload-time = "2024-06-27T15:54:27.401Z" },
+    { url = "https://files.pythonhosted.org/packages/70/fb/c5b0c8a134670a213656653d386e46c0660af408b14307b2ce3da3d5361a/fastcdc-1.7.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:7cb1de30684990fedc6615d18f42096ff00731163ea5d43b024d30fd50a634d1", size = 366457, upload-time = "2024-06-27T15:54:30.123Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2e/fcfdd711d57a5f3e5c399a7ab8835428df084b09eae603ae0d2e89f1b7c7/fastcdc-1.7.0-cp310-cp310-manylinux_2_31_x86_64.whl", hash = "sha256:52f525f610f202e83c7e6816d3027ad0b1c48d1391d864f72c423d13b14a896f", size = 721569, upload-time = "2024-06-27T15:54:33.75Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d8/d5d3c5822a803bd4f203b94d81d1e7483e50ea4af6966f2f5c5aa17f211a/fastcdc-1.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:738615171cddc4b428a63f69d02cf79bb665bebd4bb56bbb8b495b502bd52743", size = 270183, upload-time = "2024-06-27T15:54:35.797Z" },
+]
+
+[[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+]
+
+[[package]]
+name = "inflate64"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/f3/41bb2901543abe7aad0b0b0284ae5854bb75f848cf406bf8a046bf525f67/inflate64-1.0.4.tar.gz", hash = "sha256:b398c686960c029777afc0ed281a86f66adb956cfc3fbf6667cc6453f7b407ce", size = 902542, upload-time = "2025-11-28T10:55:52.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/d5/5c13cfc7954ed716ae0e5e64c4f54be43f8c145b546472b67803feaa18a4/inflate64-1.0.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f1a47837d4322e0684824f91eb635aa6fd1967584140c478b0a1aca7b11740d6", size = 58602, upload-time = "2025-11-28T10:54:21.346Z" },
+    { url = "https://files.pythonhosted.org/packages/33/57/4d740b677cda81ec6f47c05b502ed15103c8a7d9c3e91ee93352d46fe69c/inflate64-1.0.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8600478542e2354d1ee7b5c57c957006cabacd8b787b4046951f487a2216e5c0", size = 35856, upload-time = "2025-11-28T10:54:22.629Z" },
+    { url = "https://files.pythonhosted.org/packages/17/cd/ec3c058283706a43ab790e8d611a3a787a4f4cc4ae3faeafba6e2e216e36/inflate64-1.0.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fb2b5a62579d074f38352a3494c3c6ac1a90516b75c5793c39303547f1fea925", size = 36007, upload-time = "2025-11-28T10:54:23.685Z" },
+    { url = "https://files.pythonhosted.org/packages/24/83/90f7086f8078057a090db43459e478dc45e2d5ce2509f9c6a6a08100efa0/inflate64-1.0.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dcfafc572a642215894af1ec8d05949fa35eb7cb36d053aa97b11eccf1ae579e", size = 95055, upload-time = "2025-11-28T10:54:24.864Z" },
+    { url = "https://files.pythonhosted.org/packages/95/d3/4f760f095ce8a9494d441b96a8735346141dd24f52fa573c971c0da1c958/inflate64-1.0.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cb93159cb60aee8cab62541aa70e4c460f13359660a27a1a486518bba0153535", size = 96645, upload-time = "2025-11-28T10:54:26.308Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2a/78ab2fcb02c13e3c8c93c2d82bf5eec1862b428bc6177dcc76ac4044408d/inflate64-1.0.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:89126ceb4d96e76842f4697017a9a3e750c34e029ddb360b3d8ca79a648d47f6", size = 92933, upload-time = "2025-11-28T10:54:27.563Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/1b/c9a2d84fc117dddee0749dc1b3ab9ed725bf92e866ef0ede0945a5128ef0/inflate64-1.0.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f70e6692617ec82500b203eefac8765302298ce7e73584fcf995bb9e23184530", size = 95898, upload-time = "2025-11-28T10:54:28.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/85/5879fa47122c7d5b563c6dacbd4a782bd9464405f69d46af01e02d4a3907/inflate64-1.0.4-cp310-cp310-win32.whl", hash = "sha256:d08cdda33341b4f992af60c12dc60e370e9993b80a936c17244a602711eeb727", size = 32940, upload-time = "2025-11-28T10:54:30.385Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/cef1b3505dc33d8cb9d115481923dec1de1372d29ac278622feecf9c03a1/inflate64-1.0.4-cp310-cp310-win_amd64.whl", hash = "sha256:950dd7fe53474df5f4699b8f099980027e812d55fd82d8e167d599822c3d27d6", size = 35541, upload-time = "2025-11-28T10:54:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/72/13/d964fbfceeee6752c36c45645e5e9a9ef0dd70d4ce64e5e7316822e43382/inflate64-1.0.4-cp310-cp310-win_arm64.whl", hash = "sha256:bad20de249d6336793f6267880668dbb286ca5c6e6991795aa6344c817588068", size = 33460, upload-time = "2025-11-28T10:54:32.954Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
+name = "libarchive-c"
+version = "5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/23/e72434d5457c24113e0c22605cbf7dd806a2561294a335047f5aa8ddc1ca/libarchive_c-5.3.tar.gz", hash = "sha256:5ddb42f1a245c927e7686545da77159859d5d4c6d00163c59daff4df314dae82", size = 54349, upload-time = "2025-05-22T08:08:04.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/3f/ff00c588ebd7eae46a9d6223389f5ae28a3af4b6d975c0f2a6d86b1342b9/libarchive_c-5.3-py3-none-any.whl", hash = "sha256:651550a6ec39266b78f81414140a1e04776c935e72dfc70f1d7c8e0a3672ffba", size = 17035, upload-time = "2025-05-22T08:08:03.045Z" },
+]
+
+[[package]]
+name = "machfs"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "macresources" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/5e/04d568847e2632f18908636f4e688835292643f5c5cdf93fb764323a6940/machfs-1.3.tar.gz", hash = "sha256:89201818ca16c2385be234b5bfe90946cf80e8141dfa4ed42a54dfa164690389", size = 18949, upload-time = "2021-04-12T00:09:17.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/9c/3c6e7f389327857c8258e863e0dddf352307c97f005cedd64d3b62929636/machfs-1.3-py2.py3-none-any.whl", hash = "sha256:17a87350c46d4542c74f1d7e2045201ff90d73906e2021b3864a4f9a7f8e8ff7", size = 19413, upload-time = "2021-04-12T00:09:15.418Z" },
+]
+
+[[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
+name = "macresources"
+version = "1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/b1/0a709220dca1038e7e5e6c86a22db3dc85f5708258eecd007668643d95a3/macresources-1.2.tar.gz", hash = "sha256:f5a1465e02b11e6bc2cb9f2221e0cfac90d57d294b6baa73c28035b000c3dec4", size = 23609, upload-time = "2020-06-23T05:52:36.504Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/92/a056fa4f262f57d43f48b43c3cdb8eedd4c51e6e1046abbe481c3df5dd46/macresources-1.2-py2.py3-none-any.whl", hash = "sha256:6aac6ee6c8170ad0d7e2b3ee810b97eede3bd6ff421097dfb59fc7b88c53f9fb", size = 33925, upload-time = "2020-06-23T05:52:35.4Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "methodtools"
+version = "0.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wirerope" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/3b/c21b74ac17befdf17b286494b02221b7a84affb1d410ff86e38ba0e14b13/methodtools-0.4.7.tar.gz", hash = "sha256:e213439dd64cfe60213f7015da6efe5dd4003fd89376db3baa09fe13ec2bb0ba", size = 3586, upload-time = "2023-02-05T13:17:54.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/4b/6497ffb463b1b75e04b348ef31070606d43e3c503fa295383538ded999c9/methodtools-0.4.7-py2.py3-none-any.whl", hash = "sha256:5e188c780b236adc12e75b5f078c5afb419ef99eb648569fc6d7071f053a1f11", size = 4038, upload-time = "2024-08-23T09:18:03.631Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb", size = 21165245, upload-time = "2025-05-17T21:27:58.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90", size = 14360048, upload-time = "2025-05-17T21:28:21.406Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163", size = 5340542, upload-time = "2025-05-17T21:28:30.931Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf", size = 6878301, upload-time = "2025-05-17T21:28:41.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83", size = 14297320, upload-time = "2025-05-17T21:29:02.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915", size = 16801050, upload-time = "2025-05-17T21:29:27.675Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680", size = 15807034, upload-time = "2025-05-17T21:29:51.102Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289", size = 18614185, upload-time = "2025-05-17T21:30:18.703Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d", size = 6527149, upload-time = "2025-05-17T21:30:29.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3", size = 12904620, upload-time = "2025-05-17T21:30:48.994Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d", size = 21040391, upload-time = "2025-05-17T21:44:35.948Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
+    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathlab"
+version = "0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/e6/645a3ba346d332187f3573abff39f8bf47cf5591fcd357edc42dac12a8df/pathlab-0.2.tar.gz", hash = "sha256:e089925abd330ce1fffa1d1683a1e70b2f03a8dd71a4ad83380cd29838142a69", size = 12523, upload-time = "2020-02-16T20:36:50.39Z" }
+
+[[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/aa/d0b28e1c811cd4d5f5c2bfe2e022292bd255ae5744a3b9ac7d6c8f72dd75/pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f", size = 5354355, upload-time = "2026-04-01T14:42:15.402Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8e/1d5b39b8ae2bd7650d0c7b6abb9602d16043ead9ebbfef4bc4047454da2a/pillow-12.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e589959f10d9824d39b350472b92f0ce3b443c0a3442ebf41c40cb8361c5b97", size = 4695871, upload-time = "2026-04-01T14:42:18.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c5/dcb7a6ca6b7d3be41a76958e90018d56c8462166b3ef223150360850c8da/pillow-12.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a52edc8bfff4429aaabdf4d9ee0daadbbf8562364f940937b941f87a4290f5ff", size = 6269734, upload-time = "2026-04-01T14:42:20.608Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f1/aa1bb13b2f4eba914e9637893c73f2af8e48d7d4023b9d3750d4c5eb2d0c/pillow-12.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:975385f4776fafde056abb318f612ef6285b10a1f12b8570f3647ad0d74b48ec", size = 8076080, upload-time = "2026-04-01T14:42:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/2a/8c79d6a53169937784604a8ae8d77e45888c41537f7f6f65ed1f407fe66d/pillow-12.2.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd9c0c7a0c681a347b3194c500cb1e6ca9cab053ea4d82a5cf45b6b754560136", size = 6382236, upload-time = "2026-04-01T14:42:25.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/42/bbcb6051030e1e421d103ce7a8ecadf837aa2f39b8f82ef1a8d37c3d4ebc/pillow-12.2.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88d387ff40b3ff7c274947ed3125dedf5262ec6919d83946753b5f3d7c67ea4c", size = 7070220, upload-time = "2026-04-01T14:42:28.68Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e1/c2a7d6dd8cfa6b231227da096fd2d58754bab3603b9d73bf609d3c18b64f/pillow-12.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:51c4167c34b0d8ba05b547a3bb23578d0ba17b80a5593f93bd8ecb123dd336a3", size = 6493124, upload-time = "2026-04-01T14:42:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/41/7c8617da5d32e1d2f026e509484fdb6f3ad7efaef1749a0c1928adbb099e/pillow-12.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:34c0d99ecccea270c04882cb3b86e7b57296079c9a4aff88cb3b33563d95afaa", size = 7194324, upload-time = "2026-04-01T14:42:34.615Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/de/a777627e19fd6d62f84070ee1521adde5eeda4855b5cf60fe0b149118bca/pillow-12.2.0-cp310-cp310-win32.whl", hash = "sha256:b85f66ae9eb53e860a873b858b789217ba505e5e405a24b85c0464822fe88032", size = 6376363, upload-time = "2026-04-01T14:42:37.19Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/34/fc4cb5204896465842767b96d250c08410f01f2f28afc43b257de842eed5/pillow-12.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:673aa32138f3e7531ccdbca7b3901dba9b70940a19ccecc6a37c77d5fdeb05b5", size = 7083523, upload-time = "2026-04-01T14:42:39.62Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/a0/32852d36bc7709f14dc3f64f929a275e958ad8c19a6deba9610d458e28b3/pillow-12.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:3e080565d8d7c671db5802eedfb438e5565ffa40115216eabb8cd52d0ecce024", size = 2463318, upload-time = "2026-04-01T14:42:42.063Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
+name = "py-tlsh"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/fb/a1aceafcf0c5196f1cb558319dca5231190f248f27fbec2e4033276db77f/py_tlsh-5.0.0.tar.gz", hash = "sha256:a21cb75eb49e9d9237c8c39d2fb310a5c976b3abc6c35c2e405e16c089abad1b", size = 49020, upload-time = "2026-05-08T04:31:47.377Z" }
+
+[[package]]
+name = "pycdlib"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/d3/52b8dd7a862aec7cc4043a520490bfc9b408179dc374d0e3416fb0614a86/pycdlib-1.14.0.tar.gz", hash = "sha256:8ec306b31d9c850f28c5fda52438d904edd1e8fcf862c5ffd756272efac9f422", size = 287166, upload-time = "2023-01-14T16:39:31.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/dd/95557c0e3bad0e8ba10c0f17d9deffb139b106eda528a744e544799cbbfb/pycdlib-1.14.0-py2.py3-none-any.whl", hash = "sha256:a905827335f0066af3fd416c5cf9b1f29dffaf4d0914b714555213d1809f38d4", size = 213201, upload-time = "2023-01-14T16:39:29.13Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pycryptodome"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
+    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
+    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/12/e33935a0709c07de084d7d58d330ec3f4daf7910a18e77937affdb728452/pycryptodome-3.23.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ddb95b49df036ddd264a0ad246d1be5b672000f12d6961ea2c267083a5e19379", size = 1623886, upload-time = "2025-05-17T17:21:20.614Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0b/aa8f9419f25870889bebf0b26b223c6986652bdf071f000623df11212c90/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e95564beb8782abfd9e431c974e14563a794a4944c29d6d3b7b5ea042110b4", size = 1672151, upload-time = "2025-05-17T17:21:22.666Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5e/63f5cbde2342b7f70a39e591dbe75d9809d6338ce0b07c10406f1a140cdc/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14e15c081e912c4b0d75632acd8382dfce45b258667aa3c67caf7a4d4c13f630", size = 1664461, upload-time = "2025-05-17T17:21:25.225Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/92/608fbdad566ebe499297a86aae5f2a5263818ceeecd16733006f1600403c/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7fc76bf273353dc7e5207d172b83f569540fc9a28d63171061c42e361d22353", size = 1702440, upload-time = "2025-05-17T17:21:27.991Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/92/2eadd1341abd2989cce2e2740b4423608ee2014acb8110438244ee97d7ff/pycryptodome-3.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:45c69ad715ca1a94f778215a11e66b7ff989d792a4d63b68dc586a1da1392ff5", size = 1803005, upload-time = "2025-05-17T17:21:31.37Z" },
+]
+
+[[package]]
+name = "pygithub"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pynacl" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/c3/8465a311197e16cf5ab68789fe689535e90f6b61ab524cc32a39e67237ae/pygithub-2.9.1.tar.gz", hash = "sha256:59771d7ff63d54d427be2e7d0dad2208dfffc2b0a045fec959263787739b611c", size = 2594989, upload-time = "2026-04-14T07:26:13.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/aa/81a5506f089a26338bff17535e4339b3b22049ebd1bcdeff756c4d7a7559/pygithub-2.9.1-py3-none-any.whl", hash = "sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9", size = 449710, upload-time = "2026-04-14T07:26:12.382Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyinstaller"
+version = "6.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/60/d03d52e6690d4e9caf333dcd14550cde634ce6c118b3bc8fa3112c3186fd/pyinstaller-6.20.0.tar.gz", hash = "sha256:95c5c7e03d5d61e9dfb8ef259c699cf492bb1041beb6dbe83696608cec07347a", size = 4048728, upload-time = "2026-04-22T20:59:36.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/e4/e228d6d1bbb7fd62dc660a8fb202a583b023d3a3624ca95d1a9290ee4d6a/pyinstaller-6.20.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:bf3be4e1284ee78ddccba5e29f99443a12a7b4673168288ffc4c9d38c6f7b90e", size = 1047642, upload-time = "2026-04-22T20:58:32.006Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bd/afb631bcb3f9040efebd4f6d067f0828b51710818f69fb41a2d4b7787f52/pyinstaller-6.20.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:72ae9c1fdea134afa791f58bdc9a1934d5c7609753c111e0026bfc272b32b712", size = 742494, upload-time = "2026-04-22T20:58:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/76/08/0729a5bac14754150e5d83b39d87d842eb42b0bffcaa03dbad6252e23a39/pyinstaller-6.20.0-py3-none-manylinux2014_i686.whl", hash = "sha256:1031bcc307f3fbeffd4e162723e64d46dbf591c82dd0997413afb2a07328b941", size = 754191, upload-time = "2026-04-22T20:58:40.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/82/bc0ee4c7b97db1958eb651e0da9fb1e672e5ae53ca8867fd97701de52906/pyinstaller-6.20.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:8df3b3f347659fa2562d8d193a98ad4600133b8b8d07c268df89e4154376750e", size = 751902, upload-time = "2026-04-22T20:58:44.7Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/770002d6aaa54173881cb2c49bb195ba67b97bf39bac1cdf320f28401629/pyinstaller-6.20.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:b0d3cc9dd8120d448459bd3880a12e2f9774c51443af49047801446377999a59", size = 748634, upload-time = "2026-04-22T20:58:48.579Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/db/68ba1fccb71278b2124fb90b37b7c8c0bc4c1173fba45b94466df3d9cb7f/pyinstaller-6.20.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:03696bb6350177c6bc23bcaf78e71a33c4a89b6754dd90d1be2f318e978c918b", size = 748490, upload-time = "2026-04-22T20:58:52.749Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0f/ac77ffa996a56be3d5c8f85734a007f8347240691657f9704e7de2527fa3/pyinstaller-6.20.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:6357f1699f6af84f37e7367f031d4f68abdba65543b83990c9e8f5a4cebed0b7", size = 747650, upload-time = "2026-04-22T20:58:57.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/56/1ee91c3a2bc10ca1f36da10a6fd55ff7efc4dec367171eb25992a827874f/pyinstaller-6.20.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0ab39c690abad26ba148e8f664f0478acc82a733997f4f22e757774832802da9", size = 747413, upload-time = "2026-04-22T20:59:01.174Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/55/ae264339996953c4cdf9d89d916a0a8fa26a83cf917a742fff8b9d5f3fe8/pyinstaller-6.20.0-py3-none-win32.whl", hash = "sha256:9a7637e8e44b4387b13667fdcaac86ab6b29c446c16d34d8401539b81838759c", size = 1331584, upload-time = "2026-04-22T20:59:07.201Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/300f57578882cce259bfb5ae56fda3b69caa3fe9df40a176c719920ea6e2/pyinstaller-6.20.0-py3-none-win_amd64.whl", hash = "sha256:d588844e890ee80c4365867f98146636e1849bbca8e4284bbf0c809aff0f161a", size = 1391851, upload-time = "2026-04-22T20:59:14.024Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ea/b2f8e1642aecda78c0b75c7321f708e49e10bb3c00dd4f148c40761a1527/pyinstaller-6.20.0-py3-none-win_arm64.whl", hash = "sha256:bd53282c0a73e5c95573e1ddc8e5d564d4932bec91efbaed4dc5fdff9c2ae7f2", size = 1332259, upload-time = "2026-04-22T20:59:20.509Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/67/f4452d68793fb15beba4f19ef39a38a8822f0da7452b503c400d5a21f5c1/pyinstaller_hooks_contrib-2026.5.tar.gz", hash = "sha256:f066dfca8f7c45ff6336c9cf9fe25b4e48bfeb322a1aa24faaedfb8a8d1b0b08", size = 173689, upload-time = "2026-05-04T22:36:55.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/5c/fd465d11da4d12b50d7eb5d2ee2ceb780d8d049dbb489f3828d131e387af/pyinstaller_hooks_contrib-2026.5-py3-none-any.whl", hash = "sha256:ea1535783fbdac4626351709e83f3ea80b681d3a4745763ebb407b5e27342eb9", size = 457314, upload-time = "2026-05-04T22:36:53.598Z" },
+]
+
+[[package]]
+name = "pyisotools"
+version = "2.4.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bs4" },
+    { name = "chardet" },
+    { name = "dolreader" },
+    { name = "pillow" },
+    { name = "pygithub" },
+    { name = "pyinstaller" },
+    { name = "pylint" },
+    { name = "pyside6" },
+    { name = "qdarkstyle" },
+    { name = "setuptools" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/33/6df279d183d4a8bc493df784ea66ad773d2e321076ac78a2ec52678d51b3/pyisotools-2.4.7.tar.gz", hash = "sha256:2f6dba5ca2004c11eb3b9c4ef3afdab4349beff4195b05fb8dce2a122456a416", size = 180642, upload-time = "2025-01-12T06:23:19.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/4b/54d4d7a77356491586ae9c119493f5860e083c6747e9ed88ea6a1d10824b/pyisotools-2.4.7-py3-none-any.whl", hash = "sha256:32773d11fe62543dc881be355ac5dd59621aee38215ff8e4635217ff5f0cfa25", size = 193842, upload-time = "2025-01-12T06:23:16.94Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pylint"
+version = "4.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomli" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
+]
+
+[[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
+name = "pyside6"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-addons" },
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+    { name = "tomli" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/a6/27ba5947ed48918f7b74b7c43a1e280aac069e36f25adeb4c9adfac835c4/pyside6-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:537682c3b7530817203e667c1f5a2f00486b37bf52c52eeab438544c7a0917f6", size = 571921, upload-time = "2026-05-13T09:47:36.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/de/af89d71410c83b10654d86ff9aff2a4f87c30163658f1cc145242e222526/pyside6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b1fc521ba2bb5109425ab8add06bddbdd524abcad06cfa012cc39a22a189feb2", size = 572102, upload-time = "2026-05-13T09:47:38.249Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0e/d583bd3f7bf5046a4497b36f3902cfb64aa29554489a5a25c18e6b4ac0ac/pyside6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:75f0005c3eb95c07cfb65522ec50d0815ac007a96482c21dc3cb4b4c04895d84", size = 572098, upload-time = "2026-05-13T09:47:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f2/d9d8ce1373dabb37e5919f63cd18446556079631d3f2eea3ada03c29f6b8/pyside6-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:0968877ab1fb4ef3587a284da6fe05e8647ada56a6a3750b6395188e01f4aba6", size = 578377, upload-time = "2026-05-13T09:47:40.76Z" },
+    { url = "https://files.pythonhosted.org/packages/96/02/a6057d8bd2bdb1940820fff2d627fdf4013148c9c57adf69fa40d3452ac3/pyside6-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:acee467cb5f256cc47ebb9d815a054c1d8416da380c191b247a76d164aa3f805", size = 561765, upload-time = "2026-05-13T09:47:41.9Z" },
+]
+
+[[package]]
+name = "pyside6-addons"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/6b/8bc94aff48b63f788f2d84e5467c12362d68906ba742c0942f46cb04c879/pyside6_addons-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:54733c77f789bef5f03c6aff4ad3bec8b2eff021f0cfcbc53d5e6c250ded24f9", size = 331714589, upload-time = "2026-05-13T09:39:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/62/fb1428a523b2a4541e232aab50d9e789e6b4526f37fd9593452a7ea5b6b3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8e6c65fbd73a512d6f72cda8d8277444a85a34dc99dd1dae9c21d35b8671bb1f", size = 175063224, upload-time = "2026-05-13T09:39:34.185Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9b/2ccd52f66db55c06de65d0501170a1935d04d64d0a230c0d892284a02ce3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:bf1c6c4e954e5eba3d2a7c661ad4b9689e8f09c7f4a16bdf29713371d11af993", size = 170553429, upload-time = "2026-05-13T09:39:54.424Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bd/8adc4d350b3b363f3dfc8fccdcf5bfed25f7e36c2fff30c64e106f4f1572/pyside6_addons-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:0d13c4dfd671b050a48e4f8d8ddc724b7248f9c0437e7fc47fdf316278572923", size = 168816308, upload-time = "2026-05-13T09:40:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b7/9a840d97f0f0f04e372a87e205dd30ee285b4e3b021b188459a917c9dc76/pyside6_addons-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:3494f480dee92f415be2f2d989c0b3f4755ac332b28045cbf4ba0f5c5a22ba37", size = 35759347, upload-time = "2026-05-13T09:40:21.199Z" },
+]
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/da/10d9197e7370eb4fed8df5fc547b7548dec88e5c5949e2d450db4ae96feb/pyside6_essentials-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:228de53c2bc26b07e5021fbe3614fc44ca08e4dab9999af08c2b389d2c239957", size = 110352945, upload-time = "2026-05-13T09:43:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/49/0e1237c4400bec7e335d2c4eeb49bc40d9fd88a9ac44ca9083ce1abdc308/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:e3ef7027b41e4e55fadb56e3b3257dc8ee92154b639fe67fc4c8e05e9d976c60", size = 79908535, upload-time = "2026-05-13T09:43:24.836Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c5/da4c5f23c6540ac5211a1f60177c8dee84b1bf40f2719479587ab8c60731/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a039b6da68a3a4b9d243217b2b98d475eed3f617159ef6be925badab53c11b0d", size = 78960051, upload-time = "2026-05-13T09:43:35.423Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/b663ecc96ca57b5c91b83b6615d6b174380b0faf30338125c26e053d6aa7/pyside6_essentials-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:63311bd48e32c584599ab04b9ef7c324082374cd2c9fa533f978fb893bb47e40", size = 77549267, upload-time = "2026-05-13T09:43:44.92Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/eb6723faf5cb7fa581145da1c15f40d641b96e080f0491af2f1859fdeedb/pyside6_essentials-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:11253ea52aabecefe9febddbbe78b43a824129e3af1cec98431028fba7fa954f", size = 57964512, upload-time = "2026-05-13T09:43:52.968Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
+name = "qdarkstyle"
+version = "3.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "qtpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/1e/5bf72a61a7636058e25eaa7503c050dae9445de75fad6f71ba08f2174e49/QDarkStyle-3.2.3.tar.gz", hash = "sha256:0c0b7f74a6e92121008992b369bab60468157db1c02cd30d64a5e9a3b402f1ae", size = 700957, upload-time = "2023-11-28T19:54:51.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/7d/c3c10498430dadcea4def5faddf71cd199e577d20a125e7ef1e9d7bdbbfa/QDarkStyle-3.2.3-py2.py3-none-any.whl", hash = "sha256:ea980ee426d594909cf1058306832af71ff6cbad6f69237b036d1550635aefbc", size = 871762, upload-time = "2023-11-28T19:54:48.123Z" },
+]
+
+[[package]]
+name = "qtpy"
+version = "2.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/01/392eba83c8e47b946b929d7c46e0f04b35e9671f8bb6fc36b6f7945b4de8/qtpy-2.4.3.tar.gz", hash = "sha256:db744f7832e6d3da90568ba6ccbca3ee2b3b4a890c3d6fbbc63142f6e4cdf5bb", size = 66982, upload-time = "2025-02-11T15:09:25.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/76/37c0ccd5ab968a6a438f9c623aeecc84c202ab2fabc6a8fd927580c15b5a/QtPy-2.4.3-py3-none-any.whl", hash = "sha256:72095afe13673e017946cc258b8d5da43314197b741ed2890e563cf384b51aa1", size = 95045, upload-time = "2025-02-11T15:09:24.162Z" },
+]
+
+[[package]]
+name = "rarfile"
+version = "4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/3f/3118a797444e7e30e784921c4bfafb6500fb288a0c84cb8c32ed15853c16/rarfile-4.2.tar.gz", hash = "sha256:8e1c8e72d0845ad2b32a47ab11a719bc2e41165ec101fd4d3fe9e92aa3f469ef", size = 153476, upload-time = "2024-04-03T17:10:53.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/fc/ab37559419ca36dd8dd317c3a98395ed4dcee2beeb28bf6059b972906727/rarfile-4.2-py3-none-any.whl", hash = "sha256:8757e1e3757e32962e229cab2432efc1f15f210823cc96ccba0f6a39d17370c9", size = 29052, upload-time = "2024-04-03T17:10:52.632Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "shiboken6"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/f3/f2b63df0251e7cd3172ea28e32ede52739de9566bcefcd0178681538ac81/shiboken6-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:1a16867f103ef1c662a5f09dfed03273a9f81688b174555162c58e83650a3f02", size = 476874, upload-time = "2026-05-13T09:47:01.091Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/9b/e0355d8897b5c150770f1d95718aad17d432fcc9c035c04f3f58427d4693/shiboken6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9a8bccfafc8805254cabcfa1edfaf55cd52889f4998c91ad0d9a4433fb1bcdbe", size = 272222, upload-time = "2026-05-13T09:47:02.653Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d5/dd4f1defed400be03340f2ede34b61f846776650b4e7ed9ebaf4c71979a2/shiboken6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:1bd2f4314414df2d122d9f646e03b731bc6d6b5f77a5f53f99a4fe4e97d84e6f", size = 270350, upload-time = "2026-05-13T09:47:04.02Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/3f6fb2ee65b534193fb4ef713dd619dc31dadff5d12c16979a7699ad58be/shiboken6-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:c2c6863aa80ec18c0f82cea3417837b279cdc60024ac17123461dc9042577df7", size = 1223647, upload-time = "2026-05-13T09:47:05.924Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d1/f15ca0e1666faae02c945f48e745ea35f8fcd8243b176109b4e2c4251f47/shiboken6-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:7c8d9af17db4495d4fa5b1c393f218311c4855546b9dfa6a0bd21bcd66b55e9d", size = 1784170, upload-time = "2026-05-13T09:47:07.617Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wirerope"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/f1/d0a4c936ba77eb1050da6ea5e7cd80aa36add343d9e5f7f9cf79a206c5b8/wirerope-1.0.0.tar.gz", hash = "sha256:7da8bb6feeff9dd939bd7141ef0dc392674e43ba662e20909d6729db81a7c8d0", size = 10930, upload-time = "2025-01-16T11:01:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/2d/3557ee32d8268b04ce8aada3212b0d49f2ddcf86dc200f3999a772262dc5/wirerope-1.0.0-py2.py3-none-any.whl", hash = "sha256:59346555c7b5dbd1c683a4e123f8bed30ca99df646f6867ea6439ceabf43c2f6", size = 9166, upload-time = "2025-01-16T11:01:23.507Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/2f/e183a1b407002f5af81822bee18b61cdb94b8670208ef34734d8d2b8ebe9/xxhash-3.7.0.tar.gz", hash = "sha256:6cc4eefbb542a5d6ffd6d70ea9c502957c925e800f998c5630ecc809d6702bae", size = 82022, upload-time = "2026-04-25T11:10:32.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/49/e4b575b4ed170a7f640c8bd69cfadfa81c7b700191fde5e72228762b9f73/xxhash-3.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd8ab85c916a58d5c8656ea15e3ce9df836fe2f120a74c296e01d69fab2614b4", size = 33426, upload-time = "2026-04-25T11:05:15.702Z" },
+    { url = "https://files.pythonhosted.org/packages/07/61/40f0155b0b09988eb6cdbfc52652f2f371810b0c58163208cb05667757bd/xxhash-3.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:85f5c0e26d945b5bb475e0a3d95193117498130baa7619357bdc7869c2391b5a", size = 30859, upload-time = "2026-04-25T11:05:17.708Z" },
+    { url = "https://files.pythonhosted.org/packages/12/bd/2902b7aad574e43cd85fd84849cfbce48c52cb02c7d6902b8a2b3f6e668e/xxhash-3.7.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b7ffeaada9f8699be63d639536b0b60dff73b7d3325b7475c5bc8fdbf4eed47f", size = 193839, upload-time = "2026-04-25T11:05:19.364Z" },
+    { url = "https://files.pythonhosted.org/packages/48/df/343ce8fd09e47ba8fba43b3bad3283ddf0deca799d5a27b084c3aa2ce502/xxhash-3.7.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee88dfaa6b1b2bfadd3c031fa5f05584870e62fb05dc500942e9900c44fcfda", size = 212896, upload-time = "2026-04-25T11:05:21.131Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cf/703e8422a8b52407864281fb4eb52c605e9f33180413b4458f05de110eba/xxhash-3.7.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7426ff0dfa76eb47efc2cc59d4a717bfa9dc9938bff5e49e748bca749f6aa616", size = 235896, upload-time = "2026-04-25T11:05:22.988Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bc/d4b039edbd426575add5f217abeeb2bf870e2c510d35445df81b4f457901/xxhash-3.7.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8ff6ec73110f610425caef3ea875afbfc34caa542f01df3a80f45aadeb9f906", size = 211665, upload-time = "2026-04-25T11:05:24.799Z" },
+    { url = "https://files.pythonhosted.org/packages/42/24/c6f81361796814b92399a88bf079d3b65e617f531819128fcf1bd6ef0571/xxhash-3.7.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0d23fd49fdc5c8af61fb7104f1ad247954499140f6cb6045b3aa5c99dadbbf28", size = 444929, upload-time = "2026-04-25T11:05:26.245Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/db/268012153eb7f6bf2c8a0491fdcde11e093f166990821a2ab754fe95537d/xxhash-3.7.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12c249621af6d50a05d9f10af894b404157b15819878e18f75fcbb0213a77d07", size = 193271, upload-time = "2026-04-25T11:05:28.282Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/86/1d0d905d659850dad7f59c807c130249fdb204dc6f71f1fb36268f3f3e61/xxhash-3.7.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6741564a923f082f3c2941c8bb920462ed5b25eaebdd1e161f162233c9a10bc5", size = 284580, upload-time = "2026-04-25T11:05:30.116Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/52/fc01ca7ff425a9bdb38d9e3a17f2630447ce3b45d45a929a6cd94d469334/xxhash-3.7.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c4fd8acc6e32596350619896feb372033c0920975992d29837c32853bb1feacd", size = 210193, upload-time = "2026-04-25T11:05:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/122e0c6a3537a54b30752031dca557182576bae1a4171c0be8c532c84496/xxhash-3.7.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:646a69b56d8145d85f7fd2289d14fba07880c8a5bda406aa256b407481a61f35", size = 241094, upload-time = "2026-04-25T11:05:33.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/17/92e33338db8c18add33a46b56c2b7d5dcc6cc2ac076c45389f6017b1bf37/xxhash-3.7.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:11dd69b1a34b7b9af29012f390825b0cdb0617c0966560e227ca74daa7478ba9", size = 197721, upload-time = "2026-04-25T11:05:35.387Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/04/fd4114a0820913f336bef5c82ef851bde8d06270982ebd7b2a859961bbf2/xxhash-3.7.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:01cf5c5333aed26cc8d5eea33b8d6398e085e365a704b7372fabdf7ab06441a9", size = 210073, upload-time = "2026-04-25T11:05:37.405Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/eb/a2472b8b81cd576a9af3a4889ad8ba5784e8c5a04592587056cdaededd6c/xxhash-3.7.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:f1e65d52c2d526734abecb98372c256b7eacce8fdc42e0df8570417fb39e2772", size = 274960, upload-time = "2026-04-25T11:05:39.224Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d3/493afc544aae50b5fb2844ceaeb3697283bb59695db1a7cb40448636de05/xxhash-3.7.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:8ff00fcc3eb436617ed8556cf15daf76c2b501248361a065625a588af78a0a02", size = 413113, upload-time = "2026-04-25T11:05:40.669Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6a/002800845a22bff32bcf5fd09caceb4d3f5c3da6b754c46edb9743ce908b/xxhash-3.7.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b5cd29840505631c6f7dbb8a5d34b742b5e6bbda38fe0b9f54e825f3ea6b61dc", size = 190677, upload-time = "2026-04-25T11:05:42.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0f/86ee514622a381c0dc49167c8d431a22aa93518a4063559c3e36e4b82bc8/xxhash-3.7.0-cp310-cp310-win32.whl", hash = "sha256:5bf2f1940499839b39fef1561b5ecb6ede9ac34ef4457474e1337fc7ef07c2f3", size = 30627, upload-time = "2026-04-25T11:05:44.022Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/2ef2310803efb4a2d07844e8098d797e25702024793aa2e85858623a43b5/xxhash-3.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:d41fcda2fa8ca682ebca134a2f2dc02575ba549267585597e73061565795f475", size = 31463, upload-time = "2026-04-25T11:05:45.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/75/40dbf8f142baf8993c38cd988c8d8f51fe0c51e6c84c5769a3c0280a651d/xxhash-3.7.0-cp310-cp310-win_arm64.whl", hash = "sha256:a845a59664d5c531525a467470220f8edc37959e0a6f8e734ffb6654da5c4bee", size = 27747, upload-time = "2026-04-25T11:05:46.422Z" },
+]


### PR DESCRIPTION
Python extraction adapter wrapping the ps2exe submodule (pointer bumped): extraction CLI, audio fingerprinting, progress protocol, tests, and a PyInstaller spec. Talks to the core via the adapter JSON protocol; reviewable independently of #40.