### PR TITLE
Add asset viewer to build pages

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# asset viewer blob store (populated by scripts/ingest.ts)
+/asset-store/

--- a/web/README.md
+++ b/web/README.md
@@ -13,17 +13,22 @@ DATABASE_URL=postgres:///curator npm run dev
 ## Ingesting
 
 ```sh
-# from a desktop export bundle (curator export -o builds.jsonl)
-DATABASE_URL=postgres:///curator npm run ingest -- builds.jsonl
+# from a desktop export bundle (curator export -o builds.zip)
+DATABASE_URL=postgres:///curator npm run ingest -- builds.zip
 ```
 Populates `builds`, `files`, `build_fileset`, `build_chunk_signature`,
-`build_resemblance`, `exe_fp`, and `audio_fp`, computing the `text_embedding`
-(all-MiniLM-L6-v2) and LSH bands at ingest.
+`build_resemblance`, `exe_fp`, `audio_fp`, and `build_asset`, computing the
+`text_embedding` (all-MiniLM-L6-v2) and LSH bands at ingest. A `.zip` bundle
+also carries the viewable-asset blobs (`assets/<sha256>` members), which land
+in the content-addressed store at `ASSET_STORE_DIR` (default `./asset-store`)
+for the build page's inline asset viewer.
 
 ## API
 
 - `GET /api/search?q=<term>` — filename FTS + trigram fuzzy, or exact hash lookup when
   the term looks like a hash.
+- `GET /api/asset/<sha256>` — one viewable asset from the blob store (immutable,
+  range-capable; text always served as `text/plain`).
 - `POST /api/similarity` — body = a canonical `BuildRecord`. Logs the check by sha256
   (read-only, not ingested) and returns fused similar-build neighbors.
 - `POST /api/submissions` — body `{ nickname, record }`; enqueues for moderation

--- a/web/db/migrations/002-assets.sql
+++ b/web/db/migrations/002-assets.sql
@@ -1,0 +1,20 @@
+-- Per-build browser-viewable assets (images/audio/text ≤ 20MB), extracted by
+-- the desktop analyzer into a content-addressed store and shipped in export
+-- bundles. Rows are metadata only; the bytes live on disk in ASSET_STORE_DIR
+-- (blobs at <store>/<sha256[:2]>/<sha256>), placed there by scripts/ingest.ts.
+-- Idempotent — safe to re-run. Apply to every curator DB:
+--   psql -d <db> -f db/migrations/002-assets.sql
+--
+-- No backfill: records ingested before the analyzer grew asset extraction
+-- carry no asset list. Re-analyzing + re-exporting a collection tops them up.
+
+CREATE TABLE IF NOT EXISTS build_asset (
+    build_sha256 TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE,
+    path         TEXT NOT NULL,           -- full path within the build (matches files.path)
+    sha256       TEXT NOT NULL,           -- content hash = key into the blob store
+    size         BIGINT NOT NULL,
+    mime         TEXT NOT NULL,           -- as served; text is always text/plain
+    kind         TEXT NOT NULL,           -- image|audio|video|text
+    PRIMARY KEY (build_sha256, path)
+);
+CREATE INDEX IF NOT EXISTS idx_build_asset_sha256 ON build_asset(sha256);

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -60,6 +60,20 @@ CREATE INDEX idx_files_sha1      ON files(sha1);
 CREATE INDEX idx_files_md5       ON files(md5);
 CREATE INDEX idx_files_sha256    ON files(sha256);
 
+-- ── per-build viewable assets (images/audio/text ≤ 20MB) ─────────────────────
+-- Metadata for the build page's inline asset viewer; the bytes live in the
+-- content-addressed blob store on disk (ASSET_STORE_DIR), filled at ingest.
+CREATE TABLE build_asset (
+    build_sha256 TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE,
+    path         TEXT NOT NULL,           -- full path within the build (matches files.path)
+    sha256       TEXT NOT NULL,           -- content hash = key into the blob store
+    size         BIGINT NOT NULL,
+    mime         TEXT NOT NULL,           -- as served; text is always text/plain
+    kind         TEXT NOT NULL,           -- image|audio|video|text
+    PRIMARY KEY (build_sha256, path)
+);
+CREATE INDEX idx_build_asset_sha256 ON build_asset(sha256);
+
 -- ── identical-file overlap (set of truncated file-content hashes) ─────
 -- bigint[] of file sha1s truncated to 63 bits; smlar (or intarray &&) for Jaccard.
 CREATE TABLE build_fileset (

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "node --import tsx --test tests/*.test.ts"
+    "test": "node --import tsx --test tests/*.test.ts",
+    "ingest": "tsx scripts/ingest.ts"
   },
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",

--- a/web/scripts/ingest.ts
+++ b/web/scripts/ingest.ts
@@ -9,10 +9,13 @@
 // src/lib/ingest.ts so the moderation accept endpoint reuses it.
 
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { spawn, execFileSync } from "node:child_process";
 import readline from "node:readline";
 import type { Readable } from "node:stream";
 import pg from "pg";
+import { assetBlobPath, assetStoreDir } from "../src/lib/assets";
 import { ingestRecordTx, refreshAudioIdf } from "../src/lib/ingest";
 import type { BuildRecord } from "../src/lib/types";
 
@@ -61,6 +64,47 @@ function readManifest(zipPath: string): Manifest {
   return m;
 }
 
+/** Unpack the bundle's asset blobs (`assets/<sha256>` members) into the
+ *  content-addressed store. Blobs already present are skipped; writes are
+ *  staged + renamed so a crash can't leave a truncated blob under its final
+ *  name. Returns how many blobs were added. */
+function unpackAssets(zipPath: string): number {
+  let listing: string;
+  try {
+    listing = execFileSync("unzip", ["-Z1", zipPath, "assets/*"], {
+      encoding: "utf8",
+      maxBuffer: 64 << 20,
+    });
+  } catch {
+    return 0; // no assets/ members — a pre-assets bundle
+  }
+  const shas = listing
+    .split("\n")
+    .map((l) => l.trim().replace(/^assets\//, ""))
+    .filter((s) => /^[0-9a-f]{64}$/.test(s));
+  const missing = shas.filter((s) => !fs.existsSync(assetBlobPath(s)));
+  if (missing.length === 0) return 0;
+
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), "curator-assets-"));
+  try {
+    execFileSync("unzip", ["-qo", zipPath, "assets/*", "-d", staging], { stdio: "ignore" });
+    let n = 0;
+    for (const sha of missing) {
+      const src = path.join(staging, "assets", sha);
+      if (!fs.existsSync(src)) continue;
+      const dest = assetBlobPath(sha);
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      const tmp = `${dest}.tmp${process.pid}`;
+      fs.copyFileSync(src, tmp);
+      fs.renameSync(tmp, dest);
+      n++;
+    }
+    return n;
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+}
+
 /** A line stream over the records, plus a cleanup/await handle for the source. */
 function openRecords(path: string): { lines: Readable; done: Promise<void> } {
   if (path.endsWith(".zip")) {
@@ -88,6 +132,11 @@ async function main() {
   let lineNo = 0;
   const failures: { line: number; sha?: string; name?: string; error: string }[] = [];
   try {
+    // Blobs before rows: once a build_asset row exists, its blob is servable.
+    if (bundle.endsWith(".zip")) {
+      const added = unpackAssets(bundle);
+      if (added > 0) console.log(`unpacked ${added} asset blob(s) into ${assetStoreDir()}`);
+    }
     const { lines, done } = openRecords(bundle);
     const rl = readline.createInterface({ input: lines, crlfDelay: Infinity });
     for await (const line of rl) {

--- a/web/src/app/api/asset/[sha256]/route.ts
+++ b/web/src/app/api/asset/[sha256]/route.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { Readable } from "node:stream";
+import type { NextRequest } from "next/server";
+import { unstable_cache } from "next/cache";
+import { assetBlobPath } from "@/lib/assets";
+import { getPool } from "@/lib/db";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// GET /api/asset/<sha256> — stream one viewable asset from the blob store.
+//
+// The URL is content-addressed, so a response never changes: cache hard.
+const CACHE = "public, max-age=31536000, immutable";
+
+// Defense against a hostile mime smuggled in through the submissions API: only
+// media types and bare text/plain are ever served inline. text/html (or
+// anything else surprising) becomes a plain download instead of a document
+// that could script against this origin. The CSP sandbox below backstops even
+// the inline types (e.g. SVG's script capability when opened as a document).
+function servableMime(mime: string): boolean {
+  return mime === "text/plain" || /^(image|audio|video)\/[\w.+-]+$/.test(mime);
+}
+
+const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+
+// Asset metadata is immutable for a given content hash — cache the row lookup
+// so a screenshot gallery's burst of first-loads costs one query, not N.
+const getMeta = unstable_cache(
+  async (sha256: string): Promise<{ path: string; mime: string } | null> => {
+    const r = await getPool().query(
+      "SELECT path, mime FROM build_asset WHERE sha256=$1 LIMIT 1",
+      [sha256]
+    );
+    return (r.rows[0] as { path: string; mime: string }) ?? null;
+  },
+  ["asset-meta"],
+  { revalidate: 3600 }
+);
+
+/** One satisfiable `bytes=start-end` range, else null (serve the whole file). */
+function parseRange(header: string | null, size: number): { start: number; end: number } | null {
+  const m = header?.match(/^bytes=(\d*)-(\d*)$/);
+  if (!m || size === 0) return null;
+  const [, a, b] = m;
+  if (a === "" && b === "") return null;
+  const start = a === "" ? Math.max(0, size - Number(b)) : Number(a);
+  const end = a !== "" && b !== "" ? Math.min(Number(b), size - 1) : size - 1;
+  if (start > end || start >= size) return null;
+  return { start, end };
+}
+
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const meta = await getMeta(sha256);
+  if (!meta) return Response.json({ error: "not found" }, { status: 404 });
+
+  // The browser already holds an immutable copy — never re-send the bytes.
+  if (request.headers.get("if-none-match") === `"${sha256}"`) {
+    return new Response(null, { status: 304, headers: { "Cache-Control": CACHE, ETag: `"${sha256}"` } });
+  }
+
+  const blob = assetBlobPath(sha256);
+  let stat: fs.Stats;
+  try {
+    stat = await fsp.stat(blob);
+  } catch {
+    // Metadata ingested but the bundle carrying the bytes hasn't landed yet.
+    return Response.json({ error: "asset bytes not in store" }, { status: 404 });
+  }
+
+  const name = meta.path.split("/").pop() || sha256;
+  const asciiName = name.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+  const inline = servableMime(meta.mime);
+  const headers: Record<string, string> = {
+    "Content-Type": inline
+      ? meta.mime === "text/plain"
+        ? "text/plain; charset=utf-8"
+        : meta.mime
+      : "application/octet-stream",
+    "Content-Disposition": `${inline ? "inline" : "attachment"}; filename="${asciiName}"`,
+    "Cache-Control": CACHE,
+    ETag: `"${sha256}"`,
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": CSP,
+    "Accept-Ranges": "bytes",
+  };
+
+  // Single-range support so <audio>/<video> can seek.
+  const range = parseRange(request.headers.get("range"), stat.size);
+  if (range) {
+    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${stat.size}`;
+    headers["Content-Length"] = String(range.end - range.start + 1);
+    const stream = fs.createReadStream(blob, { start: range.start, end: range.end });
+    return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
+  }
+
+  headers["Content-Length"] = String(stat.size);
+  const stream = fs.createReadStream(blob);
+  return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
+}

--- a/web/src/app/builds/[sha256]/AssetGallery.tsx
+++ b/web/src/app/builds/[sha256]/AssetGallery.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+// Grouped preview of a build's viewable assets: image thumbnails, audio embeds
+// with waveforms, small video players, text excerpt cards. The server page
+// passes an already-capped subset plus the full per-kind totals; when a kind is
+// truncated, a "view all" affordance links to /builds/<sha256>/assets.
+// Images and text open the same AssetViewer lightbox the file tree uses.
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import AssetViewer, { assetUrl, humanSize, type ViewableAsset } from "./AssetViewer";
+import AudioEmbed from "./AudioEmbed";
+
+const SECTIONS: { kind: string; title: string }[] = [
+  { kind: "image", title: "Images" },
+  { kind: "audio", title: "Audio" },
+  { kind: "video", title: "Video" },
+  { kind: "text", title: "Text" },
+];
+
+function baseName(path: string): string {
+  return path.split("/").pop() || path;
+}
+
+export default function AssetGallery({
+  sha256,
+  assets,
+  totals,
+  excerpts,
+}: {
+  sha256: string;
+  /** Assets to display, grouped in kind order (capped per kind by the server page). */
+  assets: ViewableAsset[];
+  /** Full per-kind counts, so truncation is visible. */
+  totals: Record<string, number>;
+  /** Text asset path → excerpt of its leading bytes. */
+  excerpts: Record<string, string>;
+}) {
+  const [viewing, setViewing] = useState<number | null>(null);
+  const indexByPath = useMemo(() => new Map(assets.map((a, i) => [a.path, i] as const)), [assets]);
+  const open = (a: ViewableAsset) => setViewing(indexByPath.get(a.path) ?? null);
+  const allHref = `/builds/${sha256}/assets`;
+
+  return (
+    <>
+      {SECTIONS.map(({ kind, title }) => {
+        const group = assets.filter((a) => a.kind === kind);
+        if (group.length === 0) return null;
+        const total = totals[kind] ?? group.length;
+        const more = total - group.length;
+        return (
+          <div key={kind} className="mt-5 first:mt-3">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+              {title} <span className="font-normal">({total})</span>
+            </h3>
+
+            {kind === "image" && (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {group.map((a) => (
+                  <button
+                    key={a.path}
+                    onClick={() => open(a)}
+                    title={a.path}
+                    className="h-24 w-24 overflow-hidden rounded border border-neutral-200 bg-neutral-50 hover:border-sky-400 dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-sky-600"
+                  >
+                    {/* Not next/image: blobs are local, immutable, hard-cached (see AssetViewer). */}
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img src={assetUrl(a)} alt={a.path} loading="lazy" className="h-full w-full object-contain" />
+                  </button>
+                ))}
+                {more > 0 && (
+                  <Link
+                    href={allHref}
+                    className="flex h-24 w-24 items-center justify-center rounded border border-dashed border-neutral-300 text-center text-xs text-neutral-500 hover:border-sky-400 hover:text-sky-700 dark:border-neutral-700 dark:hover:border-sky-600 dark:hover:text-sky-400"
+                  >
+                    view more…
+                    <br />+{more}
+                  </Link>
+                )}
+              </div>
+            )}
+
+            {kind === "audio" && (
+              <div className="mt-2 grid gap-1.5 md:grid-cols-2 xl:grid-cols-3">
+                {group.map((a) => (
+                  <AudioEmbed key={a.path} asset={a} />
+                ))}
+              </div>
+            )}
+
+            {kind === "video" && (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {group.map((a) => (
+                  <video
+                    key={a.path}
+                    controls
+                    preload="none"
+                    src={assetUrl(a)}
+                    title={a.path}
+                    className="h-36 rounded border border-neutral-200 dark:border-neutral-800"
+                  />
+                ))}
+              </div>
+            )}
+
+            {kind === "text" && (
+              <div className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                {group.map((a) => (
+                  <button
+                    key={a.path}
+                    onClick={() => open(a)}
+                    title={a.path}
+                    className="rounded border border-neutral-200 p-3 text-left hover:border-sky-400 dark:border-neutral-800 dark:hover:border-sky-600"
+                  >
+                    <div className="flex items-baseline justify-between gap-2">
+                      <span className="truncate font-mono text-xs text-sky-700 dark:text-sky-400">
+                        {baseName(a.path)}
+                      </span>
+                      <span className="shrink-0 text-[10px] text-neutral-400">{humanSize(a.size)}</span>
+                    </div>
+                    <pre className="mt-1.5 line-clamp-4 whitespace-pre-wrap break-words font-mono text-[11px] leading-4 text-neutral-500">
+                      {excerpts[a.path] ?? ""}
+                    </pre>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {kind !== "image" && more > 0 && (
+              <Link
+                href={allHref}
+                className="mt-2 inline-block text-xs text-sky-700 hover:underline dark:text-sky-400"
+              >
+                view more… (all {total})
+              </Link>
+            )}
+          </div>
+        );
+      })}
+
+      {viewing !== null && assets[viewing] && (
+        <AssetViewer
+          assets={assets}
+          index={viewing}
+          onClose={() => setViewing(null)}
+          onNavigate={setViewing}
+        />
+      )}
+    </>
+  );
+}

--- a/web/src/app/builds/[sha256]/AssetViewer.tsx
+++ b/web/src/app/builds/[sha256]/AssetViewer.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+// Lightbox over the build's viewable assets. Media loads only when an asset is
+// opened (and the blob URLs are content-addressed + immutable, so anything
+// once seen comes back from browser cache). ← → step through the list, Esc closes.
+
+import { useEffect, useState } from "react";
+
+/** Mirrors queries.ts BuildAsset — redeclared here so client components don't
+ *  import the server-only queries module (it pulls in pg). */
+export interface ViewableAsset {
+  path: string;
+  sha256: string;
+  size: number;
+  mime: string;
+  kind: string; // image | audio | video | text
+}
+
+export function assetUrl(a: ViewableAsset): string {
+  return `/api/asset/${a.sha256}`;
+}
+
+export function humanSize(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let v = bytes;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return i === 0 ? `${bytes} B` : `${v.toFixed(1)} ${units[i]}`;
+}
+
+// Show at most this much decoded text — a 20MB DOM node makes the tab crawl.
+const TEXT_DISPLAY_CAP = 1_000_000;
+
+function TextBody({ url }: { url: string }) {
+  // No reset-on-url-change needed: the viewer remounts this per asset (see the
+  // key on <Body/>), so "loading" as initial state always holds.
+  const [state, setState] = useState<{ text: string; truncated: boolean } | "loading" | "error">(
+    "loading"
+  );
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const buf = await res.arrayBuffer();
+        const text = new TextDecoder().decode(buf.slice(0, TEXT_DISPLAY_CAP));
+        if (!cancelled) setState({ text, truncated: buf.byteLength > TEXT_DISPLAY_CAP });
+      } catch {
+        if (!cancelled) setState("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (state === "loading") return <p className="p-6 text-sm text-neutral-400">Loading…</p>;
+  if (state === "error") return <p className="p-6 text-sm text-red-500">Failed to load file.</p>;
+  return (
+    <div className="max-h-[70vh] w-[min(80rem,90vw)] overflow-auto rounded bg-white p-4 dark:bg-neutral-900">
+      <pre className="whitespace-pre-wrap break-words font-mono text-xs text-neutral-800 dark:text-neutral-200">
+        {state.text}
+      </pre>
+      {state.truncated && (
+        <p className="mt-3 text-xs text-neutral-400">Preview truncated — download for the full file.</p>
+      )}
+    </div>
+  );
+}
+
+function Body({ asset }: { asset: ViewableAsset }) {
+  const [failed, setFailed] = useState(false);
+  const url = assetUrl(asset);
+  if (failed) {
+    return <p className="p-6 text-sm text-red-500">Failed to load media.</p>;
+  }
+  switch (asset.kind) {
+    case "image":
+      return (
+        // Not next/image: blobs are local, immutable, and served with hard
+        // cache headers — optimization would only re-encode them.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={url}
+          alt={asset.path}
+          className="max-h-[75vh] max-w-[90vw] rounded object-contain"
+          onError={() => setFailed(true)}
+        />
+      );
+    case "audio":
+      return <audio controls src={url} className="w-[min(40rem,85vw)]" onError={() => setFailed(true)} />;
+    case "video":
+      return (
+        <video
+          controls
+          src={url}
+          className="max-h-[75vh] max-w-[90vw] rounded"
+          onError={() => setFailed(true)}
+        />
+      );
+    default:
+      return <TextBody url={url} />;
+  }
+}
+
+export default function AssetViewer({
+  assets,
+  index,
+  onClose,
+  onNavigate,
+}: {
+  assets: ViewableAsset[];
+  index: number;
+  onClose: () => void;
+  onNavigate: (index: number) => void;
+}) {
+  const asset = assets[index];
+  const prev = () => onNavigate((index - 1 + assets.length) % assets.length);
+  const next = () => onNavigate((index + 1) % assets.length);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+      else if (e.key === "ArrowLeft") prev();
+      else if (e.key === "ArrowRight") next();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
+
+  // The overlay owns the viewport while open; keep the page from scrolling under it.
+  useEffect(() => {
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+
+  const name = asset.path.split("/").pop() || asset.path;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex flex-col bg-black/70 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Asset viewer: ${name}`}
+    >
+      <div
+        className="flex items-center gap-3 bg-neutral-950/80 px-4 py-2 text-sm text-neutral-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <span className="min-w-0 flex-1 truncate font-mono" title={asset.path}>
+          {asset.path}
+        </span>
+        <span className="shrink-0 text-xs text-neutral-400">
+          {humanSize(asset.size)} · {asset.mime}
+        </span>
+        <a
+          href={assetUrl(asset)}
+          download={name}
+          className="shrink-0 text-xs text-neutral-300 hover:text-white hover:underline"
+        >
+          Download
+        </a>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="shrink-0 rounded px-2 py-0.5 text-neutral-300 hover:bg-neutral-800 hover:text-white"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="flex min-h-0 flex-1 items-center justify-center gap-2 p-4">
+        {assets.length > 1 && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              prev();
+            }}
+            aria-label="Previous asset"
+            className="shrink-0 rounded-full bg-neutral-900/70 px-3 py-2 text-lg text-neutral-300 hover:bg-neutral-800 hover:text-white"
+          >
+            ‹
+          </button>
+        )}
+        {/* Remount per asset so per-file load state never bleeds across navigation. */}
+        <div className="flex min-w-0 items-center justify-center" onClick={(e) => e.stopPropagation()}>
+          <Body key={asset.sha256} asset={asset} />
+        </div>
+        {assets.length > 1 && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              next();
+            }}
+            aria-label="Next asset"
+            className="shrink-0 rounded-full bg-neutral-900/70 px-3 py-2 text-lg text-neutral-300 hover:bg-neutral-800 hover:text-white"
+          >
+            ›
+          </button>
+        )}
+      </div>
+
+      {assets.length > 1 && (
+        <div className="pb-3 text-center text-xs text-neutral-400" onClick={(e) => e.stopPropagation()}>
+          {index + 1} / {assets.length}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/builds/[sha256]/AssetViewer.tsx
+++ b/web/src/app/builds/[sha256]/AssetViewer.tsx
@@ -173,7 +173,7 @@ export default function AssetViewer({
           aria-label="Close"
           className="shrink-0 rounded px-2 py-0.5 text-neutral-300 hover:bg-neutral-800 hover:text-white"
         >
-          ✕
+          &times;
         </button>
       </div>
 

--- a/web/src/app/builds/[sha256]/AudioEmbed.tsx
+++ b/web/src/app/builds/[sha256]/AudioEmbed.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+// Compact SoundCloud-style audio embed: play/pause button + peak-bar waveform
+// with click-to-seek. Computing peaks needs the whole file (Web Audio decodes
+// full buffers only), so the decode is lazy: when the embed scrolls into view
+// for small files, or on first play. The decode fetch warms the browser's HTTP
+// cache — blobs are immutable — so the <audio> element's own load is free.
+// Files whose codec the browser can't decode still play natively if possible;
+// the waveform just stays a flat placeholder.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { assetUrl, humanSize, type ViewableAsset } from "./AssetViewer";
+
+const BARS = 160;
+// Auto-decode on scroll-into-view only below this size, so a page of embeds
+// can't pull tens of MB unasked; bigger files decode on first play.
+const AUTO_DECODE_MAX = 8 * 1024 * 1024;
+
+const PLAYED = "#0ea5e9"; // sky-500 — legible on light and dark
+const UNPLAYED = "rgba(148, 163, 184, 0.45)"; // slate-400 @ 45%
+
+function computePeaks(buf: AudioBuffer, bars: number): Float32Array {
+  const ch0 = buf.getChannelData(0);
+  const ch1 = buf.numberOfChannels > 1 ? buf.getChannelData(1) : null;
+  const out = new Float32Array(bars);
+  const per = Math.max(1, Math.floor(ch0.length / bars));
+  for (let i = 0; i < bars; i++) {
+    const start = i * per;
+    const end = Math.min(start + per, ch0.length);
+    // Stride-sample the bucket — an exact max over millions of samples per bar
+    // buys nothing visually.
+    const stride = Math.max(1, Math.floor((end - start) / 512));
+    let peak = 0;
+    for (let j = start; j < end; j += stride) {
+      const v = Math.abs(ch1 ? (ch0[j] + ch1[j]) / 2 : ch0[j]);
+      if (v > peak) peak = v;
+    }
+    out[i] = peak;
+  }
+  let max = 0;
+  for (const v of out) if (v > max) max = v;
+  if (max > 0) for (let i = 0; i < out.length; i++) out[i] /= max;
+  return out;
+}
+
+function fmtTime(s: number): string {
+  if (!isFinite(s)) return "–:––";
+  const m = Math.floor(s / 60);
+  return `${m}:${String(Math.floor(s % 60)).padStart(2, "0")}`;
+}
+
+export default function AudioEmbed({ asset }: { asset: ViewableAsset }) {
+  const url = assetUrl(asset);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const peaksRef = useRef<Float32Array | null>(null);
+  const progressRef = useRef(0); // 0..1 played fraction
+  const pendingSeekRef = useRef<number | null>(null); // fraction, applied once metadata arrives
+  const decodeStartedRef = useRef(false);
+
+  const [playing, setPlaying] = useState(false);
+  const [decoding, setDecoding] = useState(false);
+  const [duration, setDuration] = useState<number | null>(null);
+  const [time, setTime] = useState(0);
+  const [failed, setFailed] = useState(false);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const dpr = window.devicePixelRatio || 1;
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    if (w === 0 || h === 0) return;
+    if (canvas.width !== Math.round(w * dpr) || canvas.height !== Math.round(h * dpr)) {
+      canvas.width = Math.round(w * dpr);
+      canvas.height = Math.round(h * dpr);
+    }
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, w, h);
+    const peaks = peaksRef.current;
+    const progress = progressRef.current;
+    const gap = 1;
+    const bw = Math.max(1, w / BARS - gap);
+    for (let i = 0; i < BARS; i++) {
+      // Flat mid-height placeholder until real peaks arrive.
+      const p = peaks ? peaks[i] : 0.25;
+      const bh = Math.max(2, p * (h - 2));
+      ctx.fillStyle = (i + 0.5) / BARS <= progress ? PLAYED : UNPLAYED;
+      ctx.fillRect((i * w) / BARS, (h - bh) / 2, bw, bh);
+    }
+  }, []);
+
+  const decode = useCallback(async () => {
+    if (decodeStartedRef.current) return;
+    decodeStartedRef.current = true;
+    setDecoding(true);
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const buf = await res.arrayBuffer();
+      // OfflineAudioContext decodes without tripping autoplay policies.
+      const ctx = new OfflineAudioContext(1, 1, 44100);
+      const audioBuf = await ctx.decodeAudioData(buf);
+      peaksRef.current = computePeaks(audioBuf, BARS);
+      setDuration((d) => d ?? audioBuf.duration);
+    } catch {
+      // Codec the browser can't decode (or fetch hiccup): keep the placeholder
+      // bars — native playback may still work.
+    } finally {
+      setDecoding(false);
+      draw();
+    }
+  }, [url, draw]);
+
+  // Small files build their waveform when scrolled into view.
+  useEffect(() => {
+    if (asset.size > AUTO_DECODE_MAX) return;
+    const el = rootRef.current;
+    if (!el) return;
+    const obs = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) {
+        obs.disconnect();
+        void decode();
+      }
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [asset.size, decode]);
+
+  // Redraw on resize; initial draw renders the placeholder.
+  useEffect(() => {
+    draw();
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const obs = new ResizeObserver(() => draw());
+    obs.observe(canvas);
+    return () => obs.disconnect();
+  }, [draw]);
+
+  // Progress sweep while playing, off React state (state only for the m:ss label).
+  useEffect(() => {
+    if (!playing) return;
+    let raf = 0;
+    const tick = () => {
+      const a = audioRef.current;
+      if (a && isFinite(a.duration) && a.duration > 0) {
+        progressRef.current = a.currentTime / a.duration;
+        setTime((t) => (Math.floor(a.currentTime) === Math.floor(t) ? t : a.currentTime));
+        draw();
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [playing, draw]);
+
+  const toggle = () => {
+    const a = audioRef.current;
+    if (!a) return;
+    if (a.paused) {
+      void decode();
+      void a.play().catch(() => setFailed(true));
+    } else {
+      a.pause();
+    }
+  };
+
+  const seek = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current;
+    const a = audioRef.current;
+    if (!canvas || !a) return;
+    const rect = canvas.getBoundingClientRect();
+    const frac = Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width));
+    if (isFinite(a.duration) && a.duration > 0) {
+      a.currentTime = frac * a.duration;
+      progressRef.current = frac;
+      draw();
+    } else {
+      // Metadata not loaded yet: remember the spot and start playback to get it.
+      pendingSeekRef.current = frac;
+      toggle();
+    }
+  };
+
+  const name = asset.path.split("/").pop() || asset.path;
+
+  return (
+    <div
+      ref={rootRef}
+      className="flex items-center gap-2.5 rounded border border-neutral-200 px-2.5 py-1.5 dark:border-neutral-800"
+    >
+      <button
+        onClick={toggle}
+        aria-label={playing ? `Pause ${name}` : `Play ${name}`}
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-sky-600 text-white hover:bg-sky-500"
+      >
+        {playing ? (
+          <svg viewBox="0 0 16 16" className="h-3 w-3 fill-current" aria-hidden>
+            <path d="M4 2h3v12H4zM9 2h3v12H9z" />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 16 16" className="ml-0.5 h-3 w-3 fill-current" aria-hidden>
+            <path d="M4 2.5v11l9-5.5z" />
+          </svg>
+        )}
+      </button>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-2 text-[11px]">
+          <span className="truncate font-mono text-neutral-600 dark:text-neutral-300" title={asset.path}>
+            {name}
+          </span>
+          <span className="shrink-0 tabular-nums text-neutral-400">
+            {failed
+              ? "playback failed"
+              : duration != null
+                ? `${fmtTime(time)} / ${fmtTime(duration)}`
+                : humanSize(asset.size)}
+          </span>
+        </div>
+        <canvas
+          ref={canvasRef}
+          onClick={seek}
+          className={`mt-0.5 h-7 w-full cursor-pointer ${decoding ? "animate-pulse" : ""}`}
+          role="slider"
+          aria-label={`Seek within ${name}`}
+          aria-valuemin={0}
+          aria-valuemax={duration != null ? Math.round(duration) : 0}
+          aria-valuenow={Math.round(time)}
+        />
+      </div>
+      <audio
+        ref={audioRef}
+        src={url}
+        preload="none"
+        className="hidden"
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onEnded={() => setPlaying(false)}
+        onError={() => setFailed(true)}
+        onLoadedMetadata={(e) => {
+          const a = e.currentTarget;
+          if (isFinite(a.duration)) setDuration(a.duration);
+          if (pendingSeekRef.current != null && isFinite(a.duration)) {
+            a.currentTime = pendingSeekRef.current * a.duration;
+            pendingSeekRef.current = null;
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/web/src/app/builds/[sha256]/FileTree.tsx
+++ b/web/src/app/builds/[sha256]/FileTree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   collectDirPaths,
   findByPath,
@@ -8,6 +8,10 @@ import {
   graftChildren,
   type TreeNode,
 } from "@/lib/filetree";
+import AssetViewer, { type ViewableAsset } from "./AssetViewer";
+
+// Chip label on viewable file rows, by asset kind.
+const KIND_TAG: Record<string, string> = { image: "img", audio: "aud", video: "vid", text: "txt" };
 
 function humanSize(bytes?: number): string {
   if (bytes == null) return "—";
@@ -52,15 +56,24 @@ export default function FileTree({
   sha256,
   roots,
   initiallyExpanded,
+  assets,
 }: {
   sha256: string;
   roots: TreeNode[];
   initiallyExpanded: string[];
+  /** The build's viewable assets, path-ordered (see getBuildAssets). */
+  assets: ViewableAsset[];
 }) {
   const [tree, setTree] = useState<TreeNode[]>(roots);
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set(initiallyExpanded));
   const [loading, setLoading] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
+  // Index into `assets` of the file open in the viewer overlay, if any.
+  const [viewing, setViewing] = useState<number | null>(null);
+  const assetIndexByPath = useMemo(
+    () => new Map(assets.map((a, i) => [a.path, i] as const)),
+    [assets]
+  );
 
   const rows = visibleRows(tree, expanded);
 
@@ -150,6 +163,7 @@ export default function FileTree({
         {rows.map(({ node, depth }) => {
           const open = expanded.has(node.path);
           const busy = loading.has(node.path);
+          const assetIdx = node.dir ? undefined : assetIndexByPath.get(node.path);
           return (
             <div
               key={node.path}
@@ -175,6 +189,17 @@ export default function FileTree({
                     <span className="truncate">{node.name}/</span>
                     <span className="shrink-0 text-xs text-neutral-400">({node.fileCount})</span>
                   </button>
+                ) : assetIdx !== undefined ? (
+                  <button
+                    onClick={() => setViewing(assetIdx)}
+                    title={`View ${node.name}`}
+                    className="flex w-full min-w-0 items-center gap-1.5 pl-4 text-left text-sky-700 hover:underline dark:text-sky-400"
+                  >
+                    <span className="truncate">{node.name}</span>
+                    <span className="shrink-0 rounded bg-neutral-100 px-1 text-[10px] uppercase tracking-wide text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400">
+                      {KIND_TAG[assets[assetIdx].kind] ?? assets[assetIdx].kind}
+                    </span>
+                  </button>
                 ) : (
                   <span className="block truncate pl-4">{node.name}</span>
                 )}
@@ -189,6 +214,14 @@ export default function FileTree({
           );
         })}
       </div>
+      {viewing !== null && assets[viewing] && (
+        <AssetViewer
+          assets={assets}
+          index={viewing}
+          onClose={() => setViewing(null)}
+          onNavigate={setViewing}
+        />
+      )}
     </>
   );
 }

--- a/web/src/app/builds/[sha256]/assets/page.tsx
+++ b/web/src/app/builds/[sha256]/assets/page.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getPool } from "@/lib/db";
+import { getBuildAssets } from "@/lib/queries";
+import { assetTotals, orderAssets, readAssetExcerpt } from "@/lib/assets";
+import AssetGallery from "../AssetGallery";
+
+export const runtime = "nodejs";
+// Same ISR shape as the build page: the corpus only changes at ingest.
+export const revalidate = 3600;
+export function generateStaticParams(): Array<{ sha256: string }> {
+  return [];
+}
+
+// Excerpt reads are tiny (2KB head per file) but keep them bounded on builds
+// with pathological text counts; cards past the cap still open in the viewer.
+const MAX_EXCERPT_READS = 200;
+
+export default async function BuildAssetsPage({ params }: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await params;
+  const pool = getPool();
+  // Name only — the build page's full record (MBs of jsonb) isn't needed here.
+  const [nameRes, assets] = await Promise.all([
+    pool.query("SELECT name, system FROM builds WHERE sha256=$1", [sha256]),
+    getBuildAssets(pool, sha256),
+  ]);
+  const build = nameRes.rows[0] as { name: string; system: string } | undefined;
+  if (!build) notFound();
+
+  const ordered = orderAssets(assets);
+  const excerpts = Object.fromEntries(
+    await Promise.all(
+      ordered
+        .filter((a) => a.kind === "text")
+        .slice(0, MAX_EXCERPT_READS)
+        .map(async (a) => [a.path, (await readAssetExcerpt(a.sha256)) ?? ""] as const)
+    )
+  );
+
+  return (
+    <main className="mx-auto max-w-none px-4 py-10 sm:px-8">
+      <Link href={`/builds/${sha256}`} className="text-sm text-neutral-500 hover:underline">
+        &larr; {build.name}
+      </Link>
+
+      <h1 className="mt-3 text-2xl font-semibold tracking-tight">
+        Assets <span className="text-base font-normal text-neutral-400">({assets.length})</span>
+      </h1>
+
+      <section className="mt-4">
+        <AssetGallery sha256={sha256} assets={ordered} totals={assetTotals(assets)} excerpts={excerpts} />
+      </section>
+    </main>
+  );
+}

--- a/web/src/app/builds/[sha256]/page.tsx
+++ b/web/src/app/builds/[sha256]/page.tsx
@@ -4,10 +4,16 @@ import { notFound } from "next/navigation";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
 import { buildTree, initialExpanded, pruneToExpanded, treeCounts } from "@/lib/filetree";
-import { getBuild, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities } from "@/lib/queries";
+import { getBuild, getBuildAssets, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities } from "@/lib/queries";
+import { assetTotals, orderAssets, readAssetExcerpt } from "@/lib/assets";
 import type { BuildRecord } from "@/lib/types";
 import SimilarBuilds from "./SimilarBuilds";
 import FileTree from "./FileTree";
+import AssetGallery from "./AssetGallery";
+
+// The assets section previews at most this many items per kind; the rest live
+// on /builds/<sha256>/assets.
+const ASSET_PREVIEW_PER_KIND = { image: 30, audio: 20, video: 10, text: 10 };
 
 export const runtime = "nodejs";
 // The corpus only changes at ingest; render once and serve cached for an hour
@@ -91,9 +97,10 @@ export default async function BuildPage({ params }: { params: Promise<{ sha256: 
   const q = deriveQueryFeatures(build.record);
   // Pull a wide candidate set per tier so the fused top-50 is well-populated.
   // Text neighbors use this build's already-stored embedding — no re-embedding per load.
-  const [similar, textNeighbors] = await Promise.all([
+  const [similar, textNeighbors, assets] = await Promise.all([
     findSimilar(pool, q, 100),
     findByEmbeddingOf(pool, sha256, 100),
+    getBuildAssets(pool, sha256),
   ]);
   const fused = fuseSimilar(similar, textNeighbors);
 
@@ -102,6 +109,17 @@ export default async function BuildPage({ params }: { params: Promise<{ sha256: 
   const caps = await getCapabilities(pool, [sha256, ...fused.map((f) => f.sha256)]);
   const queryCaps = caps.get(sha256) ?? [];
   for (const f of fused) f.caps = caps.get(f.sha256) ?? [];
+
+  // Preview subset for the assets section, plus server-read excerpts for its
+  // text cards (tiny head reads from the local blob store).
+  const previewAssets = orderAssets(assets, ASSET_PREVIEW_PER_KIND);
+  const excerpts = Object.fromEntries(
+    await Promise.all(
+      previewAssets
+        .filter((a) => a.kind === "text")
+        .map(async (a) => [a.path, (await readAssetExcerpt(a.sha256)) ?? ""] as const)
+    )
+  );
 
   // Ship only the initially-visible subtree; FileTree lazily fetches the rest.
   const tree = buildTree(build.record.contents);
@@ -122,6 +140,7 @@ export default async function BuildPage({ params }: { params: Promise<{ sha256: 
         <Chip>{build.file_count} files</Chip>
         <Chip>{humanSize(build.total_size)}</Chip>
         <Chip>profile {build.fingerprint_profile}</Chip>
+        {assets.length > 0 && <Chip>{assets.length} viewable</Chip>}
       </div>
 
       <dl className="mt-4 grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-sm">
@@ -157,11 +176,20 @@ export default async function BuildPage({ params }: { params: Promise<{ sha256: 
 
       <SimilarBuilds builds={fused} queryCaps={queryCaps} />
 
+      {assets.length > 0 && (
+        <section className="mt-8">
+          <h2 className="text-lg font-medium">
+            Assets <span className="text-sm font-normal text-neutral-400">({assets.length} viewable)</span>
+          </h2>
+          <AssetGallery sha256={sha256} assets={previewAssets} totals={assetTotals(assets)} excerpts={excerpts} />
+        </section>
+      )}
+
       <section className="mt-8">
         <h2 className="text-lg font-medium">
           Files <span className="text-sm font-normal text-neutral-400">({counts.files} files, {counts.dirs} dirs)</span>
         </h2>
-        <FileTree sha256={sha256} roots={pruneToExpanded(tree, expanded)} initiallyExpanded={[...expanded]} />
+        <FileTree sha256={sha256} roots={pruneToExpanded(tree, expanded)} initiallyExpanded={[...expanded]} assets={assets} />
       </section>
     </main>
   );

--- a/web/src/lib/assets.ts
+++ b/web/src/lib/assets.ts
@@ -1,0 +1,57 @@
+// The on-disk content-addressed blob store backing the asset viewer. Blobs are
+// extracted by the desktop analyzer, shipped inside export bundles, and placed
+// here by scripts/ingest.ts; the API route streams them out by sha256.
+
+import path from "node:path";
+import { open } from "node:fs/promises";
+
+/** Root of the blob store. Blobs live at `<root>/<sha256[:2]>/<sha256>`. */
+export function assetStoreDir(): string {
+  // Default sits next to the app (survives the deploy rsync, excluded from git).
+  return process.env.ASSET_STORE_DIR || path.join(process.cwd(), "asset-store");
+}
+
+/** Absolute path of one blob. Caller must have validated `sha256` (isSha256). */
+export function assetBlobPath(sha256: string): string {
+  return path.join(assetStoreDir(), sha256.slice(0, 2), sha256);
+}
+
+/** Display order for asset kinds on the build pages. */
+export const ASSET_KIND_ORDER = ["image", "audio", "video", "text"] as const;
+
+/** Per-kind asset counts. */
+export function assetTotals(assets: { kind: string }[]): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const a of assets) totals[a.kind] = (totals[a.kind] ?? 0) + 1;
+  return totals;
+}
+
+/** Assets regrouped in display-kind order, keeping at most `capPerKind` of each
+ *  — one number for all kinds, or a per-kind map (missing kind = uncapped).
+ *  Path order within a kind is preserved (getBuildAssets sorts by path). */
+export function orderAssets<T extends { kind: string }>(
+  assets: T[],
+  capPerKind: number | Record<string, number> = Infinity
+): T[] {
+  const cap = (k: string) => (typeof capPerKind === "number" ? capPerKind : (capPerKind[k] ?? Infinity));
+  return ASSET_KIND_ORDER.flatMap((k) => assets.filter((a) => a.kind === k).slice(0, cap(k)));
+}
+
+/** Leading bytes of a text blob decoded as lossy UTF-8 for an excerpt card, or
+ *  null when the blob is missing from the store. */
+export async function readAssetExcerpt(sha256: string, maxBytes = 2048): Promise<string | null> {
+  let fh;
+  try {
+    fh = await open(assetBlobPath(sha256), "r");
+    const buf = Buffer.alloc(maxBytes);
+    const { bytesRead } = await fh.read(buf, 0, maxBytes, 0);
+    return new TextDecoder("utf-8", { fatal: false })
+      .decode(buf.subarray(0, bytesRead))
+      .replace(/\u0000/g, "")
+      .replace(/\r\n?/g, "\n");
+  } catch {
+    return null;
+  } finally {
+    await fh?.close();
+  }
+}

--- a/web/src/lib/ingest.ts
+++ b/web/src/lib/ingest.ts
@@ -14,7 +14,8 @@ export interface Queryable {
 
 // Postgres text/jsonb cannot store a literal NUL (U+0000), so a disc-header
 // field that smuggled one through (see the adapter's _nullify) would otherwise
-// abort the whole INSERT. Strip NUL from every string in the record — in the
+// abort the whole INSERT. Strip NUL from every string in the record — object
+// keys included (ext_histogram keys carry mis-decoded UCS-2 filenames) — in the
 // columns we extract and in the `record` jsonb we store verbatim — before it
 // reaches the DB. Minimal on purpose: NUL is the only byte Postgres rejects, so
 // we leave all other text untouched and don't second-guess the adapter.
@@ -27,10 +28,23 @@ function stripNulls<T>(value: T): T {
   }
   if (value && typeof value === "object") {
     const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value)) out[k] = stripNulls(v);
+    for (const [k, v] of Object.entries(value)) out[stripNulls(k)] = stripNulls(v);
     return out as T;
   }
   return value;
+}
+
+// The GIN index on to_tsvector('simple', text_doc) caps the lexeme pool at
+// 1048575 bytes; a text_doc past that aborts the INSERT. The pool can't exceed
+// the input's byte length, so capping the column (the full text stays in
+// `record`) keeps the index valid at the cost of FTS on the truncated tail.
+const TEXT_DOC_MAX_BYTES = 1_000_000;
+function capTextDoc(s: string): string {
+  if (Buffer.byteLength(s) <= TEXT_DOC_MAX_BYTES) return s;
+  const buf = Buffer.from(s);
+  let end = TEXT_DOC_MAX_BYTES;
+  while (end > 0 && (buf[end] & 0xc0) === 0x80) end--; // don't split a UTF-8 sequence
+  return buf.subarray(0, end).toString();
 }
 
 // Disc mastering date for the sortable builds.build_date column — volume
@@ -78,7 +92,7 @@ export async function ingestRecord(db: Queryable, rec: BuildRecord): Promise<voi
      ON CONFLICT (sha256) DO UPDATE SET record=excluded.record, build_date=excluded.build_date`,
     [sha, rec.image.name, rec.info?.system ?? "", rec.image.size, rec.image.md5, rec.image.sha1,
      comp.content_hash ?? null, comp.filtered_content_hash ?? null, st.file_count, st.total_size, st.max_depth,
-     JSON.stringify(st.ext_histogram ?? {}), rec.text_doc ?? "", rec.fingerprint_profile, rec, buildDate(rec)]
+     JSON.stringify(st.ext_histogram ?? {}), capTextDoc(rec.text_doc ?? ""), rec.fingerprint_profile, rec, buildDate(rec)]
   );
 
   // Semantic embedding from the build's identity (see semanticDoc), not the
@@ -113,6 +127,41 @@ export async function ingestRecord(db: Queryable, rec: BuildRecord): Promise<voi
       params
     );
   }
+  // Viewable assets: metadata only — the blobs travel in the bundle zip and are
+  // placed into the store by scripts/ingest.ts. Guard each row: records can
+  // arrive from the submissions API, and a malformed sha256 must never become a
+  // blob-store lookup key (the asset route interpolates it into a file path).
+  // A null/absent list means the record was never asset-extracted — keep rows
+  // from any earlier ingest; only an extracted list (even []) is authoritative.
+  if (rec.assets != null) {
+    await db.query("DELETE FROM build_asset WHERE build_sha256=$1", [sha]);
+    const assets = rec.assets.filter(
+      (a) =>
+        typeof a?.path === "string" &&
+        a.path &&
+        typeof a.sha256 === "string" &&
+        /^[0-9a-f]{64}$/.test(a.sha256) &&
+        typeof a.mime === "string" &&
+        typeof a.kind === "string" &&
+        Number.isFinite(a.size)
+    );
+    for (let off = 0; off < assets.length; off += ROWS_PER_INSERT) {
+      const chunk = assets.slice(off, off + ROWS_PER_INSERT);
+      const rows: string[] = [];
+      const params: unknown[] = [];
+      for (const a of chunk) {
+        const i = params.length;
+        rows.push(`($${i + 1},$${i + 2},$${i + 3},$${i + 4},$${i + 5},$${i + 6})`);
+        params.push(sha, a.path, a.sha256, a.size, a.mime, a.kind);
+      }
+      await db.query(
+        `INSERT INTO build_asset (build_sha256,path,sha256,size,mime,kind) VALUES ${rows.join(",")}
+         ON CONFLICT (build_sha256,path) DO NOTHING`,
+        params
+      );
+    }
+  }
+
   await db.query(
     `INSERT INTO build_fileset (build_sha256,hashes) VALUES ($1,$2)
      ON CONFLICT (build_sha256) DO UPDATE SET hashes=excluded.hashes`,

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -521,6 +521,25 @@ export async function listBuildsPage(pool: Pool, opts: BuildsPageOpts = {}): Pro
   };
 }
 
+/** One viewable asset of a build, for the build page's inline viewer. */
+export interface BuildAsset {
+  path: string;
+  sha256: string;
+  size: number;
+  mime: string;
+  kind: string; // image | audio | video | text
+}
+
+/// A build's viewable assets, in path order (one indexed lookup).
+export async function getBuildAssets(pool: Pool, sha256: string): Promise<BuildAsset[]> {
+  const r = await pool.query(
+    `SELECT path, sha256, size::float8 AS size, mime, kind
+     FROM build_asset WHERE build_sha256=$1 ORDER BY path`,
+    [sha256]
+  );
+  return r.rows as BuildAsset[];
+}
+
 /// Fetch one stored build (with its full canonical record) by sha256.
 export async function getBuild(pool: Pool, sha256: string): Promise<BuildRow | null> {
   const r = await pool.query(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -58,6 +58,17 @@ export interface BuildRecord {
   resemblance?: Signature | null;
   exe_fp?: { tlsh?: string; imphash?: string } | null;
   media?: MediaFp[];
+  /** Browser-viewable files in the blob store. Absent = extraction never ran. */
+  assets?: AssetRef[] | null;
+}
+
+/** One extracted viewable asset; the bytes live in the store under `sha256`. */
+export interface AssetRef {
+  path: string;
+  sha256: string;
+  size: number;
+  mime: string;
+  kind: string; // "image" | "audio" | "video" | "text"
 }
 
 export interface MediaFp {

--- a/web/src/lib/validate.ts
+++ b/web/src/lib/validate.ts
@@ -8,6 +8,7 @@ const MAX_FILES = 200_000;
 const MAX_SIGNATURE_VALUES = 4096;
 const MAX_MEDIA = 4096;
 const MAX_AUDIO_FP = 200_000;
+const MAX_ASSETS = 4096;
 
 /** True if `s` is a lowercase 64-hex sha256. */
 export function isSha256(s: string): boolean {
@@ -67,6 +68,16 @@ export function validateBuildRecord(rec: unknown): ValidateResult {
       if (Array.isArray(fp) && fp.length > MAX_AUDIO_FP) {
         return { ok: false, error: `media[].audio_fp exceeds ${MAX_AUDIO_FP} entries` };
       }
+    }
+  }
+
+  const assets = r.assets;
+  if (assets != null) {
+    if (!Array.isArray(assets)) {
+      return { ok: false, error: "assets must be an array" };
+    }
+    if (assets.length > MAX_ASSETS) {
+      return { ok: false, error: `assets exceeds ${MAX_ASSETS} entries` };
     }
   }
 

--- a/web/tests/lib.test.ts
+++ b/web/tests/lib.test.ts
@@ -102,3 +102,92 @@ test("a tier absent from either build is dropped from the denominator (not penal
   const ap2 = applicableTiers(all, ["files", "audio"], ["files"]);
   assert.equal(fusedScore({ files: 0.5 }, ap2), 0.5);
 });
+
+// --- asset ingest semantics -------------------------------------------------
+// ingestRecord against a fake Queryable: assets == null means "extraction never
+// ran" and must not touch existing build_asset rows; only an extracted list
+// (even an empty one) is authoritative and replaces them.
+
+import { ingestRecord } from "../src/lib/ingest";
+import type { BuildRecord, AssetRef } from "../src/lib/types";
+
+function minimalRecord(assets?: AssetRef[] | null): BuildRecord {
+  const rec: BuildRecord = {
+    record_schema_version: 1,
+    fingerprint_profile: "v1",
+    // Empty name + text_doc keep semanticDoc empty, so ingest skips the
+    // embedding model and the test stays hermetic.
+    image: { name: "", size: 0, md5: "", sha1: "", sha256: "ab".repeat(32) },
+    info: { system: "test" },
+    composites: {},
+    structural: { system: "test", file_count: 0, total_size: 0, max_depth: 0, ext_histogram: {} },
+    text_doc: "",
+    contents: [],
+  };
+  if (assets !== undefined) rec.assets = assets;
+  return rec;
+}
+
+function fakeDb() {
+  const calls: { sql: string; params?: unknown[] }[] = [];
+  return {
+    calls,
+    query: async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params });
+      return { rows: [] };
+    },
+  };
+}
+
+test("ingest with assets missing/null never touches build_asset", async () => {
+  for (const rec of [minimalRecord(), minimalRecord(null)]) {
+    const db = fakeDb();
+    await ingestRecord(db, rec);
+    assert.ok(db.calls.length > 0);
+    assert.ok(!db.calls.some((c) => c.sql.includes("build_asset")));
+  }
+});
+
+test("ingest with assets [] clears build_asset (extracted, nothing viewable)", async () => {
+  const db = fakeDb();
+  await ingestRecord(db, minimalRecord([]));
+  assert.ok(db.calls.some((c) => c.sql.startsWith("DELETE FROM build_asset")));
+  assert.ok(!db.calls.some((c) => c.sql.includes("INSERT INTO build_asset")));
+});
+
+test("ingest keeps well-formed asset rows and drops malformed ones", async () => {
+  const good: AssetRef = { path: "/A.PNG", sha256: "cd".repeat(32), size: 10, mime: "image/png", kind: "image" };
+  const badSha = { path: "/B.PNG", sha256: "../etc/passwd", size: 10, mime: "image/png", kind: "image" } as AssetRef;
+  const db = fakeDb();
+  await ingestRecord(db, minimalRecord([good, badSha]));
+  const inserts = db.calls.filter((c) => c.sql.includes("INSERT INTO build_asset"));
+  assert.equal(inserts.length, 1);
+  assert.ok(inserts[0].params!.includes("/A.PNG"));
+  assert.ok(!inserts[0].params!.includes("/B.PNG"));
+});
+
+// --- asset grouping helpers ---------------------------------------------------
+
+import { orderAssets, assetTotals } from "../src/lib/assets";
+
+test("orderAssets groups by display kind and caps per kind", () => {
+  const mk = (kind: string, n: number) => Array.from({ length: n }, (_, i) => ({ kind, path: `${kind}${i}` }));
+  const mixed = [...mk("text", 3), ...mk("image", 12), ...mk("audio", 1)];
+  const ordered = orderAssets(mixed, 10);
+  assert.deepEqual(
+    ordered.map((a) => a.kind),
+    [...Array(10).fill("image"), "audio", ...Array(3).fill("text")]
+  );
+  // Uncapped keeps everything, still grouped.
+  assert.equal(orderAssets(mixed).length, 16);
+  assert.deepEqual(assetTotals(mixed), { text: 3, image: 12, audio: 1 });
+});
+
+test("orderAssets accepts a per-kind cap map (missing kind = uncapped)", () => {
+  const mk = (kind: string, n: number) => Array.from({ length: n }, (_, i) => ({ kind, path: `${kind}${i}` }));
+  const mixed = [...mk("image", 40), ...mk("audio", 25), ...mk("text", 12)];
+  const ordered = orderAssets(mixed, { image: 30, audio: 20 });
+  const counts: Record<string, number> = {};
+  for (const a of ordered) counts[a.kind] = (counts[a.kind] ?? 0) + 1;
+  assert.deepEqual(counts, { image: 30, audio: 20, text: 12 });
+});


### PR DESCRIPTION
Build pages gain an Assets section: image thumbnails, waveform audio players, video embeds, and text excerpts, capped per kind with a `/builds/<sha256>/assets` page showing everything. Blobs are served by a new `/api/asset/<sha256>` route (immutable caching, ETag/304, Range support, mime allowlist, CSP sandbox) from a content-addressed store that `npm run ingest` populates from export bundles. Migration `002-assets.sql` adds the `build_asset` table.

Asset extraction happens upstream in #40 (core) and #41 (adapter); this PR is safe to merge independently — builds without extracted assets simply show no section.