### PR TITLE
Desktop asset viewing and upload-on-submit

### DIFF
--- a/crates/curator-core/src/lib.rs
+++ b/crates/curator-core/src/lib.rs
@@ -71,6 +71,7 @@ impl Analyzer {
         Ok(Reader {
             db: Db::open(&self.data_dir)?,
             cache: Cache::open(Some(&self.data_dir))?,
+            data_dir: self.data_dir.clone(),
         })
     }
 
@@ -211,6 +212,12 @@ impl Analyzer {
     /// The content-addressed asset store (blobs at `<dir>/<sha256[:2]>/<sha256>`).
     pub fn assets_dir(&self) -> PathBuf {
         self.data_dir.join("assets")
+    }
+
+    /// Absolute path of one asset blob, or `None` when the sha is malformed or
+    /// the blob isn't in the local store.
+    pub fn asset_blob_path(&self, sha256: &str) -> Option<PathBuf> {
+        asset_blob_in(&self.assets_dir(), sha256)
     }
 
     /// Run the adapter's asset extraction into the store. Failures degrade to a
@@ -442,6 +449,7 @@ fn looks_importable(path: &Path) -> bool {
 pub struct Reader {
     db: Db,
     cache: Cache,
+    data_dir: PathBuf,
 }
 
 impl Reader {
@@ -479,6 +487,26 @@ impl Reader {
             None => Ok(None),
         }
     }
+
+    /// The content-addressed asset store — see [`Analyzer::assets_dir`].
+    pub fn assets_dir(&self) -> PathBuf {
+        self.data_dir.join("assets")
+    }
+
+    /// Absolute path of one asset blob — see [`Analyzer::asset_blob_path`].
+    pub fn asset_blob_path(&self, sha256: &str) -> Option<PathBuf> {
+        asset_blob_in(&self.assets_dir(), sha256)
+    }
+}
+
+/// `<store>/<sha256[:2]>/<sha256>` when the sha is well-formed and the blob
+/// exists locally. Hex validation makes the interpolation path-safe.
+fn asset_blob_in(store: &Path, sha256: &str) -> Option<PathBuf> {
+    if !is_sha256_hex(sha256) {
+        return None;
+    }
+    let path = store.join(&sha256[..2]).join(sha256);
+    path.is_file().then_some(path)
 }
 
 /// Recursively collect importable files under `root`, depth-first, sorted for a

--- a/crates/curator-ffi/src/lib.rs
+++ b/crates/curator-ffi/src/lib.rs
@@ -53,6 +53,19 @@ pub struct FileNode {
     pub children: Vec<FileNode>,
 }
 
+/// One browser-viewable asset extracted from the build (image/audio/video/text).
+#[derive(uniffi::Record)]
+pub struct AssetInfo {
+    /// Full path from the volume root — matches the contents tree.
+    pub path: String,
+    pub sha256: String,
+    pub size: u64,
+    pub mime: String,
+    pub kind: String, // "image" | "audio" | "video" | "text"
+    /// Absolute path of the blob in the local store, when present.
+    pub blob_path: Option<String>,
+}
+
 /// Everything the GUI needs to render one analyzed image.
 #[derive(uniffi::Record)]
 pub struct AnalysisSummary {
@@ -69,6 +82,8 @@ pub struct AnalysisSummary {
     pub xml: String,
     /// Pretty-printed canonical JSON record.
     pub json: String,
+    /// Viewable assets. `None` = extraction never ran on this record.
+    pub assets: Option<Vec<AssetInfo>>,
 }
 
 /// Column the library browser sorts on.
@@ -106,10 +121,27 @@ pub struct LibraryEntry {
 }
 
 /// Assemble the UI summary from a canonical record (shared by analyze + loadBuild).
-fn build_summary(analysis: &Analysis) -> Result<AnalysisSummary, CuratorError> {
+/// `blob_path` resolves an asset sha256 to its local blob, when present.
+fn build_summary(
+    analysis: &Analysis,
+    blob_path: impl Fn(&str) -> Option<std::path::PathBuf>,
+) -> Result<AnalysisSummary, CuratorError> {
     let record = &analysis.record;
     let xml = render::to_dat_xml(record);
     let json = render::to_json(record).map_err(CuratorError::from)?;
+    let assets = record.assets.as_ref().map(|assets| {
+        assets
+            .iter()
+            .map(|a| AssetInfo {
+                path: a.path.clone(),
+                sha256: a.sha256.clone(),
+                size: a.size,
+                mime: a.mime.clone(),
+                kind: a.kind.clone(),
+                blob_path: blob_path(&a.sha256).map(|p| p.to_string_lossy().into_owned()),
+            })
+            .collect()
+    });
     Ok(AnalysisSummary {
         sha256: record.image.sha256.clone(),
         name: record.image.name.clone(),
@@ -122,6 +154,7 @@ fn build_summary(analysis: &Analysis) -> Result<AnalysisSummary, CuratorError> {
         tree: record.contents.iter().map(node_to_ffi).collect(),
         xml,
         json,
+        assets,
     })
 }
 
@@ -269,8 +302,9 @@ impl Engine {
         cancel: Option<Arc<CancelHandle>>,
     ) -> Result<AnalysisSummary, CuratorError> {
         let observer = Arc::new(ListenerObserver { listener, cancel });
-        let analysis = self.inner.lock().unwrap_or_else(|e| e.into_inner()).analyze(&path, observer)?;
-        build_summary(&analysis)
+        let analyzer = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let analysis = analyzer.analyze(&path, observer)?;
+        build_summary(&analysis, |sha| analyzer.asset_blob_path(sha))
     }
 
     /// Number of builds in the local library.
@@ -325,8 +359,9 @@ impl Engine {
     /// Reload a stored build from cache by sha256 (no adapter run). `None` if absent.
     /// Uses the reader, so it works while an import holds the writer.
     pub fn load_build(&self, sha256: String) -> Result<Option<AnalysisSummary>, CuratorError> {
-        match self.reader.lock().unwrap_or_else(|e| e.into_inner()).load_cached(&sha256)? {
-            Some(analysis) => Ok(Some(build_summary(&analysis)?)),
+        let reader = self.reader.lock().unwrap_or_else(|e| e.into_inner());
+        match reader.load_cached(&sha256)? {
+            Some(analysis) => Ok(Some(build_summary(&analysis, |sha| reader.asset_blob_path(sha))?)),
             None => Ok(None),
         }
     }

--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -2022,18 +2022,7 @@ mod app {
         let (mut uploaded, mut failed) = (0usize, 0usize);
         for (i, sha) in todo.iter().enumerate() {
             post_service_result(hwnd_i, format!("Uploading asset {} of {}…", i + 1, todo.len()));
-            let ok = std::fs::read(&local[*sha]).ok().is_some_and(|bytes| {
-                matches!(
-                    http_request(
-                        "PUT",
-                        &format!("{assets_url}/{sha}"),
-                        Some("Content-Type: application/octet-stream"),
-                        &bytes,
-                    ),
-                    Ok((code, _)) if (200..300).contains(&code)
-                )
-            });
-            if ok {
+            if upload_asset_chunked(&assets_url, sha, &local[*sha]) {
                 uploaded += 1;
             } else {
                 failed += 1;
@@ -2048,6 +2037,55 @@ mod app {
         }
         note.push('.');
         note
+    }
+
+    /// Upload chunk size — small enough to clear typical proxy body-size limits.
+    const UPLOAD_CHUNK: usize = 4 * 1024 * 1024;
+
+    /// PUT one asset blob in resumable chunks: each request appends at `offset`,
+    /// a 409 answers with the server's staged offset to resume from, and the
+    /// final chunk returns `stored` (or `exists`).
+    unsafe fn upload_asset_chunked(assets_url: &str, sha: &str, path: &std::path::Path) -> bool {
+        let Ok(bytes) = std::fs::read(path) else { return false };
+        let mut offset: usize = 0;
+        let mut last_staged: Option<usize> = None;
+        while offset < bytes.len() {
+            let end = (offset + UPLOAD_CHUNK).min(bytes.len());
+            let url = format!("{assets_url}/{sha}?offset={offset}");
+            let chunk = &bytes[offset..end];
+            match http_request("PUT", &url, Some("Content-Type: application/octet-stream"), chunk) {
+                Ok((code, body)) if (200..300).contains(&code) => {
+                    let v = serde_json::from_str::<serde_json::Value>(&body).unwrap_or_default();
+                    match v.get("status").and_then(|s| s.as_str()) {
+                        Some("stored") | Some("exists") => return true,
+                        _ => {
+                            offset = v
+                                .get("offset")
+                                .and_then(|o| o.as_u64())
+                                .map(|o| o as usize)
+                                .unwrap_or(end);
+                            last_staged = None;
+                        }
+                    }
+                }
+                Ok((409, body)) => {
+                    // Resume where the server actually is; the same answer twice
+                    // means we're not making progress — give up.
+                    let staged = serde_json::from_str::<serde_json::Value>(&body)
+                        .ok()
+                        .and_then(|v| v.get("offset").and_then(|o| o.as_u64()))
+                        .map(|o| o as usize)
+                        .unwrap_or(0);
+                    if last_staged == Some(staged) {
+                        return false;
+                    }
+                    last_staged = Some(staged);
+                    offset = staged;
+                }
+                _ => return false,
+            }
+        }
+        false // ran out of local bytes without the server confirming the store
     }
 
     /// Export the whole local library to a single `.zip` the user can copy to the

--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -30,7 +30,9 @@ mod app {
 
     use curator_core::adapter::AdapterCommand;
     use curator_core::db::LibrarySort;
-    use curator_core::{render, Analyzer, BuildRecord, Config, Event, Node, ProgressObserver, Reader};
+    use curator_core::{
+        render, Analyzer, AssetRef, BuildRecord, Config, Event, Node, ProgressObserver, Reader,
+    };
 
     use windows::core::{w, PCWSTR, PWSTR, Result};
     use windows::Win32::Foundation::{HANDLE, HWND, LPARAM, LRESULT, WPARAM};
@@ -62,7 +64,8 @@ mod app {
     };
     use windows::Win32::UI::Shell::{
         DefSubclassProc, DragAcceptFiles, DragFinish, DragQueryFileW, SetWindowSubclass,
-        SHBrowseForFolderW, SHGetPathFromIDListW, BIF_RETURNONLYFSDIRS, BROWSEINFOW, HDROP,
+        ShellExecuteW, SHBrowseForFolderW, SHGetPathFromIDListW, BIF_RETURNONLYFSDIRS,
+        BROWSEINFOW, HDROP,
     };
     use windows::Win32::UI::WindowsAndMessaging::*;
 
@@ -78,15 +81,17 @@ mod app {
     const IDM_VIEW_JSON: usize = 9;
     const IDM_EXPORT: usize = 10;
     const IDM_BROWSE: usize = 11;
+    const IDM_VIEW_ASSETS: usize = 12;
     const IDM_RECENT_BASE: usize = 2000;
     const MAX_RECENT: u32 = 15;
 
-    /// What the right-hand document pane is showing. Overview/Selection render in the
-    /// grouped ListView; Xml/Json render as text in the EDIT control.
+    /// What the right-hand document pane is showing. Overview/Selection/Assets render
+    /// in the grouped ListView; Xml/Json render as text in the EDIT control.
     #[derive(Clone, Copy, PartialEq)]
     enum DocView {
         Overview,
         Selection,
+        Assets,
         Xml,
         Json,
     }
@@ -146,6 +151,14 @@ mod app {
         import_base: String,
         /// Canonical JSON of the loaded build (for similarity/submit), if any.
         last_json: Option<String>,
+        /// Image sha256 of the loaded build (keys the asset-upload endpoints).
+        last_sha: Option<String>,
+        /// The loaded build's viewable assets; `assets_extracted` distinguishes
+        /// "extraction ran, nothing viewable" from "extraction never ran".
+        assets: Vec<AssetRef>,
+        assets_extracted: bool,
+        /// Assets-view ListView row → index into `assets` (rows flatten kind groups).
+        asset_rows: Vec<usize>,
         /// Document-pane content, by view. `view` selects which one is shown.
         view: DocView,
         doc_overview: Vec<Section>,
@@ -535,6 +548,10 @@ mod app {
             importing: false,
             import_base: String::new(),
             last_json: None,
+            last_sha: None,
+            assets: Vec::new(),
+            assets_extracted: false,
+            asset_rows: Vec::new(),
             view: DocView::Overview,
             doc_overview: Vec::new(),
             doc_xml: String::new(),
@@ -582,6 +599,7 @@ mod app {
         let _ = AppendMenuW(analysis, MF_STRING, IDM_SUBMIT, w!("Su&bmit Build…"));
         let view = CreatePopupMenu().unwrap_or_default();
         let _ = AppendMenuW(view, MF_STRING, IDM_VIEW_OVERVIEW, w!("&Overview"));
+        let _ = AppendMenuW(view, MF_STRING, IDM_VIEW_ASSETS, w!("&Assets"));
         let _ = AppendMenuW(view, MF_STRING, IDM_VIEW_XML, w!("&DAT (XML)"));
         let _ = AppendMenuW(view, MF_STRING, IDM_VIEW_JSON, w!("&JSON"));
         let _ = AppendMenuW(menu, MF_POPUP, file.0 as usize, w!("&File"));
@@ -648,6 +666,7 @@ mod app {
             IDM_SIMILAR => find_similar(hwnd),
             IDM_SUBMIT => submit_build(hwnd),
             IDM_VIEW_OVERVIEW => set_view(hwnd, DocView::Overview),
+            IDM_VIEW_ASSETS => set_view(hwnd, DocView::Assets),
             IDM_VIEW_XML => set_view(hwnd, DocView::Xml),
             IDM_VIEW_JSON => set_view(hwnd, DocView::Json),
             IDM_EXIT => {
@@ -871,6 +890,10 @@ mod app {
         if let Some(st) = state(hwnd) {
             st.node_sections = populate_tree(st.tree, &done.record);
             st.last_json = Some(done.json.clone());
+            st.last_sha = Some(done.record.image.sha256.clone());
+            st.assets = done.record.assets.clone().unwrap_or_default();
+            st.assets_extracted = done.record.assets.is_some();
+            st.asset_rows = Vec::new();
             st.doc_xml = done.xml.replace('\n', "\r\n");
             st.doc_overview = overview_sections(&done.record);
             st.selected_sections = Vec::new();
@@ -904,16 +927,17 @@ mod app {
         }
     }
 
-    /// Show the control for the active view (ListView for Overview/Selection, EDIT for
-    /// Xml/Json) and load its content.
+    /// Show the control for the active view (ListView for Overview/Selection/Assets,
+    /// EDIT for Xml/Json) and load its content.
     unsafe fn apply_view(hwnd: HWND) {
         let Some(st) = state(hwnd) else { return };
-        let grouped = matches!(st.view, DocView::Overview | DocView::Selection);
+        let grouped = matches!(st.view, DocView::Overview | DocView::Selection | DocView::Assets);
         let _ = ShowWindow(st.list, if grouped { SW_SHOW } else { SW_HIDE });
         let _ = ShowWindow(st.edit, if grouped { SW_HIDE } else { SW_SHOW });
         match st.view {
             DocView::Overview => fill_list(st.list, &st.doc_overview),
             DocView::Selection => fill_list(st.list, &st.selected_sections),
+            DocView::Assets => fill_assets(st),
             DocView::Xml | DocView::Json => {
                 let text = if matches!(st.view, DocView::Xml) {
                     st.doc_xml.clone()
@@ -927,10 +951,72 @@ mod app {
     }
 
     unsafe fn set_view(hwnd: HWND, view: DocView) {
+        if matches!(view, DocView::Assets) {
+            ensure_reader(hwnd); // fill_assets checks blob presence via the reader
+        }
         if let Some(st) = state(hwnd) {
             st.view = view;
         }
         apply_view(hwnd);
+        if matches!(view, DocView::Assets) {
+            set_status(hwnd, "Double-click an asset to open it.");
+        }
+    }
+
+    /// Display order + section titles for asset kinds — mirrors the web build pages.
+    const ASSET_KINDS: [(&str, &str); 4] =
+        [("image", "Images"), ("audio", "Audio"), ("video", "Video"), ("text", "Text")];
+
+    /// Fill the grouped ListView with the loaded build's assets (one group per kind)
+    /// and rebuild the row → asset index map used by double-click-to-open.
+    unsafe fn fill_assets(st: &mut AppState) {
+        st.asset_rows.clear();
+        let mut sections = Vec::new();
+        if st.assets.is_empty() {
+            sections.push(Section {
+                title: "Assets".into(),
+                rows: vec![(
+                    "Status".into(),
+                    if st.assets_extracted {
+                        "No browser-viewable assets in this build.".into()
+                    } else {
+                        "Asset extraction hasn't run for this build — re-analyze the image.".into()
+                    },
+                )],
+            });
+        }
+        for (kind, title) in ASSET_KINDS {
+            let idxs: Vec<usize> = st
+                .assets
+                .iter()
+                .enumerate()
+                .filter(|(_, a)| a.kind == kind)
+                .map(|(i, _)| i)
+                .collect();
+            if idxs.is_empty() {
+                continue;
+            }
+            let rows = idxs
+                .iter()
+                .map(|&i| {
+                    let a = &st.assets[i];
+                    let name = a.path.rsplit('/').next().unwrap_or(&a.path).to_string();
+                    let local = st
+                        .reader
+                        .as_ref()
+                        .and_then(|r| r.asset_blob_path(&a.sha256))
+                        .is_some();
+                    let mut detail = format!("{} — {} — {}", a.path, human_size(a.size), a.mime);
+                    if !local {
+                        detail.push_str(" — not in local store");
+                    }
+                    (name, detail)
+                })
+                .collect();
+            sections.push(Section { title: format!("{title} ({})", idxs.len()), rows });
+            st.asset_rows.extend(idxs);
+        }
+        fill_list(st.list, &sections);
     }
 
     /// Clear and repopulate the grouped ListView from `sections`.
@@ -984,6 +1070,7 @@ mod app {
         let mut selection_changed = false;
         let mut copied: Option<String> = None;
         let mut open_sha: Option<String> = None;
+        let mut open_asset: Option<usize> = None;
         let mut lib_resort = false;
         if let Some(st) = state(hwnd) {
             if from == st.tree && code == TVN_SELCHANGEDW {
@@ -997,7 +1084,13 @@ mod app {
             } else if from == st.list && code == NM_DBLCLK as u32 {
                 let nia = &*(lparam.0 as *const NMITEMACTIVATE);
                 if nia.iItem >= 0 {
-                    copied = Some(list_value(st.list, nia.iItem));
+                    // In the assets view a row is a file to open; elsewhere it's
+                    // a key/value pair whose value copies to the clipboard.
+                    if st.view == DocView::Assets {
+                        open_asset = st.asset_rows.get(nia.iItem as usize).copied();
+                    } else {
+                        copied = Some(list_value(st.list, nia.iItem));
+                    }
                 }
             } else if from == st.lib_list && code == NM_DBLCLK as u32 {
                 let nia = &*(lparam.0 as *const NMITEMACTIVATE);
@@ -1030,6 +1123,9 @@ mod app {
         }
         if let Some(sha) = open_sha {
             open_sha256(hwnd, &sha); // leaves library mode and shows the build
+        }
+        if let Some(idx) = open_asset {
+            open_asset_at(hwnd, idx);
         }
         if let Some(value) = copied {
             if !value.is_empty() {
@@ -1749,6 +1845,73 @@ mod app {
         }
     }
 
+    // ---- asset viewer ----
+
+    /// Open the asset at `assets[idx]`. Media kinds go to their default app via a
+    /// temp copy carrying the original filename (store blobs are extensionless, so
+    /// the shell can't pick a handler for them directly). Text kinds always open
+    /// in Notepad: handing a `.bat`/`.cmd`/`.js` from an untrusted disc to the
+    /// shell's default verb would execute it.
+    unsafe fn open_asset_at(hwnd: HWND, idx: usize) {
+        ensure_reader(hwnd);
+        let (asset, blob) = {
+            let Some(st) = state(hwnd) else { return };
+            let Some(asset) = st.assets.get(idx).cloned() else { return };
+            let blob = st.reader.as_ref().and_then(|r| r.asset_blob_path(&asset.sha256));
+            (asset, blob)
+        };
+        let Some(blob) = blob else {
+            set_status(hwnd, "Asset not in the local store — re-analyze the image to extract it.");
+            return;
+        };
+        let path = match materialize_asset(&asset, &blob) {
+            Ok(p) => p,
+            Err(e) => {
+                set_status(hwnd, &format!("Couldn't stage asset: {e}"));
+                return;
+            }
+        };
+        let path_str = path.to_string_lossy().into_owned();
+        let launched = if asset.kind == "text" {
+            let args = wide(&format!("\"{path_str}\""));
+            ShellExecuteW(hwnd, w!("open"), w!("notepad.exe"), PCWSTR(args.as_ptr()), PCWSTR::null(), SW_SHOWNORMAL)
+        } else {
+            let file = wide(&path_str);
+            ShellExecuteW(hwnd, w!("open"), PCWSTR(file.as_ptr()), PCWSTR::null(), PCWSTR::null(), SW_SHOWNORMAL)
+        };
+        // ShellExecuteW reports success as a value > 32.
+        if launched.0 as isize <= 32 {
+            set_status(hwnd, &format!("No application could open {}.", asset.path));
+        } else {
+            set_status(hwnd, &format!("Opened {}.", asset.path));
+        }
+    }
+
+    /// Copy a blob into a per-asset temp dir under its original (sanitized)
+    /// filename so the shell can pick a handler by extension. Content-addressed,
+    /// so an existing copy is reused.
+    fn materialize_asset(asset: &AssetRef, blob: &std::path::Path) -> std::result::Result<PathBuf, String> {
+        let base = asset.path.rsplit('/').next().unwrap_or_default();
+        let safe: String = base
+            .chars()
+            .map(|c| {
+                if matches!(c, '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*') || (c as u32) < 0x20 {
+                    '_'
+                } else {
+                    c
+                }
+            })
+            .collect();
+        let name = if safe.trim_matches(['.', ' ']).is_empty() { asset.sha256.clone() } else { safe };
+        let dir = std::env::temp_dir().join("curator-assets").join(&asset.sha256);
+        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        let dest = dir.join(name);
+        if !dest.exists() {
+            std::fs::copy(blob, &dest).map_err(|e| e.to_string())?;
+        }
+        Ok(dest)
+    }
+
     // ---- web service: Find Similar / Submit ----
 
     unsafe fn find_similar(hwnd: HWND) {
@@ -1771,8 +1934,11 @@ mod app {
     }
 
     unsafe fn submit_build(hwnd: HWND) {
-        let Some(st) = state(hwnd) else { return };
-        let Some(json) = st.last_json.clone() else {
+        let json = {
+            let Some(st) = state(hwnd) else { return };
+            st.last_json.clone()
+        };
+        let Some(json) = json else {
             set_status(hwnd, "Analyze a build first.");
             return;
         };
@@ -1780,7 +1946,20 @@ mod app {
         if nickname.trim().is_empty() {
             return;
         }
-        let url = format!("{}/api/submissions", st.web_url.trim_end_matches('/'));
+        // Resolve which of the build's asset blobs exist locally (sha256 → path)
+        // up front on the UI thread; the worker uploads whichever the server lacks.
+        ensure_reader(hwnd);
+        let (base, sha, local_assets) = {
+            let Some(st) = state(hwnd) else { return };
+            let mut local: HashMap<String, PathBuf> = HashMap::new();
+            for a in &st.assets {
+                if let Some(p) = st.reader.as_ref().and_then(|r| r.asset_blob_path(&a.sha256)) {
+                    local.insert(a.sha256.clone(), p);
+                }
+            }
+            (st.web_url.trim_end_matches('/').to_string(), st.last_sha.clone(), local)
+        };
+        let url = format!("{base}/api/submissions");
         // { "nickname": <json string>, "record": <record> } — embed the raw record JSON.
         let body = format!(
             "{{\"nickname\":{},\"record\":{}}}",
@@ -1796,13 +1975,79 @@ mod app {
                         .ok()
                         .and_then(|v| v.get("status").and_then(|s| s.as_str()).map(String::from))
                         .unwrap_or_else(|| "queued".into());
-                    format!("Submitted — {status}.")
+                    let note = match sha {
+                        Some(sha) => upload_missing_assets(hwnd_i, &base, &sha, &local_assets),
+                        None => String::new(),
+                    };
+                    format!("Submitted — {status}.{note}")
                 }
                 Ok((code, b)) => format!("Server error {code}: {}", b.trim()),
                 Err(e) => format!("Cannot reach service: {e}"),
             };
             post_service_result(hwnd_i, text);
         });
+    }
+
+    /// Ask the server which of the submitted build's asset blobs it lacks, then
+    /// PUT each one we hold locally. Runs on the submit worker thread; interim
+    /// one-line progress goes to the status bar. Failures degrade to a note —
+    /// the record submission already succeeded.
+    unsafe fn upload_missing_assets(
+        hwnd_i: isize,
+        base: &str,
+        build_sha: &str,
+        local: &HashMap<String, PathBuf>,
+    ) -> String {
+        if local.is_empty() {
+            return String::new(); // nothing extracted locally — nothing to offer
+        }
+        let assets_url = format!("{base}/api/submissions/{build_sha}/assets");
+        let missing: Vec<String> = match http_request("GET", &assets_url, None, &[]) {
+            Ok((code, b)) if (200..300).contains(&code) => serde_json::from_str::<serde_json::Value>(&b)
+                .ok()
+                .and_then(|v| {
+                    v.get("missing").and_then(|m| m.as_array()).map(|arr| {
+                        arr.iter().filter_map(|s| s.as_str().map(String::from)).collect()
+                    })
+                })
+                .unwrap_or_default(),
+            Ok((code, _)) => return format!(" Asset check failed: server error {code}."),
+            Err(e) => return format!(" Asset check failed: {e}."),
+        };
+        if missing.is_empty() {
+            return " Assets already on server.".into();
+        }
+        let todo: Vec<&String> = missing.iter().filter(|sha| local.contains_key(*sha)).collect();
+        let unavailable = missing.len() - todo.len();
+        let (mut uploaded, mut failed) = (0usize, 0usize);
+        for (i, sha) in todo.iter().enumerate() {
+            post_service_result(hwnd_i, format!("Uploading asset {} of {}…", i + 1, todo.len()));
+            let ok = std::fs::read(&local[*sha]).ok().is_some_and(|bytes| {
+                matches!(
+                    http_request(
+                        "PUT",
+                        &format!("{assets_url}/{sha}"),
+                        Some("Content-Type: application/octet-stream"),
+                        &bytes,
+                    ),
+                    Ok((code, _)) if (200..300).contains(&code)
+                )
+            });
+            if ok {
+                uploaded += 1;
+            } else {
+                failed += 1;
+            }
+        }
+        let mut note = format!(" Uploaded {uploaded} asset blob{}", if uploaded == 1 { "" } else { "s" });
+        if failed > 0 {
+            note.push_str(&format!(", {failed} failed"));
+        }
+        if unavailable > 0 {
+            note.push_str(&format!(", {unavailable} not in local store"));
+        }
+        note.push('.');
+        note
     }
 
     /// Export the whole local library to a single `.zip` the user can copy to the
@@ -1913,6 +2158,17 @@ mod app {
 
     /// Native WinHTTP `POST <url>` with a JSON body. Returns (status_code, body).
     unsafe fn http_post_json(url: &str, body: &str) -> std::result::Result<(u32, String), String> {
+        http_request("POST", url, Some("Content-Type: application/json"), body.as_bytes())
+    }
+
+    /// Native WinHTTP request with an arbitrary verb, optional extra header line,
+    /// and raw byte body (empty = no body). Returns (status_code, body).
+    unsafe fn http_request(
+        verb: &str,
+        url: &str,
+        header: Option<&str>,
+        body: &[u8],
+    ) -> std::result::Result<(u32, String), String> {
         // Parse scheme://host[:port]/path (minimal; http/https only).
         let (secure, rest) = if let Some(r) = url.strip_prefix("https://") {
             (true, r)
@@ -1934,9 +2190,9 @@ mod app {
         };
 
         let host_w = wide(host);
-        let verb_w = wide("POST");
+        let verb_w = wide(verb);
         let path_w = wide(path);
-        let headers_w = wide("Content-Type: application/json");
+        let headers_w = header.map(wide);
 
         let session = WinHttpOpen(
             w!("curator-gui-win"),
@@ -1971,13 +2227,16 @@ mod app {
                 return Err("WinHttpOpenRequest failed".to_string());
             }
 
-            let bytes = body.as_bytes();
             let sent = WinHttpSendRequest(
                 req,
-                Some(&headers_w[..headers_w.len() - 1]), // sans NUL
-                Some(bytes.as_ptr() as *const core::ffi::c_void),
-                bytes.len() as u32,
-                bytes.len() as u32,
+                headers_w.as_deref().map(|h| &h[..h.len() - 1]), // sans NUL
+                if body.is_empty() {
+                    None
+                } else {
+                    Some(body.as_ptr() as *const core::ffi::c_void)
+                },
+                body.len() as u32,
+                body.len() as u32,
                 0,
             )
             .is_ok()

--- a/macos/README.md
+++ b/macos/README.md
@@ -61,7 +61,12 @@ cd macos && swift run curator-probe
 - **Find Similar** → `POST /api/similarity`; tiered neighbors (content / files / chunks /
   audio / exe / text) in the Similar tab. Click a neighbor to open its web build-detail
   page (`/builds/<sha256>`), or right-click to copy the hash.
-- **Submit** → `POST /api/submissions` with a nickname (moderation queue).
+- **Submit** → `POST /api/submissions` with a nickname (moderation queue), then uploads
+  whichever of the build's asset blobs the server reports missing
+  (`GET`/`PUT /api/submissions/<sha>/assets[/<assetSha>]`).
+- **Assets tab** — the build's extracted viewable files: image thumbnails, audio/video
+  rows (open in the default app via a named temp copy), and an in-app text preview
+  (text assets are never handed to the shell — a `.sh`/`.js` could execute).
 
 ## Notes
 

--- a/macos/Sources/CuratorApp/AppModel.swift
+++ b/macos/Sources/CuratorApp/AppModel.swift
@@ -28,7 +28,16 @@ enum DocMode: String, CaseIterable, Identifiable {
 /// Which detail-pane tab is showing. Defaults to `.overview` on load; selecting a file
 /// in the sidebar switches to `.selection`. XML/JSON live under `.document` (opt-in).
 enum DetailTab: Hashable {
-    case overview, selection, document, similar
+    case overview, selection, assets, document, similar
+}
+
+/// An in-app preview of one text asset (never shell-opened — a `.sh`/`.bat`/`.js`
+/// from an untrusted disc must not reach an app that might execute it).
+struct AssetTextPreview: Identifiable {
+    let id: String // asset sha256
+    let name: String
+    let text: String
+    let truncated: Bool
 }
 
 /// Forwards UniFFI progress callbacks (delivered on a background thread) to a main-actor sink.
@@ -83,6 +92,9 @@ final class AppModel: ObservableObject {
     @Published var isQuerying = false
     @Published var serviceMessage: String?
     @Published var showingSubmitSheet = false
+
+    // Asset viewer.
+    @Published var assetPreview: AssetTextPreview?
 
     private let service = CuratorService()
     private var engine: Engine?
@@ -261,7 +273,8 @@ final class AppModel: ObservableObject {
         }
     }
 
-    /// Submit the loaded build to the moderation queue under `nickname`.
+    /// Submit the loaded build to the moderation queue under `nickname`, then
+    /// upload whichever of its asset blobs the server reports missing.
     func submit(nickname: String) {
         guard let summary, !isQuerying else { return }
         let json = summary.json
@@ -272,12 +285,109 @@ final class AppModel: ObservableObject {
         Task {
             do {
                 let r = try await service.submit(recordJSON: json, nickname: nick)
-                serviceMessage = "Submitted \(r.sha256.prefix(12))… — \(r.status)."
+                let assetNote = await uploadMissingAssets(for: summary)
+                serviceMessage = "Submitted \(r.sha256.prefix(12))… — \(r.status).\(assetNote)"
             } catch {
                 serviceMessage = (error as? LocalizedError)?.errorDescription ?? "\(error)"
             }
             isQuerying = false
         }
+    }
+
+    /// Upload the build's asset blobs that the server lacks and we hold locally.
+    /// Returns a status suffix for the submit message ("" when moot). Upload
+    /// failures degrade to a note — the record submission already succeeded.
+    private func uploadMissingAssets(for summary: AnalysisSummary) async -> String {
+        guard let assets = summary.assets, !assets.isEmpty else { return "" }
+        var local: [String: String] = [:] // asset sha256 → blob path
+        for a in assets where a.blobPath != nil { local[a.sha256] = a.blobPath }
+        do {
+            let missing = try await service.missingAssets(buildSha: summary.sha256)
+            if missing.isEmpty { return " Assets already on server." }
+            let todo = missing.filter { local[$0] != nil }
+            var done = 0
+            for sha in todo {
+                serviceMessage = "Uploading assets \(done + 1)/\(todo.count)…"
+                guard let blob = local[sha] else { continue }
+                try await service.uploadAsset(
+                    buildSha: summary.sha256,
+                    assetSha: sha,
+                    fileURL: URL(fileURLWithPath: blob)
+                )
+                done += 1
+            }
+            let unavailable = missing.count - todo.count
+            var note = " Uploaded \(done) asset blob\(done == 1 ? "" : "s")"
+            if unavailable > 0 { note += " (\(unavailable) not in the local store)" }
+            return note + "."
+        } catch {
+            let detail = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+            return " Asset upload failed: \(detail)"
+        }
+    }
+
+    // MARK: - Asset viewer
+
+    /// Open one extracted asset. Media kinds go to the default app via a temp
+    /// copy carrying the original filename (blobs are extensionless, so the
+    /// store path alone can't pick a handler). Text kinds preview in-app only:
+    /// shell-opening a `.sh`/`.bat`/`.js` from an untrusted disc could hand it
+    /// to something that executes it.
+    func openAsset(_ asset: AssetInfo) {
+        guard let blob = asset.blobPath else {
+            status = "Asset not in the local store — re-analyze the image to extract it."
+            return
+        }
+        if asset.kind == "text" {
+            previewTextAsset(asset, blob: blob)
+            return
+        }
+        do {
+            let url = try materializeAsset(asset, blob: blob)
+            if !NSWorkspace.shared.open(url) {
+                status = "No application could open \(url.lastPathComponent)."
+            }
+        } catch {
+            status = "Couldn't open asset: \(error.localizedDescription)"
+        }
+    }
+
+    /// Show a text asset in the in-app preview sheet (display capped at 256 KB).
+    private func previewTextAsset(_ asset: AssetInfo, blob: String) {
+        let capBytes = 256 * 1024
+        guard let fh = FileHandle(forReadingAtPath: blob) else {
+            status = "Couldn't read asset from the local store."
+            return
+        }
+        defer { try? fh.close() }
+        let data = (try? fh.read(upToCount: capBytes)) ?? Data()
+        let text = String(decoding: data, as: UTF8.self)
+            .replacingOccurrences(of: "\0", with: "")
+            .replacingOccurrences(of: "\r\n", with: "\n")
+        assetPreview = AssetTextPreview(
+            id: asset.sha256,
+            name: (asset.path as NSString).lastPathComponent,
+            text: text,
+            truncated: asset.size > UInt64(capBytes)
+        )
+    }
+
+    /// Copy a blob into a per-asset temp dir under its original filename so
+    /// Launch Services can pick the right app. Content-addressed, so an
+    /// existing copy is reused.
+    private func materializeAsset(_ asset: AssetInfo, blob: String) throws -> URL {
+        let base = (asset.path as NSString).lastPathComponent
+            .replacingOccurrences(of: ":", with: "_")
+        let name = base.isEmpty ? asset.sha256 : base
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("curator-assets", isDirectory: true)
+            .appendingPathComponent(asset.sha256, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let dest = dir.appendingPathComponent(name)
+        if !FileManager.default.fileExists(atPath: dest.path) {
+            try FileManager.default.copyItem(at: URL(fileURLWithPath: blob), to: dest)
+        }
+        return dest
     }
 
     /// Open a build's detail page in the web library in the default browser.

--- a/macos/Sources/CuratorApp/ContentView.swift
+++ b/macos/Sources/CuratorApp/ContentView.swift
@@ -47,6 +47,7 @@ struct ContentView: View {
         .safeAreaInset(edge: .bottom) { StatusBar() }
         .sheet(isPresented: $model.showingSubmitSheet) { SubmitSheet() }
         .sheet(isPresented: $model.showingError) { ErrorSheet() }
+        .sheet(item: $model.assetPreview) { AssetTextSheet(preview: $0) }
         .onChange(of: model.selection) { sel in
             // Clicking a file in the sidebar surfaces its metadata table.
             if sel != nil { model.detailTab = .selection }
@@ -268,6 +269,9 @@ struct DetailView: View {
                     NodeDetail(node: model.selectedNode)
                         .tabItem { Label("Selection", systemImage: "doc.text.magnifyingglass") }
                         .tag(DetailTab.selection)
+                    AssetsView(summary: summary)
+                        .tabItem { Label("Assets", systemImage: "photo.on.rectangle") }
+                        .tag(DetailTab.assets)
                     DocumentView(summary: summary)
                         .tabItem { Label("DAT / JSON", systemImage: "doc.plaintext") }
                         .tag(DetailTab.document)
@@ -457,6 +461,181 @@ struct DocumentView: View {
                     .padding(8)
             }
         }
+    }
+}
+
+// MARK: - Assets (browser-viewable files extracted from the build)
+
+/// Display order for asset kinds — mirrors the web build pages.
+private let assetKindOrder = ["image", "audio", "video", "text"]
+
+private func assetKindIcon(_ kind: String) -> String {
+    switch kind {
+    case "image": return "photo"
+    case "audio": return "music.note"
+    case "video": return "film"
+    default: return "doc.text"
+    }
+}
+
+struct AssetsView: View {
+    @EnvironmentObject var model: AppModel
+    let summary: AnalysisSummary
+
+    private var grouped: [(String, [AssetInfo])] {
+        let assets = summary.assets ?? []
+        return assetKindOrder
+            .map { kind in (kind, assets.filter { $0.kind == kind }) }
+            .filter { !$0.1.isEmpty }
+    }
+
+    var body: some View {
+        if grouped.isEmpty {
+            ContentUnavailableViewCompat(
+                title: "No viewable assets",
+                systemImage: "photo.on.rectangle",
+                message: summary.assets == nil
+                    ? "Asset extraction hasn't run for this build yet — re-analyze the image to extract viewable files."
+                    : "This build carries no browser-viewable images, audio, video, or text."
+            )
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    ForEach(grouped, id: \.0) { kind, assets in
+                        Text("\(kind.capitalized) (\(assets.count))")
+                            .font(.caption.bold()).foregroundStyle(.secondary)
+                            .padding(.horizontal, 12)
+                        if kind == "image" {
+                            LazyVGrid(columns: [GridItem(.adaptive(minimum: 120, maximum: 180), spacing: 8)], spacing: 8) {
+                                ForEach(assets, id: \.sha256) { AssetThumb(asset: $0) }
+                            }
+                            .padding(.horizontal, 12)
+                        } else {
+                            VStack(spacing: 0) {
+                                ForEach(assets, id: \.sha256) { a in
+                                    AssetRow(asset: a)
+                                    Divider()
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 10)
+            }
+        }
+    }
+}
+
+/// One image asset as a clickable thumbnail (decoded off the main thread).
+struct AssetThumb: View {
+    @EnvironmentObject var model: AppModel
+    let asset: AssetInfo
+    @State private var image: NSImage?
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Group {
+                if let image {
+                    Image(nsImage: image).resizable().aspectRatio(contentMode: .fit)
+                } else {
+                    Image(systemName: asset.blobPath == nil ? "photo.badge.exclamationmark" : "photo")
+                        .font(.system(size: 28)).foregroundStyle(.tertiary)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 90, maxHeight: 120)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+            Text((asset.path as NSString).lastPathComponent)
+                .font(.caption2).lineLimit(1).truncationMode(.middle)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { model.openAsset(asset) }
+        .contextMenu { AssetMenu(asset: asset) }
+        .help(asset.path)
+        .task {
+            guard image == nil, let blob = asset.blobPath else { return }
+            // Read off the main thread (Data is Sendable; NSImage is not);
+            // NSImage defers the actual decode until first draw.
+            let data = await Task.detached(priority: .utility) {
+                try? Data(contentsOf: URL(fileURLWithPath: blob))
+            }.value
+            if let data { image = NSImage(data: data) }
+        }
+    }
+}
+
+/// One audio/video/text asset as a clickable list row.
+struct AssetRow: View {
+    @EnvironmentObject var model: AppModel
+    let asset: AssetInfo
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: assetKindIcon(asset.kind)).foregroundStyle(.secondary)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 1) {
+                Text((asset.path as NSString).lastPathComponent).lineLimit(1)
+                Text(asset.path).font(.caption).foregroundStyle(.secondary)
+                    .lineLimit(1).truncationMode(.middle)
+            }
+            Spacer()
+            if asset.blobPath == nil { Tag(text: "not local", tint: .orange) }
+            Text(humanSize(asset.size)).font(.caption).foregroundStyle(.secondary).monospacedDigit()
+            Text(asset.mime).font(.caption).foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 5)
+        .contentShape(Rectangle())
+        .onTapGesture { model.openAsset(asset) }
+        .contextMenu { AssetMenu(asset: asset) }
+    }
+}
+
+/// Shared context-menu actions for an asset.
+struct AssetMenu: View {
+    @EnvironmentObject var model: AppModel
+    let asset: AssetInfo
+
+    var body: some View {
+        Button(asset.kind == "text" ? "Preview" : "Open") { model.openAsset(asset) }
+        Button("Copy SHA-256") {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(asset.sha256, forType: .string)
+        }
+    }
+}
+
+/// In-app viewer for text assets (they are never handed to the shell).
+struct AssetTextSheet: View {
+    let preview: AssetTextPreview
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(preview.name, systemImage: "doc.text").font(.headline)
+            ScrollView([.vertical, .horizontal]) {
+                Text(preview.text.isEmpty ? "(empty file)" : preview.text)
+                    .font(.system(.callout, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+            }
+            .frame(minWidth: 480, minHeight: 240, maxHeight: 480)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+            HStack {
+                if preview.truncated {
+                    Text("Preview truncated to the first 256 KB.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Copy") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(preview.text, forType: .string)
+                }
+                Button("Close") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(16)
+        .frame(width: 640)
     }
 }
 

--- a/macos/Sources/CuratorApp/CuratorService.swift
+++ b/macos/Sources/CuratorApp/CuratorService.swift
@@ -128,14 +128,42 @@ struct CuratorService {
         return try JSONDecoder().decode(SubmitResult.self, from: data)
     }
 
+    private struct AssetsStatus: Decodable { let missing: [String] }
+
+    /// GET `/api/submissions/<sha>/assets` — asset blobs the server still lacks.
+    func missingAssets(buildSha: String) async throws -> [String] {
+        var req = URLRequest(url: baseURL.appendingPathComponent("/api/submissions/\(buildSha)/assets"))
+        req.httpMethod = "GET"
+        let data = try await perform(req)
+        return try JSONDecoder().decode(AssetsStatus.self, from: data).missing
+    }
+
+    /// PUT one asset blob (raw bytes, streamed from the local store) under its build.
+    func uploadAsset(buildSha: String, assetSha: String, fileURL: URL) async throws {
+        var req = URLRequest(url: baseURL.appendingPathComponent("/api/submissions/\(buildSha)/assets/\(assetSha)"))
+        req.httpMethod = "PUT"
+        req.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        _ = try await perform(req, uploadFile: fileURL)
+    }
+
     private func post(path: String, body: Data) async throws -> Data {
         var req = URLRequest(url: baseURL.appendingPathComponent(path))
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.httpBody = body
+        return try await perform(req)
+    }
+
+    /// Run one request with the shared friendly-error mapping. `uploadFile`
+    /// streams a file as the body (kept off the request to avoid buffering).
+    private func perform(_ req: URLRequest, uploadFile: URL? = nil) async throws -> Data {
         let (data, response): (Data, URLResponse)
         do {
-            (data, response) = try await URLSession.shared.data(for: req)
+            if let uploadFile {
+                (data, response) = try await URLSession.shared.upload(for: req, fromFile: uploadFile)
+            } else {
+                (data, response) = try await URLSession.shared.data(for: req)
+            }
         } catch let urlError as URLError {
             let host = baseURL.absoluteString
             switch urlError.code {

--- a/macos/Sources/CuratorApp/CuratorService.swift
+++ b/macos/Sources/CuratorApp/CuratorService.swift
@@ -138,12 +138,57 @@ struct CuratorService {
         return try JSONDecoder().decode(AssetsStatus.self, from: data).missing
     }
 
-    /// PUT one asset blob (raw bytes, streamed from the local store) under its build.
+    /// Upload chunk size — small enough to clear typical proxy body-size limits.
+    private static let uploadChunkBytes = 4 * 1024 * 1024
+
+    /// One chunk response: `partial` carries the next offset; `stored`/`exists`
+    /// end the upload. A 409 body carries only `offset` (the staged size).
+    private struct ChunkResult: Decodable {
+        let status: String?
+        let offset: UInt64?
+    }
+
+    /// PUT one asset blob under its build in resumable chunks: each request
+    /// appends at `offset`, a 409 answers with the server's staged offset to
+    /// resume from, and the final chunk returns `stored` (or `exists`).
     func uploadAsset(buildSha: String, assetSha: String, fileURL: URL) async throws {
-        var req = URLRequest(url: baseURL.appendingPathComponent("/api/submissions/\(buildSha)/assets/\(assetSha)"))
-        req.httpMethod = "PUT"
-        req.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
-        _ = try await perform(req, uploadFile: fileURL)
+        let fh = try FileHandle(forReadingFrom: fileURL)
+        defer { try? fh.close() }
+        var offset: UInt64 = 0
+        var lastStaged: UInt64?
+        while true {
+            try fh.seek(toOffset: offset)
+            let chunk = try fh.read(upToCount: Self.uploadChunkBytes) ?? Data()
+            if chunk.isEmpty {
+                // The record claims more bytes than the local blob holds.
+                throw ServiceError.transport(baseURL.absoluteString, "asset blob shorter than its record claims")
+            }
+            var req = URLRequest(url: assetChunkURL(buildSha: buildSha, assetSha: assetSha, offset: offset))
+            req.httpMethod = "PUT"
+            req.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+            req.httpBody = chunk
+            do {
+                let data = try await perform(req)
+                let r = try JSONDecoder().decode(ChunkResult.self, from: data)
+                if r.status == "stored" || r.status == "exists" { return }
+                offset = r.offset ?? offset + UInt64(chunk.count)
+                lastStaged = nil
+            } catch let ServiceError.http(code, body) where code == 409 {
+                // Resume where the server actually is; the same answer twice
+                // means we're not making progress — give up.
+                let staged = (try? JSONDecoder().decode(ChunkResult.self, from: Data(body.utf8)))?.offset ?? 0
+                if lastStaged == staged { throw ServiceError.http(code, body) }
+                lastStaged = staged
+                offset = staged
+            }
+        }
+    }
+
+    private func assetChunkURL(buildSha: String, assetSha: String, offset: UInt64) -> URL {
+        let url = baseURL.appendingPathComponent("/api/submissions/\(buildSha)/assets/\(assetSha)")
+        var comps = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        comps?.queryItems = [URLQueryItem(name: "offset", value: String(offset))]
+        return comps?.url ?? url
     }
 
     private func post(path: String, body: Data) async throws -> Data {
@@ -154,16 +199,11 @@ struct CuratorService {
         return try await perform(req)
     }
 
-    /// Run one request with the shared friendly-error mapping. `uploadFile`
-    /// streams a file as the body (kept off the request to avoid buffering).
-    private func perform(_ req: URLRequest, uploadFile: URL? = nil) async throws -> Data {
+    /// Run one request with the shared friendly-error mapping.
+    private func perform(_ req: URLRequest) async throws -> Data {
         let (data, response): (Data, URLResponse)
         do {
-            if let uploadFile {
-                (data, response) = try await URLSession.shared.upload(for: req, fromFile: uploadFile)
-            } else {
-                (data, response) = try await URLSession.shared.data(for: req)
-            }
+            (data, response) = try await URLSession.shared.data(for: req)
         } catch let urlError as URLError {
             let host = baseURL.absoluteString
             switch urlError.code {

--- a/macos/Sources/CuratorKit/curator_ffi.swift
+++ b/macos/Sources/CuratorKit/curator_ffi.swift
@@ -736,6 +736,7 @@ public protocol EngineProtocol: AnyObject, Sendable {
     
     /**
      * Reload a stored build from cache by sha256 (no adapter run). `None` if absent.
+     * Uses the reader, so it works while an import holds the writer.
      */
     func loadBuild(sha256: String) throws  -> AnalysisSummary?
     
@@ -901,6 +902,7 @@ open func listFiles(root: String)throws  -> [String]  {
     
     /**
      * Reload a stored build from cache by sha256 (no adapter run). `None` if absent.
+     * Uses the reader, so it works while an import holds the writer.
      */
 open func loadBuild(sha256: String)throws  -> AnalysisSummary?  {
     return try  FfiConverterOptionTypeAnalysisSummary.lift(try rustCallWithError(FfiConverterTypeCuratorError_lift) {
@@ -1010,6 +1012,10 @@ public struct AnalysisSummary: Equatable, Hashable {
      * Pretty-printed canonical JSON record.
      */
     public var json: String
+    /**
+     * Viewable assets. `None` = extraction never ran on this record.
+     */
+    public var assets: [AssetInfo]?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
@@ -1019,7 +1025,10 @@ public struct AnalysisSummary: Equatable, Hashable {
          */xml: String, 
         /**
          * Pretty-printed canonical JSON record.
-         */json: String) {
+         */json: String, 
+        /**
+         * Viewable assets. `None` = extraction never ran on this record.
+         */assets: [AssetInfo]?) {
         self.sha256 = sha256
         self.name = name
         self.system = system
@@ -1031,6 +1040,7 @@ public struct AnalysisSummary: Equatable, Hashable {
         self.tree = tree
         self.xml = xml
         self.json = json
+        self.assets = assets
     }
 
     
@@ -1059,7 +1069,8 @@ public struct FfiConverterTypeAnalysisSummary: FfiConverterRustBuffer {
                 jsonPath: FfiConverterString.read(from: &buf), 
                 tree: FfiConverterSequenceTypeFileNode.read(from: &buf), 
                 xml: FfiConverterString.read(from: &buf), 
-                json: FfiConverterString.read(from: &buf)
+                json: FfiConverterString.read(from: &buf), 
+                assets: FfiConverterOptionSequenceTypeAssetInfo.read(from: &buf)
         )
     }
 
@@ -1075,6 +1086,7 @@ public struct FfiConverterTypeAnalysisSummary: FfiConverterRustBuffer {
         FfiConverterSequenceTypeFileNode.write(value.tree, into: &buf)
         FfiConverterString.write(value.xml, into: &buf)
         FfiConverterString.write(value.json, into: &buf)
+        FfiConverterOptionSequenceTypeAssetInfo.write(value.assets, into: &buf)
     }
 }
 
@@ -1091,6 +1103,91 @@ public func FfiConverterTypeAnalysisSummary_lift(_ buf: RustBuffer) throws -> An
 #endif
 public func FfiConverterTypeAnalysisSummary_lower(_ value: AnalysisSummary) -> RustBuffer {
     return FfiConverterTypeAnalysisSummary.lower(value)
+}
+
+
+/**
+ * One browser-viewable asset extracted from the build (image/audio/video/text).
+ */
+public struct AssetInfo: Equatable, Hashable {
+    /**
+     * Full path from the volume root — matches the contents tree.
+     */
+    public var path: String
+    public var sha256: String
+    public var size: UInt64
+    public var mime: String
+    public var kind: String
+    /**
+     * Absolute path of the blob in the local store, when present.
+     */
+    public var blobPath: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Full path from the volume root — matches the contents tree.
+         */path: String, sha256: String, size: UInt64, mime: String, kind: String, 
+        /**
+         * Absolute path of the blob in the local store, when present.
+         */blobPath: String?) {
+        self.path = path
+        self.sha256 = sha256
+        self.size = size
+        self.mime = mime
+        self.kind = kind
+        self.blobPath = blobPath
+    }
+
+    
+
+    
+}
+
+#if compiler(>=6)
+extension AssetInfo: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeAssetInfo: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> AssetInfo {
+        return
+            try AssetInfo(
+                path: FfiConverterString.read(from: &buf), 
+                sha256: FfiConverterString.read(from: &buf), 
+                size: FfiConverterUInt64.read(from: &buf), 
+                mime: FfiConverterString.read(from: &buf), 
+                kind: FfiConverterString.read(from: &buf), 
+                blobPath: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: AssetInfo, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.path, into: &buf)
+        FfiConverterString.write(value.sha256, into: &buf)
+        FfiConverterUInt64.write(value.size, into: &buf)
+        FfiConverterString.write(value.mime, into: &buf)
+        FfiConverterString.write(value.kind, into: &buf)
+        FfiConverterOptionString.write(value.blobPath, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeAssetInfo_lift(_ buf: RustBuffer) throws -> AssetInfo {
+    return try FfiConverterTypeAssetInfo.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeAssetInfo_lower(_ value: AssetInfo) -> RustBuffer {
+    return FfiConverterTypeAssetInfo.lower(value)
 }
 
 
@@ -1816,6 +1913,30 @@ fileprivate struct FfiConverterOptionTypeAnalysisSummary: FfiConverterRustBuffer
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionSequenceTypeAssetInfo: FfiConverterRustBuffer {
+    typealias SwiftType = [AssetInfo]?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterSequenceTypeAssetInfo.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterSequenceTypeAssetInfo.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceString: FfiConverterRustBuffer {
     typealias SwiftType = [String]
 
@@ -1833,6 +1954,31 @@ fileprivate struct FfiConverterSequenceString: FfiConverterRustBuffer {
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterString.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeAssetInfo: FfiConverterRustBuffer {
+    typealias SwiftType = [AssetInfo]
+
+    public static func write(_ value: [AssetInfo], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeAssetInfo.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [AssetInfo] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [AssetInfo]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeAssetInfo.read(from: &buf))
         }
         return seq
     }
@@ -1927,7 +2073,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_curator_ffi_checksum_method_engine_list_files() != 6362) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_curator_ffi_checksum_method_engine_load_build() != 6979) {
+    if (uniffi_curator_ffi_checksum_method_engine_load_build() != 49667) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_curator_ffi_checksum_method_engine_recent_builds() != 34130) {

--- a/macos/Sources/curator-probe/main.swift
+++ b/macos/Sources/curator-probe/main.swift
@@ -60,10 +60,24 @@ do {
 // 4. New library reads round-trip (empty data dir → [] and nil).
 let recent = try engine.recentBuilds(limit: 10)
 print("4. recentBuilds(10) -> \(recent.count) entries")
-let missing = try engine.loadBuild(sha256: "deadbeef")
+// Well-formed but unknown (a malformed key like "deadbeef" throws instead).
+let missing = try engine.loadBuild(sha256: String(repeating: "de", count: 32))
 print("   loadBuild(unknown) -> \(missing == nil ? "nil" : "unexpected hit")")
 if let first = recent.first, let loaded = try engine.loadBuild(sha256: first.sha256) {
     print("   loadBuild(\(first.sha256.prefix(8))) -> \(loaded.name), \(loaded.tree.count) root node(s), fromCache=\(loaded.fromCache)")
+}
+
+// 5. Asset metadata round-trip: find a recent build whose record carries assets
+//    and confirm blob paths resolve into the local store.
+for entry in recent {
+    guard let loaded = try engine.loadBuild(sha256: entry.sha256), let assets = loaded.assets else { continue }
+    let local = assets.filter { $0.blobPath != nil }
+    print("5. assets(\(entry.sha256.prefix(8))) -> \(assets.count) recorded, \(local.count) blob(s) local")
+    if let a = local.first {
+        let exists = fm.fileExists(atPath: a.blobPath ?? "")
+        print("   first local blob: \(a.kind) \(a.path) (\(a.size) bytes) -> exists=\(exists)")
+    }
+    break
 }
 
 print("probe done.")

--- a/web/README.md
+++ b/web/README.md
@@ -34,6 +34,9 @@ for the build page's inline asset viewer.
 - `POST /api/submissions` — body `{ nickname, record }`; enqueues for moderation
   (dedup by sha256). `GET /api/submissions/<sha256>` returns status.
 - `GET /api/submissions/<sha256>/assets` — which of the build's referenced asset
-  blobs the store lacks; `PUT /api/submissions/<sha256>/assets/<assetSha>` uploads
-  one (raw body ≤ 20MB, must hash to `<assetSha>` and be referenced by the
-  submitted record). The desktop apps call these after submitting a record.
+  blobs the store lacks; `PUT /api/submissions/<sha256>/assets/<assetSha>[?offset=N]`
+  uploads one (raw body, ≤ 20MB total, must hash to `<assetSha>` and be referenced
+  by the submitted record), in one shot or resumable chunks: chunks append at
+  `offset` (0 restarts; a mismatch answers 409 with the staged offset, a short
+  append 202 with the next one) and the last chunk hash-verifies and stores the
+  blob. The desktop apps call these after submitting a record.

--- a/web/README.md
+++ b/web/README.md
@@ -33,3 +33,7 @@ for the build page's inline asset viewer.
   (read-only, not ingested) and returns fused similar-build neighbors.
 - `POST /api/submissions` — body `{ nickname, record }`; enqueues for moderation
   (dedup by sha256). `GET /api/submissions/<sha256>` returns status.
+- `GET /api/submissions/<sha256>/assets` — which of the build's referenced asset
+  blobs the store lacks; `PUT /api/submissions/<sha256>/assets/<assetSha>` uploads
+  one (raw body ≤ 20MB, must hash to `<assetSha>` and be referenced by the
+  submitted record). The desktop apps call these after submitting a record.

--- a/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import type { NextRequest } from "next/server";
+import { getPool } from "@/lib/db";
+import { assetBlobPath } from "@/lib/assets";
+import { referencedAssets, MAX_BUILD_ASSET_BYTES } from "@/lib/submission-assets";
+import { rateLimit, clientKey } from "@/lib/ratelimit";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// PUT /api/submissions/<sha256>/assets/<assetSha> — upload one asset blob (raw
+// body). Accepted only when <assetSha> is referenced by the submission's (or
+// an ingested build's) record, the size matches the record's claim, and the
+// body actually hashes to <assetSha> — the content address is the authority;
+// nothing else about the request is trusted. Idempotent by construction.
+export async function PUT(
+  request: NextRequest,
+  ctx: { params: Promise<{ sha256: string; assetSha: string }> }
+) {
+  if (!rateLimit(`assets-put:${clientKey(request)}`, 240, 60_000)) {
+    return Response.json({ error: "rate limit exceeded" }, { status: 429 });
+  }
+  const { sha256, assetSha } = await ctx.params;
+  if (!isSha256(sha256) || !isSha256(assetSha)) {
+    return Response.json({ error: "invalid sha256" }, { status: 400 });
+  }
+
+  const refs = await referencedAssets(getPool(), sha256);
+  if (!refs) return Response.json({ error: "not found" }, { status: 404 });
+  const claimed = refs.sizes.get(assetSha);
+  if (claimed === undefined) {
+    return Response.json({ error: "asset not referenced by this build" }, { status: 404 });
+  }
+  if (refs.totalBytes > MAX_BUILD_ASSET_BYTES) {
+    return Response.json({ error: "build's total asset bytes exceed the cap" }, { status: 413 });
+  }
+
+  const dest = assetBlobPath(assetSha);
+  if (fs.existsSync(dest)) return Response.json({ sha256: assetSha, status: "exists" });
+
+  // Stream with a running cap so an oversized/lying body dies early instead of
+  // buffering; the record's claimed size is the per-blob budget.
+  if (!request.body) return Response.json({ error: "missing body" }, { status: 400 });
+  const hash = createHash("sha256");
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  const reader = request.body.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    received += value.byteLength;
+    if (received > claimed) {
+      reader.cancel().catch(() => {});
+      return Response.json({ error: "body exceeds the record's claimed size" }, { status: 413 });
+    }
+    hash.update(value);
+    chunks.push(value);
+  }
+  if (received !== claimed) {
+    return Response.json({ error: "body size does not match the record's claim" }, { status: 422 });
+  }
+  if (hash.digest("hex") !== assetSha) {
+    return Response.json({ error: "body does not hash to the asset sha256" }, { status: 422 });
+  }
+
+  // Atomic write (tmp + rename), same as the bundle ingest path — a concurrent
+  // upload of the same blob resolves to identical bytes either way.
+  await fsp.mkdir(path.dirname(dest), { recursive: true });
+  const tmp = `${dest}.tmp${process.pid}`;
+  try {
+    await fsp.writeFile(tmp, Buffer.concat(chunks));
+    await fsp.rename(tmp, dest);
+  } catch (e) {
+    await fsp.rm(tmp, { force: true }).catch(() => {});
+    throw e;
+  }
+  return Response.json({ sha256: assetSha, status: "stored" }, { status: 201 });
+}

--- a/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
@@ -31,7 +31,9 @@ export async function PUT(
   request: NextRequest,
   ctx: { params: Promise<{ sha256: string; assetSha: string }> }
 ) {
-  if (!rateLimit(`assets-put:${clientKey(request)}`, 240, 60_000)) {
+  // Generous: a bulk desktop upload is many sequential chunk PUTs (a 4096-asset
+  // build is legitimate), and the clients treat 429 as a hard failure.
+  if (!rateLimit(`assets-put:${clientKey(request)}`, 1200, 60_000)) {
     return Response.json({ error: "rate limit exceeded" }, { status: 429 });
   }
   const { sha256, assetSha } = await ctx.params;

--- a/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
-import { assetBlobPath } from "@/lib/assets";
+import { assetBlobPath, assetStagingPath } from "@/lib/assets";
 import { referencedAssets, MAX_BUILD_ASSET_BYTES } from "@/lib/submission-assets";
 import { rateLimit, clientKey } from "@/lib/ratelimit";
 import { isSha256 } from "@/lib/validate";
@@ -12,11 +12,21 @@ import { isSha256 } from "@/lib/validate";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// PUT /api/submissions/<sha256>/assets/<assetSha> — upload one asset blob (raw
-// body). Accepted only when <assetSha> is referenced by the submission's (or
-// an ingested build's) record, the size matches the record's claim, and the
-// body actually hashes to <assetSha> — the content address is the authority;
-// nothing else about the request is trusted. Idempotent by construction.
+// PUT /api/submissions/<sha256>/assets/<assetSha>[?offset=N] — upload one asset
+// blob, in one shot or chunked (raw body). Accepted only when <assetSha> is
+// referenced by the submission's (or an ingested build's) record; nothing else
+// about the request is trusted — the content address is the authority.
+//
+// Chunk protocol: each request appends at `offset` (default 0; 0 restarts) to
+// a staging file. A wrong offset answers 409 with the staged size so the
+// client can resume; a short append answers 202 with the new offset. When the
+// staged size reaches the record's claimed size the file must hash to
+// <assetSha> — then it lands in the store (201) — or staging is dropped (422).
+// The final hash makes interleaved/duplicate chunk writes harmless: they can
+// only cost a retry, never store wrong bytes. Idempotent by construction.
+//
+// Staging abandoned by a crashed client is bounded (referenced assets only)
+// and reclaimed the next time that blob's upload restarts at offset 0.
 export async function PUT(
   request: NextRequest,
   ctx: { params: Promise<{ sha256: string; assetSha: string }> }
@@ -42,41 +52,72 @@ export async function PUT(
   const dest = assetBlobPath(assetSha);
   if (fs.existsSync(dest)) return Response.json({ sha256: assetSha, status: "exists" });
 
-  // Stream with a running cap so an oversized/lying body dies early instead of
-  // buffering; the record's claimed size is the per-blob budget.
+  const rawOffset = new URL(request.url).searchParams.get("offset") ?? "0";
+  const offset = Number(rawOffset);
+  if (!Number.isInteger(offset) || offset < 0 || offset > claimed) {
+    return Response.json({ error: "invalid offset" }, { status: 400 });
+  }
   if (!request.body) return Response.json({ error: "missing body" }, { status: 400 });
-  const hash = createHash("sha256");
-  const chunks: Uint8Array[] = [];
-  let received = 0;
-  const reader = request.body.getReader();
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    received += value.byteLength;
-    if (received > claimed) {
-      reader.cancel().catch(() => {});
-      return Response.json({ error: "body exceeds the record's claimed size" }, { status: 413 });
+
+  // A non-zero offset must continue exactly where the staging file ends.
+  const part = assetStagingPath(assetSha);
+  if (offset !== 0) {
+    let staged = 0;
+    try {
+      staged = (await fsp.stat(part)).size;
+    } catch {}
+    if (offset !== staged) {
+      return Response.json({ error: "offset mismatch", offset: staged }, { status: 409 });
     }
-    hash.update(value);
-    chunks.push(value);
-  }
-  if (received !== claimed) {
-    return Response.json({ error: "body size does not match the record's claim" }, { status: 422 });
-  }
-  if (hash.digest("hex") !== assetSha) {
-    return Response.json({ error: "body does not hash to the asset sha256" }, { status: 422 });
   }
 
-  // Atomic write (tmp + rename), same as the bundle ingest path — a concurrent
-  // upload of the same blob resolves to identical bytes either way.
-  await fsp.mkdir(path.dirname(dest), { recursive: true });
-  const tmp = `${dest}.tmp${process.pid}`;
+  // Append the chunk as it streams in, dying early past the claimed size.
+  await fsp.mkdir(path.dirname(part), { recursive: true });
+  const fh = await fsp.open(part, offset === 0 ? "w" : "a");
+  let received = 0;
+  let overrun = false;
+  const reader = request.body.getReader();
   try {
-    await fsp.writeFile(tmp, Buffer.concat(chunks));
-    await fsp.rename(tmp, dest);
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (offset + received > claimed) {
+        overrun = true;
+        reader.cancel().catch(() => {});
+        break;
+      }
+      await fh.write(value);
+    }
+  } finally {
+    await fh.close();
+  }
+  if (overrun) {
+    await fsp.rm(part, { force: true }).catch(() => {});
+    return Response.json({ error: "body exceeds the record's claimed size" }, { status: 413 });
+  }
+
+  const size = offset + received;
+  if (size < claimed) {
+    return Response.json({ sha256: assetSha, status: "partial", offset: size }, { status: 202 });
+  }
+
+  // Complete: the staged bytes must hash to the content address.
+  const hash = createHash("sha256");
+  for await (const chunk of fs.createReadStream(part)) hash.update(chunk as Buffer);
+  if (hash.digest("hex") !== assetSha) {
+    await fsp.rm(part, { force: true }).catch(() => {});
+    return Response.json({ error: "staged bytes do not hash to the asset sha256" }, { status: 422 });
+  }
+
+  await fsp.mkdir(path.dirname(dest), { recursive: true });
+  try {
+    await fsp.rename(part, dest);
   } catch (e) {
-    await fsp.rm(tmp, { force: true }).catch(() => {});
-    throw e;
+    // A concurrent upload of the same blob may have finalized first — same bytes.
+    if (!fs.existsSync(dest)) throw e;
+    await fsp.rm(part, { force: true }).catch(() => {});
+    return Response.json({ sha256: assetSha, status: "exists" });
   }
   return Response.json({ sha256: assetSha, status: "stored" }, { status: 201 });
 }

--- a/web/src/app/api/submissions/[sha256]/assets/route.ts
+++ b/web/src/app/api/submissions/[sha256]/assets/route.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import type { NextRequest } from "next/server";
+import { getPool } from "@/lib/db";
+import { assetBlobPath } from "@/lib/assets";
+import { referencedAssets } from "@/lib/submission-assets";
+import { rateLimit, clientKey } from "@/lib/ratelimit";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// GET /api/submissions/<sha256>/assets — which of the build's referenced asset
+// blobs are absent from the store. Desktop apps call this after submitting a
+// record, then PUT only the missing blobs.
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  if (!rateLimit(`assets-check:${clientKey(request)}`, 60, 60_000)) {
+    return Response.json({ error: "rate limit exceeded" }, { status: 429 });
+  }
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const refs = await referencedAssets(getPool(), sha256);
+  if (!refs) return Response.json({ error: "not found" }, { status: 404 });
+
+  const missing = [...refs.sizes.keys()].filter((sha) => !fs.existsSync(assetBlobPath(sha)));
+  return Response.json({ sha256, referenced: refs.sizes.size, missing });
+}

--- a/web/src/lib/assets.ts
+++ b/web/src/lib/assets.ts
@@ -16,6 +16,12 @@ export function assetBlobPath(sha256: string): string {
   return path.join(assetStoreDir(), sha256.slice(0, 2), sha256);
 }
 
+/** Staging file for a blob's chunked upload (`.staging` can't collide with the
+ *  two-hex-char blob dirs). Caller must have validated `sha256`. */
+export function assetStagingPath(sha256: string): string {
+  return path.join(assetStoreDir(), ".staging", `${sha256}.part`);
+}
+
 /** Display order for asset kinds on the build pages. */
 export const ASSET_KIND_ORDER = ["image", "audio", "video", "text"] as const;
 

--- a/web/src/lib/submission-assets.ts
+++ b/web/src/lib/submission-assets.ts
@@ -1,0 +1,51 @@
+// Which asset blobs a submitted build is allowed to upload: the upload
+// endpoints only accept bytes whose sha256 is referenced by a known record
+// (submission or library build), so the store can't be used as a free blob host.
+
+import type { Pool } from "pg";
+import type { AssetRef, BuildRecord } from "./types";
+import { isSha256 } from "./validate";
+
+/** Per-blob hard cap — mirrors MAX_ASSET_SIZE in the adapter's viewable.py. */
+export const MAX_ASSET_BLOB_BYTES = 20 * 1024 * 1024;
+
+/** Cap on one build's summed (claimed) asset bytes; uploads past it refuse. */
+export const MAX_BUILD_ASSET_BYTES = 4 * 1024 * 1024 * 1024;
+
+export interface ReferencedAssets {
+  /** Deduplicated asset sha256 → claimed size, uploads must match exactly. */
+  sizes: Map<string, number>;
+  /** Sum of claimed sizes; compare against MAX_BUILD_ASSET_BYTES. */
+  totalBytes: number;
+}
+
+function collect(assets: AssetRef[] | null | undefined): ReferencedAssets {
+  const sizes = new Map<string, number>();
+  let totalBytes = 0;
+  for (const a of assets ?? []) {
+    if (!isSha256(a.sha256) || sizes.has(a.sha256)) continue;
+    const size = Number(a.size);
+    if (!Number.isInteger(size) || size <= 0 || size > MAX_ASSET_BLOB_BYTES) continue;
+    sizes.set(a.sha256, size);
+    totalBytes += size;
+  }
+  return { sizes, totalBytes };
+}
+
+/** The asset refs of a pending/accepted submission, else of a library build,
+ *  else null (unknown sha or rejected submission). */
+export async function referencedAssets(pool: Pool, buildSha256: string): Promise<ReferencedAssets | null> {
+  const sub = await pool.query<{ record: BuildRecord; status: string }>(
+    "SELECT record, status FROM submission_queue WHERE sha256=$1",
+    [buildSha256]
+  );
+  if (sub.rowCount && sub.rows[0].status !== "rejected") {
+    return collect(sub.rows[0].record.assets);
+  }
+  const build = await pool.query<{ record: BuildRecord }>(
+    "SELECT record FROM builds WHERE sha256=$1",
+    [buildSha256]
+  );
+  if (build.rowCount) return collect(build.rows[0].record.assets);
+  return null;
+}

--- a/web/tests/lib.test.ts
+++ b/web/tests/lib.test.ts
@@ -191,3 +191,47 @@ test("orderAssets accepts a per-kind cap map (missing kind = uncapped)", () => {
   for (const a of ordered) counts[a.kind] = (counts[a.kind] ?? 0) + 1;
   assert.deepEqual(counts, { image: 30, audio: 20, text: 12 });
 });
+
+// --- submission asset uploads ---------------------------------------------------
+
+import { referencedAssets, MAX_ASSET_BLOB_BYTES } from "../src/lib/submission-assets";
+import type { Pool } from "pg";
+
+function fakePool(subRow?: { record: BuildRecord; status: string }, buildRow?: { record: BuildRecord }) {
+  return {
+    query: async (sql: string) => {
+      if (sql.includes("submission_queue")) return { rowCount: subRow ? 1 : 0, rows: subRow ? [subRow] : [] };
+      if (sql.includes("FROM builds")) return { rowCount: buildRow ? 1 : 0, rows: buildRow ? [buildRow] : [] };
+      throw new Error(`unexpected query: ${sql}`);
+    },
+  } as unknown as Pool;
+}
+
+test("referencedAssets dedupes shared blobs and drops malformed refs", async () => {
+  const sha = "ef".repeat(32);
+  const assets: AssetRef[] = [
+    { path: "/A.PNG", sha256: sha, size: 10, mime: "image/png", kind: "image" },
+    { path: "/COPY.PNG", sha256: sha, size: 10, mime: "image/png", kind: "image" }, // dup blob
+    { path: "/B.PNG", sha256: "not-hex", size: 10, mime: "image/png", kind: "image" },
+    { path: "/C.PNG", sha256: "aa".repeat(32), size: 0, mime: "image/png", kind: "image" },
+    { path: "/D.PNG", sha256: "bb".repeat(32), size: MAX_ASSET_BLOB_BYTES + 1, mime: "image/png", kind: "image" },
+  ];
+  const refs = await referencedAssets(fakePool({ record: minimalRecord(assets), status: "queued" }), "ab".repeat(32));
+  assert.ok(refs);
+  assert.deepEqual([...refs.sizes.entries()], [[sha, 10]]);
+  assert.equal(refs.totalBytes, 10);
+});
+
+test("referencedAssets falls back from rejected submission to the library build", async () => {
+  const subAsset: AssetRef = { path: "/S", sha256: "cc".repeat(32), size: 1, mime: "text/plain", kind: "text" };
+  const libAsset: AssetRef = { path: "/L", sha256: "dd".repeat(32), size: 2, mime: "text/plain", kind: "text" };
+  const pool = fakePool(
+    { record: minimalRecord([subAsset]), status: "rejected" },
+    { record: minimalRecord([libAsset]) }
+  );
+  const refs = await referencedAssets(pool, "ab".repeat(32));
+  assert.ok(refs);
+  assert.deepEqual([...refs.sizes.keys()], ["dd".repeat(32)]);
+  // Unknown everywhere -> null.
+  assert.equal(await referencedAssets(fakePool(), "ab".repeat(32)), null);
+});


### PR DESCRIPTION
Brings the web asset viewer to both desktop apps and lets them ship the blobs when submitting a build.

## Web
- `GET /api/submissions/<sha256>/assets` — which of the build's referenced asset blobs the store lacks.
- `PUT /api/submissions/<sha256>/assets/<assetSha>[?offset=N]` — upload one blob, one-shot or in resumable chunks. Each request appends at `offset` (0 restarts) to a staging file; a wrong offset answers 409 with the staged size so clients resume, a short append answers 202 with the next offset, and when the staged size reaches the record's claim the bytes must hash to `<assetSha>` before landing in the store (else 422 and staging drops). Accepted only when the sha is referenced by the submission's (or an ingested build's) record; 20MB/blob and 4GB/build caps; idempotent, and the final hash check makes interleaved/duplicate chunks harmless.

## Core / FFI
- `Analyzer::asset_blob_path` / `Reader::asset_blob_path` (+ `Reader::assets_dir`) resolve store blobs with hex validation.
- UniFFI `AnalysisSummary` gains a typed `assets` list with per-asset local `blob_path`; Swift bindings regenerated.

## macOS
- New Assets tab: image thumbnail grid, audio/video/text rows, context menus.
- Submit checks the server's missing list and uploads only those blobs in 4MB chunks (resuming from the server's offset on 409), with progress in the status area.
- Text assets preview in-app only; media opens via a named temp copy so Launch Services picks the right handler.

## Windows
- View > Assets: kind-grouped rows in the existing ListView; double-click opens the asset (temp copy + ShellExecuteW).
- Submit uploads missing blobs with the same 4MB-chunk/resume protocol through a generalized WinHTTP helper.
- Text assets are forced into notepad.exe — the shell's default verb for .bat/.cmd/.js would execute them.

## Verification
- Route handlers exercised end-to-end against a real Postgres + blob store: missing list, chunked store with mid-stream 409 resume, finalize hash rejection clearing staging, one-shot path, oversize rejection, idempotent re-upload.
- Headless FFI probe round-trips assets with resolved blob paths from the real library; probe also fixes a pre-existing crash on malformed loadBuild keys.
- `cargo test --workspace`, windows-gnu cross-check, `swift build`, web unit tests and production build all pass.

Deploy note: with 4MB chunks a fronting proxy needs `client_max_body_size` >= 4MB (nothing needed when the app serves directly).