### PR TITLE
Lot grouping and build rename

### DIFF
--- a/web/db/migrations/003-lot.sql
+++ b/web/db/migrations/003-lot.sql
@@ -1,0 +1,9 @@
+-- Moderator-assigned lot: builds sharing a lot name (e.g. "Sonic Month 2026")
+-- are displayed together — cross-linked on each build page and filterable on
+-- /builds?lot=… . Assigned via PATCH /api/build/<sha256> (moderation token).
+-- Re-ingest never touches it (the builds upsert only refreshes record/build_date).
+-- Idempotent — safe to re-run. Apply to every curator DB:
+--   psql -d <db> -f db/migrations/003-lot.sql
+
+ALTER TABLE builds ADD COLUMN IF NOT EXISTS lot TEXT;
+CREATE INDEX IF NOT EXISTS idx_builds_lot ON builds(lot) WHERE lot IS NOT NULL;

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -34,7 +34,8 @@ CREATE TABLE builds (
     fingerprint_profile   TEXT NOT NULL,
     record                JSONB NOT NULL,           -- full canonical record
     ingested_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
-    build_date            TEXT                      -- volume creation date, else header release date (sortable copy)
+    build_date            TEXT,                     -- volume creation date, else header release date (sortable copy)
+    lot                   TEXT                      -- moderator-assigned display group, e.g. "Sonic Month 2026"
 );
 CREATE INDEX idx_builds_content      ON builds(content_hash);
 CREATE INDEX idx_builds_filtered     ON builds(filtered_content_hash);
@@ -43,6 +44,7 @@ CREATE INDEX idx_builds_name_lower   ON builds (lower(name));
 CREATE INDEX idx_builds_name_trgm    ON builds USING gin (name gin_trgm_ops);
 CREATE INDEX idx_builds_textdoc_fts  ON builds USING gin (to_tsvector('simple', text_doc));
 CREATE INDEX idx_builds_embedding    ON builds USING hnsw (text_embedding vector_cosine_ops);
+CREATE INDEX idx_builds_lot          ON builds(lot) WHERE lot IS NOT NULL;
 
 -- ── files (per-build) — filename FTS/fuzzy + exact hash lookup ────────────────
 CREATE TABLE files (

--- a/web/src/app/api/build/[sha256]/route.ts
+++ b/web/src/app/api/build/[sha256]/route.ts
@@ -1,8 +1,14 @@
 import type { NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
-import { getBuild, findSimilar, findByEmbeddingOf } from "@/lib/queries";
+import { getBuild, findSimilar, findByEmbeddingOf, getLotBuilds, updateBuildMeta } from "@/lib/queries";
+import { isModerator, moderationToken } from "@/lib/auth";
+import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
+
+const MAX_NAME_LEN = 300;
+const MAX_LOT_LEN = 200;
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -26,4 +32,73 @@ export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256
   const text_neighbors = await findByEmbeddingOf(pool, sha256);
 
   return Response.json({ build, similar: { ...similar, text_neighbors } });
+}
+
+// PATCH /api/build/<sha256> { name?, lot? } — moderator metadata edit.
+// `name` renames the build; `lot` assigns it to a display group ("" or null clears).
+export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  if (!isModerator(request)) {
+    return moderationToken()
+      ? Response.json({ error: "unauthorized" }, { status: 401 })
+      : Response.json({ error: "moderation disabled (set MODERATION_TOKEN)" }, { status: 403 });
+  }
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const fields: { name?: string; lot?: string | null } = {};
+  if (body.name !== undefined) {
+    if (typeof body.name !== "string" || !body.name.trim()) {
+      return Response.json({ error: "name must be a non-empty string" }, { status: 400 });
+    }
+    if (body.name.length > MAX_NAME_LEN) {
+      return Response.json({ error: `name exceeds ${MAX_NAME_LEN} characters` }, { status: 400 });
+    }
+    fields.name = body.name.trim();
+  }
+  if (body.lot !== undefined) {
+    if (body.lot !== null && typeof body.lot !== "string") {
+      return Response.json({ error: "lot must be a string or null" }, { status: 400 });
+    }
+    if (typeof body.lot === "string" && body.lot.length > MAX_LOT_LEN) {
+      return Response.json({ error: `lot exceeds ${MAX_LOT_LEN} characters` }, { status: 400 });
+    }
+    fields.lot = (body.lot ?? "").trim() || null;
+  }
+  if (fields.name === undefined && fields.lot === undefined) {
+    return Response.json({ error: "nothing to update (name and/or lot required)" }, { status: 400 });
+  }
+
+  const pool = getPool();
+  const prev = await updateBuildMeta(pool, sha256, fields);
+  if (!prev) return Response.json({ error: "not found" }, { status: 404 });
+
+  // Build pages are ISR-cached (revalidate = 3600); surface the edit now. A
+  // rename changes the canonical slug path, so refresh the old one (it now
+  // serves a redirect) and the new one, plus their assets subpages and the
+  // bare-sha redirect. A lot change also alters the lot section on every
+  // sibling page, in the lot the build joined and the one it left.
+  revalidatePath("/builds");
+  const touched = new Set([
+    buildHref(sha256, prev.name),
+    buildHref(sha256, fields.name ?? prev.name),
+    `/builds/${sha256}`,
+  ]);
+  if (fields.lot !== undefined && fields.lot !== prev.lot) {
+    const lots = [fields.lot, prev.lot].filter((l): l is string => l != null);
+    for (const lot of lots) {
+      for (const b of await getLotBuilds(pool, lot)) touched.add(buildHref(b.sha256, b.name));
+    }
+  }
+  for (const path of touched) {
+    revalidatePath(path);
+    revalidatePath(`${path}/assets`);
+  }
+  return Response.json({ sha256, name: fields.name ?? prev.name, lot: fields.lot !== undefined ? fields.lot : prev.lot });
 }

--- a/web/src/app/builds/BuildsBrowser.tsx
+++ b/web/src/app/builds/BuildsBrowser.tsx
@@ -33,13 +33,14 @@ interface Props {
   perPage: number;
   q: string;
   system: string;
+  lot: string;
   sort: BuildSortKey;
   dir: "asc" | "desc";
 }
 
 // Thin URL-driven control: every filter/sort/page change updates the search
 // params and the server re-queries — the client only ever holds one page.
-export default function BuildsBrowser({ rows, total, systems, page, perPage, q, system, sort, dir }: Props) {
+export default function BuildsBrowser({ rows, total, systems, page, perPage, q, system, lot, sort, dir }: Props) {
   const router = useRouter();
   const pathname = usePathname();
   const [isPending, startTransition] = useTransition();
@@ -47,13 +48,14 @@ export default function BuildsBrowser({ rows, total, systems, page, perPage, q, 
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const navigate = (
-    next: Partial<{ q: string; system: string; sort: BuildSortKey; dir: "asc" | "desc"; page: number }>,
+    next: Partial<{ q: string; system: string; lot: string; sort: BuildSortKey; dir: "asc" | "desc"; page: number }>,
     replace = false
   ) => {
-    const state = { q, system, sort, dir, page, ...next };
+    const state = { q, system, lot, sort, dir, page, ...next };
     const params = new URLSearchParams();
     if (state.q) params.set("q", state.q);
     if (state.system) params.set("system", state.system);
+    if (state.lot) params.set("lot", state.lot);
     if (state.sort !== "name") params.set("sort", state.sort);
     if (state.dir !== "asc") params.set("dir", state.dir);
     if (state.page > 1) params.set("page", String(state.page));
@@ -101,6 +103,15 @@ export default function BuildsBrowser({ rows, total, systems, page, perPage, q, 
             </option>
           ))}
         </select>
+        {lot && (
+          <button
+            onClick={() => navigate({ lot: "", page: 1 })}
+            title="Clear lot filter"
+            className="rounded bg-amber-100 px-2 py-1 text-xs font-medium text-amber-900 hover:opacity-80 dark:bg-amber-900/40 dark:text-amber-200"
+          >
+            lot: {lot} ✕
+          </button>
+        )}
         <span className="text-xs text-neutral-400">
           {total} match{total === 1 ? "" : "es"}
         </span>
@@ -126,7 +137,14 @@ export default function BuildsBrowser({ rows, total, systems, page, perPage, q, 
               return (
               <tr key={b.sha256} className="hover:bg-neutral-50 dark:hover:bg-neutral-900/40">
                 <td className="h-full p-0 font-medium first:[&>a]:pl-0">
-                  <RowLink href={href} focusable className="px-3 hover:underline">{b.name}</RowLink>
+                  <RowLink href={href} focusable className="px-3 hover:underline">
+                    {b.name}
+                    {b.lot && (
+                      <span className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-xs font-normal text-amber-900 dark:bg-amber-900/40 dark:text-amber-200">
+                        {b.lot}
+                      </span>
+                    )}
+                  </RowLink>
                 </td>
                 <td className="h-full p-0">
                   <RowLink href={href} className="px-3 font-mono text-xs text-neutral-400">{b.sha256.slice(0, 16)}…</RowLink>

--- a/web/src/app/builds/[buildId]/ModeratorTools.tsx
+++ b/web/src/app/builds/[buildId]/ModeratorTools.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState, useSyncExternalStore } from "react";
+import { useRouter } from "next/navigation";
+
+// The token never changes while the page is mounted (it's set on /moderate),
+// so there is nothing to subscribe to — the store only bridges the SSR/client
+// gap: the server snapshot renders nothing, hydration reveals the saved token.
+const noSubscribe = () => () => {};
+const clientToken = () => sessionStorage.getItem("curator-mod-token") ?? "";
+const serverToken = () => "";
+
+interface Props {
+  sha256: string;
+  name: string;
+  lot: string | null;
+  /** Existing lot names, offered as suggestions when assigning. */
+  lots: string[];
+}
+
+// Rename + lot assignment, shown only when a moderation token is saved (the
+// /moderate page keeps it in sessionStorage). Purely cosmetic gating — the
+// PATCH route re-checks the token server-side. The parent keys this component
+// on name+lot, so a router.refresh() after a save remounts it with fresh values.
+export default function ModeratorTools({ sha256, name, lot, lots }: Props) {
+  const router = useRouter();
+  const token = useSyncExternalStore(noSubscribe, clientToken, serverToken);
+  const [nameInput, setNameInput] = useState(name);
+  const [lotInput, setLotInput] = useState(lot ?? "");
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState("");
+
+  if (!token) return null;
+
+  async function save(patch: { name?: string; lot?: string | null }) {
+    setBusy(true);
+    setNote("");
+    try {
+      const res = await fetch(`/api/build/${sha256}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", "x-moderation-token": token },
+        body: JSON.stringify(patch),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setNote(`Error: ${data.error}`);
+        return;
+      }
+      setNote("Saved.");
+      router.refresh();
+    } catch (e) {
+      setNote(`Failed: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const nameDirty = nameInput.trim() !== "" && nameInput.trim() !== name;
+  const lotDirty = (lotInput.trim() || null) !== lot;
+
+  return (
+    <section className="mt-6 rounded-md border border-dashed border-neutral-300 px-4 py-3 dark:border-neutral-700">
+      <h2 className="text-xs font-semibold uppercase tracking-wide text-neutral-400">Moderator</h2>
+      <div className="mt-2 flex flex-wrap items-end gap-x-8 gap-y-3 text-sm">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-neutral-500">Name</span>
+          <div className="flex gap-2">
+            <input
+              value={nameInput}
+              onChange={(e) => setNameInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && nameDirty && !busy && save({ name: nameInput.trim() })}
+              className="h-9 w-96 max-w-full rounded-md border border-neutral-300 bg-transparent px-3 outline-none focus:border-neutral-500 dark:border-neutral-700"
+            />
+            <button
+              onClick={() => save({ name: nameInput.trim() })}
+              disabled={busy || !nameDirty}
+              className="rounded-md border border-neutral-300 px-3 py-1 font-medium hover:border-neutral-500 disabled:opacity-40 disabled:hover:border-neutral-300 dark:border-neutral-700"
+            >
+              Rename
+            </button>
+          </div>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-neutral-500">Lot</span>
+          <div className="flex gap-2">
+            <input
+              list="curator-lot-names"
+              value={lotInput}
+              onChange={(e) => setLotInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && lotDirty && !busy && save({ lot: lotInput.trim() || null })}
+              placeholder="e.g. Sonic Month 2026"
+              className="h-9 w-72 max-w-full rounded-md border border-neutral-300 bg-transparent px-3 outline-none placeholder:text-neutral-400 focus:border-neutral-500 dark:border-neutral-700"
+            />
+            <datalist id="curator-lot-names">
+              {lots.map((l) => (
+                <option key={l} value={l} />
+              ))}
+            </datalist>
+            <button
+              onClick={() => save({ lot: lotInput.trim() || null })}
+              disabled={busy || !lotDirty}
+              className="rounded-md border border-neutral-300 px-3 py-1 font-medium hover:border-neutral-500 disabled:opacity-40 disabled:hover:border-neutral-300 dark:border-neutral-700"
+            >
+              {lotInput.trim() ? "Set lot" : "Clear lot"}
+            </button>
+          </div>
+        </label>
+      </div>
+      {note && <p className="mt-2 text-xs text-neutral-500">{note}</p>}
+    </section>
+  );
+}

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -5,15 +5,16 @@ import { notFound, permanentRedirect } from "next/navigation";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
 import { buildTree, initialExpanded, pruneToExpanded, treeCounts } from "@/lib/filetree";
-import { getBuild, getBuildAssets, getBuildMeta, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, resolveBuild } from "@/lib/queries";
+import { getBuild, getBuildAssets, getBuildMeta, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, getLotBuilds, listLots, resolveBuild } from "@/lib/queries";
 import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
 import { buildDescription, displayTitle } from "@/lib/meta";
-import { canonicalBuildId, parseBuildParam } from "@/lib/slug";
+import { buildHref, canonicalBuildId, parseBuildParam } from "@/lib/slug";
 import type { BuildRecord } from "@/lib/types";
 import SimilarBuilds from "./SimilarBuilds";
 import FileTree from "./FileTree";
 import AssetGallery from "./AssetGallery";
 import AssetViewerHost from "./AssetViewerHost";
+import ModeratorTools from "./ModeratorTools";
 
 // The assets section previews at most this many items per kind; the rest live
 // on /builds/<id>/assets.
@@ -137,11 +138,14 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
   const q = deriveQueryFeatures(build.record);
   // Pull a wide candidate set per tier so the fused top-50 is well-populated.
   // Text neighbors use this build's already-stored embedding — no re-embedding per load.
-  const [similar, textNeighbors, assets] = await Promise.all([
+  const [similar, textNeighbors, assets, lotBuilds, lots] = await Promise.all([
     findSimilar(pool, q, 100),
     findByEmbeddingOf(pool, sha256, 100),
     getBuildAssets(pool, sha256),
+    build.lot ? getLotBuilds(pool, build.lot) : Promise.resolve([]),
+    listLots(pool),
   ]);
+  const lotMates = lotBuilds.filter((b) => b.sha256 !== sha256);
   const fused = fuseSimilar(similar, textNeighbors);
 
   // A tier only counts when both builds have its data — attach each build's capabilities
@@ -161,6 +165,7 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
   const counts = treeCounts(tree);
   const meta = metaSections(build.record);
   const filteredContentHash = build.record.composites?.filtered_content_hash;
+  const discTitle = build.record.info?.title as string | undefined;
 
   return (
     <main className="mx-auto max-w-none px-4 py-10 sm:px-8">
@@ -169,15 +174,26 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
       <AssetViewerHost assets={assets} buildHref={href} returnHref={href}>
       <Link href="/builds" className="text-sm text-neutral-500 hover:underline">&larr; All builds</Link>
 
-      <h1 className="mt-3 text-2xl font-semibold tracking-tight">
-        {build.record.info?.title as string | undefined ?? build.name}
-      </h1>
+      {/* The name column is the display identity everywhere (lists, search, rename);
+          the disc's own title stays visible as a subtitle when it differs. */}
+      <h1 className="mt-3 text-2xl font-semibold tracking-tight">{build.name}</h1>
+      {discTitle && discTitle !== build.name && (
+        <p className="mt-1 text-sm text-neutral-500">{discTitle}</p>
+      )}
       <div className="mt-2 flex flex-wrap gap-2 text-xs">
         <Chip>{build.system || "unknown"}</Chip>
         <Chip>{build.file_count} files</Chip>
         <Chip>{humanSize(build.total_size)}</Chip>
         <Chip>profile {build.fingerprint_profile}</Chip>
         {assets.length > 0 && <Chip>{assets.length} assets</Chip>}
+        {build.lot && (
+          <Link
+            href={`/builds?lot=${encodeURIComponent(build.lot)}`}
+            className="rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-900 hover:underline dark:bg-amber-900/40 dark:text-amber-200"
+          >
+            {build.lot}
+          </Link>
+        )}
       </div>
 
       <dl className="mt-4 grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-sm">
@@ -189,6 +205,35 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
           <Hash label="Filtered content hash" value={filteredContentHash} />
         )}
       </dl>
+
+      <ModeratorTools
+        key={`${build.name}\0${build.lot ?? ""}`}
+        sha256={build.sha256}
+        name={build.name}
+        lot={build.lot}
+        lots={lots}
+      />
+
+      {build.lot && lotMates.length > 0 && (
+        <section className="mt-8">
+          <h2 className="text-lg font-medium">
+            Lot: {build.lot}{" "}
+            <span className="text-sm font-normal text-neutral-400">({lotMates.length + 1} builds)</span>
+          </h2>
+          <ul className="mt-3 divide-y divide-neutral-100 dark:divide-neutral-900/60">
+            {lotMates.map((b) => (
+              <li key={b.sha256} className="flex items-center gap-3 py-2 text-sm">
+                <Link href={buildHref(b.sha256, b.name)} className="min-w-0 truncate font-medium hover:underline">
+                  {b.name}
+                </Link>
+                <Chip>{b.system || "unknown"}</Chip>
+                <span className="text-xs text-neutral-500">{b.file_count} files</span>
+                <span className="text-xs text-neutral-500">{humanSize(b.total_size)}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       {meta.length > 0 && (
         <section className="mt-8">

--- a/web/src/app/builds/page.tsx
+++ b/web/src/app/builds/page.tsx
@@ -26,6 +26,7 @@ export default async function BuildsPage({
   const str = (v: string | string[] | undefined) => (typeof v === "string" ? v : "");
   const q = str(sp.q);
   const system = str(sp.system);
+  const lot = str(sp.lot);
   const sort = (SORT_KEYS as string[]).includes(str(sp.sort)) ? (str(sp.sort) as BuildSortKey) : "name";
   const dir = str(sp.dir) === "desc" ? "desc" : "asc";
   const page = Math.max(parseInt(str(sp.page), 10) || 1, 1);
@@ -33,6 +34,7 @@ export default async function BuildsPage({
   const { rows, total, systems } = await listBuildsPage(getPool(), {
     q,
     system,
+    lot,
     sort,
     dir,
     offset: (page - 1) * PER_PAGE,
@@ -55,6 +57,7 @@ export default async function BuildsPage({
         perPage={PER_PAGE}
         q={q}
         system={system}
+        lot={lot}
         sort={sort}
         dir={dir}
       />

--- a/web/src/app/moderate/page.tsx
+++ b/web/src/app/moderate/page.tsx
@@ -85,6 +85,7 @@ export default function Moderate() {
       </div>
       <p className="mt-1 text-sm text-neutral-500">
         Review contributor submissions. Accepting ingests the build into the library.
+        While a token is saved here, build pages also show moderator tools (rename, lot).
       </p>
 
       <input

--- a/web/src/lib/meta.ts
+++ b/web/src/lib/meta.ts
@@ -14,9 +14,9 @@ export function humanSize(bytes?: number | null): string {
   return i === 0 ? `${bytes} B` : `${v.toFixed(1)} ${units[i]}`;
 }
 
-/** The heading users see: the extractor's title when present, else the dump name. */
+/** The heading users see: the curated build name (renameable by moderators). */
 export function displayTitle(m: BuildMetaRow): string {
-  return m.title || m.name;
+  return m.name;
 }
 
 /** "system · date" and "N files · SIZE" facts, used as chips on the OG card. */

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -442,6 +442,8 @@ export interface BuildRow {
   fingerprint_profile: string;
   ingested_at: string;
   record: BuildRecord;
+  /** Moderator-assigned display group, e.g. "Sonic Month 2026". */
+  lot: string | null;
 }
 
 export interface BuildListItem {
@@ -453,6 +455,8 @@ export interface BuildListItem {
   ingested_at: string;
   /** Disc mastering date — volume creation, else the header release date. */
   build_date: string | null;
+  /** Moderator-assigned display group, e.g. "Sonic Month 2026". */
+  lot: string | null;
 }
 
 export type BuildSortKey = "name" | "system" | "build_date" | "file_count" | "total_size";
@@ -460,6 +464,7 @@ export type BuildSortKey = "name" | "system" | "build_date" | "file_count" | "to
 export interface BuildsPageOpts {
   q?: string;
   system?: string;
+  lot?: string;
   sort?: BuildSortKey;
   dir?: "asc" | "desc";
   offset?: number;
@@ -499,6 +504,10 @@ export async function listBuildsPage(pool: Pool, opts: BuildsPageOpts = {}): Pro
     params.push(opts.system);
     conds.push(`system = $${params.length}`);
   }
+  if (opts.lot) {
+    params.push(opts.lot);
+    conds.push(`lot = $${params.length}`);
+  }
   const where = conds.length ? `WHERE ${conds.join(" AND ")}` : "";
 
   const key = opts.sort && BUILD_SORT[opts.sort] ? opts.sort : "name";
@@ -514,7 +523,7 @@ export async function listBuildsPage(pool: Pool, opts: BuildsPageOpts = {}): Pro
 
   const [rows, count, systems] = await Promise.all([
     pool.query(
-      `SELECT sha256, name, system, file_count, total_size, ingested_at, build_date
+      `SELECT sha256, name, system, file_count, total_size, ingested_at, build_date, lot
        FROM builds ${where} ORDER BY ${order}
        LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
       [...params, limit, offset]
@@ -602,11 +611,56 @@ export async function getBuildMeta(pool: Pool, sha256: string): Promise<BuildMet
 export async function getBuild(pool: Pool, sha256: string): Promise<BuildRow | null> {
   const r = await pool.query(
     `SELECT sha256, name, system, size, md5, sha1, content_hash, file_count,
-            total_size, fingerprint_profile, ingested_at, record
+            total_size, fingerprint_profile, ingested_at, record, lot
      FROM builds WHERE sha256=$1`,
     [sha256]
   );
   return (r.rows[0] as BuildRow) ?? null;
+}
+
+/// Moderator metadata edit: rename and/or move between lots. Omitted fields are
+/// untouched; lot=null clears it. Returns the previous name/lot (so the caller
+/// can revalidate pages of the lot the build left), or null when not found.
+export async function updateBuildMeta(
+  pool: Pool,
+  sha256: string,
+  fields: { name?: string; lot?: string | null }
+): Promise<{ name: string; lot: string | null } | null> {
+  const sets: string[] = [];
+  const params: unknown[] = [sha256];
+  if (fields.name !== undefined) {
+    params.push(fields.name);
+    sets.push(`name=$${params.length}`);
+  }
+  if (fields.lot !== undefined) {
+    params.push(fields.lot);
+    sets.push(`lot=$${params.length}`);
+  }
+  if (!sets.length) throw new Error("updateBuildMeta: no fields to update");
+  const r = await pool.query(
+    `UPDATE builds b SET ${sets.join(", ")}
+     FROM (SELECT name, lot FROM builds WHERE sha256=$1) old
+     WHERE b.sha256=$1
+     RETURNING old.name, old.lot`,
+    params
+  );
+  return (r.rows[0] as { name: string; lot: string | null }) ?? null;
+}
+
+/// All builds in a lot, for the build page's lot section and revalidation.
+export async function getLotBuilds(pool: Pool, lot: string): Promise<BuildListItem[]> {
+  const r = await pool.query(
+    `SELECT sha256, name, system, file_count, total_size, ingested_at, build_date, lot
+     FROM builds WHERE lot=$1 ORDER BY lower(name)`,
+    [lot]
+  );
+  return r.rows as BuildListItem[];
+}
+
+/** Distinct lot names, for the moderator edit box's suggestions. */
+export async function listLots(pool: Pool): Promise<string[]> {
+  const r = await pool.query("SELECT DISTINCT lot FROM builds WHERE lot IS NOT NULL ORDER BY lot");
+  return r.rows.map((row) => row.lot as string);
 }
 
 export async function submissionStatus(pool: Pool, sha256: string) {


### PR DESCRIPTION
Moderator metadata edits: group builds under a lot name (e.g. "Sonic Month 2026") so they display together, and rename builds.

## Schema
- `builds.lot` column + partial index (migration `003-lot.sql`, mirrored in `schema.sql`). Re-ingest never clobbers moderator edits — the builds upsert only refreshes `record`/`build_date`.

## API
- `PATCH /api/build/<sha256>` with `{name?, lot?}`, gated by the moderation token like submissions. Empty or null lot clears it. Revalidates the edited page, `/builds`, and every sibling page in the lot joined and the lot left.

## UI
- Build page: lot chip linking to `/builds?lot=…` and a Lot section listing the other builds in the lot. The h1 now shows the `name` column (so renames actually show) with the disc title as a muted subtitle when it differs; `name` was already the display identity in list/search/sort.
- Moderator panel on build pages (rename box + lot box with existing-lot suggestions), visible only while a moderation token is saved on `/moderate`; the server re-checks the token on every PATCH.
- `/builds`: `?lot=` filter with a clearable chip, and a lot tag next to build names.

## Deploy
Run `psql -d <db> -f db/migrations/003-lot.sql` on the server DBs before deploying (already applied to the local DBs).