### PR TITLE
Default GUIs to hiddenpalace.org

### DIFF
--- a/crates/curator-gui-win/README.md
+++ b/crates/curator-gui-win/README.md
@@ -24,7 +24,7 @@ Excluded from the root workspace so non-Windows `cargo build` skips it.
   **WinHTTP**) and lists tiered neighbors in the document pane.
 - **Analysis ▸ Submit Build…** — a small modal nickname prompt, then POSTs
   `{nickname, record}` to `/api/submissions`. Web base URL from `CURATOR_WEB_URL`
-  (default `http://localhost:3001`). Both calls run on a worker thread.
+  (default `https://hiddenpalace.org`). Both calls run on a worker thread.
 
 ## Build / check
 

--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -167,7 +167,7 @@ mod app {
         node_sections: Vec<Section>,
         /// Sections for the currently selected tree node.
         selected_sections: Vec<Section>,
-        /// Web service base URL (CURATOR_WEB_URL, default http://localhost:3001).
+        /// Web service base URL (CURATOR_WEB_URL, default https://hiddenpalace.org).
         web_url: String,
         /// The "Recent" submenu and the sha256s backing its items (by position).
         recent_menu: HMENU,
@@ -558,7 +558,7 @@ mod app {
             node_sections: Vec::new(),
             selected_sections: Vec::new(),
             web_url: std::env::var("CURATOR_WEB_URL")
-                .unwrap_or_else(|_| "http://localhost:3001".to_string()),
+                .unwrap_or_else(|_| "https://hiddenpalace.org".to_string()),
             recent_menu,
             recent: Vec::new(),
             library_mode: false,

--- a/macos/README.md
+++ b/macos/README.md
@@ -28,7 +28,7 @@ producing a static lib the app links. It exposes:
 The app finds the adapter in this order: `CURATOR_ADAPTER_BIN` →
 `Curator.app/Contents/Resources/adapter/curator-adapter` (embedded) →
 `CURATOR_ADAPTER_DIR` → `../ps2exe-adapter` (dev). Similarity/submit talk to the web
-service at `CURATOR_WEB_URL` (default `http://localhost:3001`).
+service at `CURATOR_WEB_URL` (default `https://hiddenpalace.org`).
 
 ## Build & run
 

--- a/macos/Sources/CuratorApp/CuratorService.swift
+++ b/macos/Sources/CuratorApp/CuratorService.swift
@@ -77,20 +77,19 @@ struct SimilarityResponse: Decodable {
 }
 
 /// Read-only client for the Curator web service. Base URL from `CURATOR_WEB_URL`
-/// (default `http://localhost:3001`, the dev port).
+/// (default `https://hiddenpalace.org`; point it at a local dev server to test).
 struct CuratorService {
-    /// The dev default, built once without a force-unwrap.
+    /// The production default, built once without a force-unwrap.
     static let defaultBaseURL: URL = {
         var c = URLComponents()
-        c.scheme = "http"
-        c.host = "localhost"
-        c.port = 3001
+        c.scheme = "https"
+        c.host = "hiddenpalace.org"
         return c.url ?? URL(fileURLWithPath: "/")
     }()
     let baseURL: URL
 
     init() {
-        let raw = ProcessInfo.processInfo.environment["CURATOR_WEB_URL"] ?? "http://localhost:3001"
+        let raw = ProcessInfo.processInfo.environment["CURATOR_WEB_URL"] ?? "https://hiddenpalace.org"
         baseURL = URL(string: raw) ?? CuratorService.defaultBaseURL
     }
 


### PR DESCRIPTION
Both desktop apps now point at `https://hiddenpalace.org` out of the box instead of the dev default `http://localhost:3001`. `CURATOR_WEB_URL` still overrides for local development.

- macOS: `CuratorService` default base URL (env fallback + the no-force-unwrap constant).
- Windows: `web_url` default in window state; the WinHTTP helper already speaks https (`WINHTTP_FLAG_SECURE`, port 443 when unspecified) so no client changes needed.
- Both READMEs updated.

Verified: `swift build` and `cargo check --target x86_64-pc-windows-gnu` both pass.