### PR TITLE
Raise submission asset and body caps

### DIFF
--- a/web/src/lib/validate.ts
+++ b/web/src/lib/validate.ts
@@ -2,13 +2,17 @@
 
 import type { BuildRecord, Node } from "./types";
 
-export const MAX_BODY_BYTES = 8_000_000;
+// Must fit a MAX_FILES/MAX_ASSETS-sized record: each file or asset entry is a
+// few hundred bytes of JSON, so cap-sized records run tens of MB.
+export const MAX_BODY_BYTES = 64_000_000;
 
 const MAX_FILES = 200_000;
 const MAX_SIGNATURE_VALUES = 4096;
 const MAX_MEDIA = 4096;
 const MAX_AUDIO_FP = 200_000;
-const MAX_ASSETS = 4096;
+// Asset extraction spans every viewable (image/audio/text) file in a build, and
+// real dumps carry tens of thousands — this only guards against absurdity.
+const MAX_ASSETS = 100_000;
 
 /** True if `s` is a lowercase 64-hex sha256. */
 export function isSha256(s: string): boolean {


### PR DESCRIPTION
Submitting an asset-heavy build failed with "assets exceeds 4096 entries". Asset extraction spans every viewable image/audio/text file in a build, and real dumps carry tens of thousands.

- `MAX_ASSETS`: 4096 → 100,000.
- `MAX_BODY_BYTES`: 8MB → 64MB. Necessary for the asset cap to mean anything: a 90k-asset record is ~13MB of JSON before counting the contents tree, so the old body cap would have rejected it one check earlier. 64MB fits records at the `MAX_FILES`/`MAX_ASSETS` bounds.

Both gates only stop absurd inputs now; per-blob (20MB) and per-build (4GB) asset upload caps are unchanged. Verified with a 90k-asset record validating (and 100,001 rejecting); all 19 web tests pass.