### PR TITLE
Add source code asset kind

### DIFF
--- a/crates/curator-core/src/schema.rs
+++ b/crates/curator-core/src/schema.rs
@@ -52,7 +52,7 @@ pub struct AssetRef {
     pub sha256: String,
     pub size: u64,
     pub mime: String,
-    pub kind: String, // "image" | "audio" | "video" | "text"
+    pub kind: String, // "image" | "audio" | "video" | "source" | "text"
 }
 
 /// Image-level identity. `sha256` is the primary key everywhere.

--- a/crates/curator-ffi/src/lib.rs
+++ b/crates/curator-ffi/src/lib.rs
@@ -61,7 +61,7 @@ pub struct AssetInfo {
     pub sha256: String,
     pub size: u64,
     pub mime: String,
-    pub kind: String, // "image" | "audio" | "video" | "text"
+    pub kind: String, // "image" | "audio" | "video" | "source" | "text"
     /// Absolute path of the blob in the local store, when present.
     pub blob_path: Option<String>,
 }

--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -964,8 +964,13 @@ mod app {
     }
 
     /// Display order + section titles for asset kinds — mirrors the web build pages.
-    const ASSET_KINDS: [(&str, &str); 4] =
-        [("image", "Images"), ("audio", "Audio"), ("video", "Video"), ("text", "Text")];
+    const ASSET_KINDS: [(&str, &str); 5] = [
+        ("image", "Images"),
+        ("audio", "Audio"),
+        ("video", "Video"),
+        ("source", "Source code"),
+        ("text", "Text"),
+    ];
 
     /// Fill the grouped ListView with the loaded build's assets (one group per kind)
     /// and rebuild the row → asset index map used by double-click-to-open.
@@ -1849,9 +1854,9 @@ mod app {
 
     /// Open the asset at `assets[idx]`. Media kinds go to their default app via a
     /// temp copy carrying the original filename (store blobs are extensionless, so
-    /// the shell can't pick a handler for them directly). Text kinds always open
-    /// in Notepad: handing a `.bat`/`.cmd`/`.js` from an untrusted disc to the
-    /// shell's default verb would execute it.
+    /// the shell can't pick a handler for them directly). Text and source kinds
+    /// always open in Notepad: handing a `.bat`/`.cmd`/`.js` from an untrusted
+    /// disc to the shell's default verb would execute it.
     unsafe fn open_asset_at(hwnd: HWND, idx: usize) {
         ensure_reader(hwnd);
         let (asset, blob) = {
@@ -1872,7 +1877,7 @@ mod app {
             }
         };
         let path_str = path.to_string_lossy().into_owned();
-        let launched = if asset.kind == "text" {
+        let launched = if matches!(asset.kind.as_str(), "text" | "source") {
             let args = wide(&format!("\"{path_str}\""));
             ShellExecuteW(hwnd, w!("open"), w!("notepad.exe"), PCWSTR(args.as_ptr()), PCWSTR::null(), SW_SHOWNORMAL)
         } else {

--- a/macos/Sources/CuratorApp/AppModel.swift
+++ b/macos/Sources/CuratorApp/AppModel.swift
@@ -330,15 +330,15 @@ final class AppModel: ObservableObject {
 
     /// Open one extracted asset. Media kinds go to the default app via a temp
     /// copy carrying the original filename (blobs are extensionless, so the
-    /// store path alone can't pick a handler). Text kinds preview in-app only:
-    /// shell-opening a `.sh`/`.bat`/`.js` from an untrusted disc could hand it
-    /// to something that executes it.
+    /// store path alone can't pick a handler). Text and source kinds preview
+    /// in-app only: shell-opening a `.sh`/`.bat`/`.js` from an untrusted disc
+    /// could hand it to something that executes it.
     func openAsset(_ asset: AssetInfo) {
         guard let blob = asset.blobPath else {
             status = "Asset not in the local store — re-analyze the image to extract it."
             return
         }
-        if asset.kind == "text" {
+        if asset.kind == "text" || asset.kind == "source" {
             previewTextAsset(asset, blob: blob)
             return
         }

--- a/macos/Sources/CuratorApp/ContentView.swift
+++ b/macos/Sources/CuratorApp/ContentView.swift
@@ -467,15 +467,20 @@ struct DocumentView: View {
 // MARK: - Assets (browser-viewable files extracted from the build)
 
 /// Display order for asset kinds — mirrors the web build pages.
-private let assetKindOrder = ["image", "audio", "video", "text"]
+private let assetKindOrder = ["image", "audio", "video", "source", "text"]
 
 private func assetKindIcon(_ kind: String) -> String {
     switch kind {
     case "image": return "photo"
     case "audio": return "music.note"
     case "video": return "film"
+    case "source": return "chevron.left.forwardslash.chevron.right"
     default: return "doc.text"
     }
+}
+
+private func assetKindTitle(_ kind: String) -> String {
+    kind == "source" ? "Source code" : kind.capitalized
 }
 
 struct AssetsView: View {
@@ -496,13 +501,13 @@ struct AssetsView: View {
                 systemImage: "photo.on.rectangle",
                 message: summary.assets == nil
                     ? "Asset extraction hasn't run for this build yet — re-analyze the image to extract viewable files."
-                    : "This build carries no browser-viewable images, audio, video, or text."
+                    : "This build carries no browser-viewable images, audio, video, source, or text."
             )
         } else {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 12) {
                     ForEach(grouped, id: \.0) { kind, assets in
-                        Text("\(kind.capitalized) (\(assets.count))")
+                        Text("\(assetKindTitle(kind)) (\(assets.count))")
                             .font(.caption.bold()).foregroundStyle(.secondary)
                             .padding(.horizontal, 12)
                         if kind == "image" {
@@ -595,7 +600,7 @@ struct AssetMenu: View {
     let asset: AssetInfo
 
     var body: some View {
-        Button(asset.kind == "text" ? "Preview" : "Open") { model.openAsset(asset) }
+        Button(asset.kind == "text" || asset.kind == "source" ? "Preview" : "Open") { model.openAsset(asset) }
         Button("Copy SHA-256") {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(asset.sha256, forType: .string)

--- a/ps2exe-adapter/curator_adapter/viewable.py
+++ b/ps2exe-adapter/curator_adapter/viewable.py
@@ -38,15 +38,26 @@ _VIDEO = {
     "webm": "video/webm",
 }
 
-# Docs, configs, sources — the formats prototype discs actually carry. All are
-# served as text/plain regardless of what they'd mean to a browser (html, js).
+# Docs, configs, data — the formats prototype discs actually carry. All are
+# served as text/plain regardless of what they'd mean to a browser (html).
 _TEXT = frozenset(
     """
     txt nfo diz me 1st doc readme md log ini cfg conf inf cue gdi lst csv tsv
-    json xml htm html css js mjs h c cc cpp hpp hh s asm inc mak mk bat cmd sh
-    py pl bas yml yaml toml srt
+    json xml htm html yml yaml toml srt
     """.split()
 )
+
+# Program sources and build files — split from _TEXT so the UIs can group and
+# syntax-highlight them. Same posture: always served as text/plain.
+_SOURCE = frozenset(
+    """
+    c h cc cpp cxx hpp hh hxx inc s asm pas bas lua py pl sh bat cmd js mjs css
+    ssl mak mk rc def lnk prj
+    """.split()
+)
+
+# Extensionless filenames that are still source (matched case-insensitively).
+_SOURCE_NAMES = frozenset({"makefile", "gnumakefile"})
 
 _KINDS = (
     [(_IMAGE, "image")] + [(_AUDIO, "audio")] + [(_VIDEO, "video")]
@@ -61,11 +72,13 @@ def classify(path):
     name = path.rsplit("/", 1)[-1]
     ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
     if not ext:
-        return None
+        return ("source", "text/plain") if name.lower() in _SOURCE_NAMES else None
     for table, kind in _KINDS:
         mime = table.get(ext)
         if mime:
             return kind, mime
+    if ext in _SOURCE:
+        return "source", "text/plain"
     if ext in _TEXT:
         return "text", "text/plain"
     return None

--- a/ps2exe-adapter/tests/test_viewable.py
+++ b/ps2exe-adapter/tests/test_viewable.py
@@ -10,6 +10,21 @@ def test_classify_by_extension():
     assert viewable.classify("/docs/index.html") == ("text", "text/plain")
 
 
+def test_classify_source():
+    assert viewable.classify("/SRC/GFXCORE.C") == ("source", "text/plain")
+    assert viewable.classify("/SRC/DEFS.H") == ("source", "text/plain")
+    assert viewable.classify("/SCRIPTS/INTRO.SSL") == ("source", "text/plain")
+    assert viewable.classify("/tools/mkiso.bat") == ("source", "text/plain")
+    assert viewable.classify("/SRC/VECMATH.S") == ("source", "text/plain")
+    # Build files count as source, including extensionless makefiles.
+    assert viewable.classify("/SRC/MAKEFILE") == ("source", "text/plain")
+    assert viewable.classify("/proj/Makefile") == ("source", "text/plain")
+    assert viewable.classify("/proj/win32.mak") == ("source", "text/plain")
+    # Docs and configs stay plain text; other extensionless names stay rejected.
+    assert viewable.classify("/prefs.ini") == ("text", "text/plain")
+    assert viewable.classify("/notes.md") == ("text", "text/plain")
+
+
 def test_classify_rejects_unknown_and_extensionless():
     assert viewable.classify("/SLPS_123.45") is None
     assert viewable.classify("/GAME.TIM") is None

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -69,7 +69,7 @@ CREATE TABLE build_asset (
     sha256       TEXT NOT NULL,           -- content hash = key into the blob store
     size         BIGINT NOT NULL,
     mime         TEXT NOT NULL,           -- as served; text is always text/plain
-    kind         TEXT NOT NULL,           -- image|audio|video|text
+    kind         TEXT NOT NULL,           -- image|audio|video|source|text
     PRIMARY KEY (build_sha256, path)
 );
 CREATE INDEX idx_build_asset_sha256 ON build_asset(sha256);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
+        "highlight.js": "^11.11.1",
         "next": "16.2.6",
         "pg": "^8.21.0",
         "react": "19.2.4",
@@ -4627,6 +4628,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ignore": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
+    "highlight.js": "^11.11.1",
     "next": "16.2.6",
     "pg": "^8.21.0",
     "react": "19.2.4",

--- a/web/src/app/builds/[sha256]/AssetGallery.tsx
+++ b/web/src/app/builds/[sha256]/AssetGallery.tsx
@@ -10,11 +10,13 @@ import { useMemo, useState } from "react";
 import Link from "next/link";
 import AssetViewer, { assetUrl, humanSize, type ViewableAsset } from "./AssetViewer";
 import AudioEmbed from "./AudioEmbed";
+import SourceCode from "./SourceCode";
 
 const SECTIONS: { kind: string; title: string }[] = [
   { kind: "image", title: "Images" },
   { kind: "audio", title: "Audio" },
   { kind: "video", title: "Video" },
+  { kind: "source", title: "Source code" },
   { kind: "text", title: "Text" },
 ];
 
@@ -103,7 +105,7 @@ export default function AssetGallery({
               </div>
             )}
 
-            {kind === "text" && (
+            {(kind === "source" || kind === "text") && (
               <div className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
                 {group.map((a) => (
                   <button
@@ -119,7 +121,11 @@ export default function AssetGallery({
                       <span className="shrink-0 text-[10px] text-neutral-400">{humanSize(a.size)}</span>
                     </div>
                     <pre className="mt-1.5 line-clamp-4 whitespace-pre-wrap break-words font-mono text-[11px] leading-4 text-neutral-500">
-                      {excerpts[a.path] ?? ""}
+                      {kind === "source" ? (
+                        <SourceCode path={a.path} text={excerpts[a.path] ?? ""} />
+                      ) : (
+                        excerpts[a.path] ?? ""
+                      )}
                     </pre>
                   </button>
                 ))}

--- a/web/src/app/builds/[sha256]/AssetViewer.tsx
+++ b/web/src/app/builds/[sha256]/AssetViewer.tsx
@@ -5,6 +5,7 @@
 // once seen comes back from browser cache). ← → step through the list, Esc closes.
 
 import { useEffect, useState } from "react";
+import SourceCode from "./SourceCode";
 
 /** Mirrors queries.ts BuildAsset — redeclared here so client components don't
  *  import the server-only queries module (it pulls in pg). */
@@ -13,7 +14,7 @@ export interface ViewableAsset {
   sha256: string;
   size: number;
   mime: string;
-  kind: string; // image | audio | video | text
+  kind: string; // image | audio | video | source | text
 }
 
 export function assetUrl(a: ViewableAsset): string {
@@ -34,7 +35,8 @@ export function humanSize(bytes: number): string {
 // Show at most this much decoded text — a 20MB DOM node makes the tab crawl.
 const TEXT_DISPLAY_CAP = 1_000_000;
 
-function TextBody({ url }: { url: string }) {
+function TextBody({ asset }: { asset: ViewableAsset }) {
+  const url = assetUrl(asset);
   // No reset-on-url-change needed: the viewer remounts this per asset (see the
   // key on <Body/>), so "loading" as initial state always holds.
   const [state, setState] = useState<{ text: string; truncated: boolean } | "loading" | "error">(
@@ -63,7 +65,7 @@ function TextBody({ url }: { url: string }) {
   return (
     <div className="max-h-[70vh] w-[min(80rem,90vw)] overflow-auto rounded bg-white p-4 dark:bg-neutral-900">
       <pre className="whitespace-pre-wrap break-words font-mono text-xs text-neutral-800 dark:text-neutral-200">
-        {state.text}
+        {asset.kind === "source" ? <SourceCode path={asset.path} text={state.text} /> : state.text}
       </pre>
       {state.truncated && (
         <p className="mt-3 text-xs text-neutral-400">Preview truncated — download for the full file.</p>
@@ -103,7 +105,7 @@ function Body({ asset }: { asset: ViewableAsset }) {
         />
       );
     default:
-      return <TextBody url={url} />;
+      return <TextBody asset={asset} />;
   }
 }
 

--- a/web/src/app/builds/[sha256]/FileTree.tsx
+++ b/web/src/app/builds/[sha256]/FileTree.tsx
@@ -11,7 +11,7 @@ import {
 import AssetViewer, { type ViewableAsset } from "./AssetViewer";
 
 // Chip label on viewable file rows, by asset kind.
-const KIND_TAG: Record<string, string> = { image: "img", audio: "aud", video: "vid", text: "txt" };
+const KIND_TAG: Record<string, string> = { image: "img", audio: "aud", video: "vid", source: "src", text: "txt" };
 
 function humanSize(bytes?: number): string {
   if (bytes == null) return "—";

--- a/web/src/app/builds/[sha256]/SourceCode.tsx
+++ b/web/src/app/builds/[sha256]/SourceCode.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+// Body of a source asset's <pre>: syntax-highlighted when a grammar matches
+// the filename, plain text otherwise. hljs escapes the input, so injecting
+// its output is safe.
+
+import { useMemo } from "react";
+import { highlightHtml } from "@/lib/highlight";
+
+export default function SourceCode({ path, text }: { path: string; text: string }) {
+  const html = useMemo(() => highlightHtml(text, path), [path, text]);
+  if (html == null) return <>{text}</>;
+  return <code dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/web/src/app/builds/[sha256]/assets/page.tsx
+++ b/web/src/app/builds/[sha256]/assets/page.tsx
@@ -31,7 +31,7 @@ export default async function BuildAssetsPage({ params }: { params: Promise<{ sh
   const excerpts = Object.fromEntries(
     await Promise.all(
       ordered
-        .filter((a) => a.kind === "text")
+        .filter((a) => a.kind === "source" || a.kind === "text")
         .slice(0, MAX_EXCERPT_READS)
         .map(async (a) => [a.path, (await readAssetExcerpt(a.sha256)) ?? ""] as const)
     )

--- a/web/src/app/builds/[sha256]/page.tsx
+++ b/web/src/app/builds/[sha256]/page.tsx
@@ -13,7 +13,7 @@ import AssetGallery from "./AssetGallery";
 
 // The assets section previews at most this many items per kind; the rest live
 // on /builds/<sha256>/assets.
-const ASSET_PREVIEW_PER_KIND = { image: 30, audio: 20, video: 10, text: 10 };
+const ASSET_PREVIEW_PER_KIND = { image: 30, audio: 20, video: 10, source: 10, text: 10 };
 
 export const runtime = "nodejs";
 // The corpus only changes at ingest; render once and serve cached for an hour
@@ -111,12 +111,12 @@ export default async function BuildPage({ params }: { params: Promise<{ sha256: 
   for (const f of fused) f.caps = caps.get(f.sha256) ?? [];
 
   // Preview subset for the assets section, plus server-read excerpts for its
-  // text cards (tiny head reads from the local blob store).
+  // source/text cards (tiny head reads from the local blob store).
   const previewAssets = orderAssets(assets, ASSET_PREVIEW_PER_KIND);
   const excerpts = Object.fromEntries(
     await Promise.all(
       previewAssets
-        .filter((a) => a.kind === "text")
+        .filter((a) => a.kind === "source" || a.kind === "text")
         .map(async (a) => [a.path, (await readAssetExcerpt(a.sha256)) ?? ""] as const)
     )
   );

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -28,3 +28,73 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Syntax highlighting palette for source assets (see src/lib/highlight.ts).
+   GitHub-ish hues on both schemes; unlisted scopes inherit the pre's color. */
+:root {
+  --hl-comment: #6a737d;
+  --hl-keyword: #cf222e;
+  --hl-string: #0a3069;
+  --hl-number: #0550ae;
+  --hl-title: #6639ba;
+  --hl-type: #116329;
+  --hl-meta: #953800;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --hl-comment: #8b949e;
+    --hl-keyword: #ff7b72;
+    --hl-string: #a5d6ff;
+    --hl-number: #79c0ff;
+    --hl-title: #d2a8ff;
+    --hl-type: #7ee787;
+    --hl-meta: #ffa657;
+  }
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: var(--hl-comment);
+  font-style: italic;
+}
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-literal,
+.hljs-deletion {
+  color: var(--hl-keyword);
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-char.escape_,
+.hljs-addition {
+  color: var(--hl-string);
+}
+.hljs-number,
+.hljs-symbol,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-attr,
+.hljs-attribute,
+.hljs-operator {
+  color: var(--hl-number);
+}
+.hljs-title,
+.hljs-title.function_,
+.hljs-title.class_,
+.hljs-section,
+.hljs-name {
+  color: var(--hl-title);
+}
+.hljs-type,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-selector-class,
+.hljs-selector-id {
+  color: var(--hl-type);
+}
+.hljs-meta,
+.hljs-meta .hljs-keyword,
+.hljs-doctag {
+  color: var(--hl-meta);
+}

--- a/web/src/lib/assets.ts
+++ b/web/src/lib/assets.ts
@@ -23,7 +23,7 @@ export function assetStagingPath(sha256: string): string {
 }
 
 /** Display order for asset kinds on the build pages. */
-export const ASSET_KIND_ORDER = ["image", "audio", "video", "text"] as const;
+export const ASSET_KIND_ORDER = ["image", "audio", "video", "source", "text"] as const;
 
 /** Per-kind asset counts. */
 export function assetTotals(assets: { kind: string }[]): Record<string, number> {

--- a/web/src/lib/highlight.ts
+++ b/web/src/lib/highlight.ts
@@ -1,0 +1,89 @@
+// Syntax highlighting for "source" assets (client-side). highlight.js core
+// with only the grammars the adapter's source kind can emit (see
+// ps2exe-adapter/curator_adapter/viewable.py) — the full hljs build would drag
+// ~190 grammars into the bundle. Colors live in globals.css (.hljs-* rules).
+
+import hljs from "highlight.js/lib/core";
+import c from "highlight.js/lib/languages/c";
+import cpp from "highlight.js/lib/languages/cpp";
+import x86asm from "highlight.js/lib/languages/x86asm";
+import makefile from "highlight.js/lib/languages/makefile";
+import dos from "highlight.js/lib/languages/dos";
+import bash from "highlight.js/lib/languages/bash";
+import python from "highlight.js/lib/languages/python";
+import perl from "highlight.js/lib/languages/perl";
+import basic from "highlight.js/lib/languages/basic";
+import javascript from "highlight.js/lib/languages/javascript";
+import css from "highlight.js/lib/languages/css";
+import lua from "highlight.js/lib/languages/lua";
+import delphi from "highlight.js/lib/languages/delphi";
+
+hljs.registerLanguage("c", c);
+hljs.registerLanguage("cpp", cpp);
+hljs.registerLanguage("x86asm", x86asm);
+hljs.registerLanguage("makefile", makefile);
+hljs.registerLanguage("dos", dos);
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("perl", perl);
+hljs.registerLanguage("basic", basic);
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("lua", lua);
+hljs.registerLanguage("delphi", delphi);
+
+// Extension → grammar. C-like game scripting sources (.ssl) and .rc resource
+// scripts read closest as C; .def/.lnk/.prj linker and project files have no
+// grammar and render plain.
+const EXT_LANG: Record<string, string> = {
+  c: "c",
+  h: "c",
+  inc: "c",
+  rc: "c",
+  ssl: "c",
+  cc: "cpp",
+  cpp: "cpp",
+  cxx: "cpp",
+  hpp: "cpp",
+  hh: "cpp",
+  hxx: "cpp",
+  s: "x86asm",
+  asm: "x86asm",
+  mak: "makefile",
+  mk: "makefile",
+  bat: "dos",
+  cmd: "dos",
+  sh: "bash",
+  py: "python",
+  pl: "perl",
+  bas: "basic",
+  js: "javascript",
+  mjs: "javascript",
+  css: "css",
+  lua: "lua",
+  pas: "delphi",
+};
+
+// Extensionless filenames that map to a grammar (mirrors the adapter).
+const NAME_LANG: Record<string, string> = { makefile: "makefile", gnumakefile: "makefile" };
+
+// Above this, skip highlighting — hljs on megabyte inputs stalls the tab.
+const HIGHLIGHT_CAP = 512_000;
+
+export function sourceLanguage(path: string): string | null {
+  const name = (path.split("/").pop() || path).toLowerCase();
+  const ext = name.includes(".") ? name.split(".").pop()! : "";
+  return (ext ? EXT_LANG[ext] : NAME_LANG[name]) ?? null;
+}
+
+/** Highlighted (and HTML-escaped, hljs does both) markup for a source file,
+ *  or null when there's no grammar / the file is too big — render plain then. */
+export function highlightHtml(text: string, path: string): string | null {
+  const lang = sourceLanguage(path);
+  if (!lang || text.length > HIGHLIGHT_CAP) return null;
+  try {
+    return hljs.highlight(text, { language: lang }).value;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -527,7 +527,7 @@ export interface BuildAsset {
   sha256: string;
   size: number;
   mime: string;
-  kind: string; // image | audio | video | text
+  kind: string; // image | audio | video | source | text
 }
 
 /// A build's viewable assets, in path order (one indexed lookup).

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -68,7 +68,7 @@ export interface AssetRef {
   sha256: string;
   size: number;
   mime: string;
-  kind: string; // "image" | "audio" | "video" | "text"
+  kind: string; // "image" | "audio" | "video" | "source" | "text"
 }
 
 export interface MediaFp {

--- a/web/tests/lib.test.ts
+++ b/web/tests/lib.test.ts
@@ -172,15 +172,15 @@ import { orderAssets, assetTotals } from "../src/lib/assets";
 
 test("orderAssets groups by display kind and caps per kind", () => {
   const mk = (kind: string, n: number) => Array.from({ length: n }, (_, i) => ({ kind, path: `${kind}${i}` }));
-  const mixed = [...mk("text", 3), ...mk("image", 12), ...mk("audio", 1)];
+  const mixed = [...mk("text", 3), ...mk("image", 12), ...mk("source", 2), ...mk("audio", 1)];
   const ordered = orderAssets(mixed, 10);
   assert.deepEqual(
     ordered.map((a) => a.kind),
-    [...Array(10).fill("image"), "audio", ...Array(3).fill("text")]
+    [...Array(10).fill("image"), "audio", ...Array(2).fill("source"), ...Array(3).fill("text")]
   );
   // Uncapped keeps everything, still grouped.
-  assert.equal(orderAssets(mixed).length, 16);
-  assert.deepEqual(assetTotals(mixed), { text: 3, image: 12, audio: 1 });
+  assert.equal(orderAssets(mixed).length, 18);
+  assert.deepEqual(assetTotals(mixed), { text: 3, image: 12, source: 2, audio: 1 });
 });
 
 test("orderAssets accepts a per-kind cap map (missing kind = uncapped)", () => {


### PR DESCRIPTION
Splits source files out of the text asset kind so they group separately and render with syntax highlighting.

## Detection (adapter)

A new `_SOURCE` table in `viewable.py` classifies program sources and build files as `kind: "source"`: C family, assembly, Pascal, BASIC, Lua, Python, Perl, shell/batch, JS, CSS, plus `.ssl` scripts, `.mak`/`.mk`/`.rc`/`.def`/`.lnk`/`.prj` build files, and extensionless `MAKEFILE`/`GNUmakefile` by filename. Docs and configs (txt, md, ini, json, xml, ...) stay `text`. Everything is still served `text/plain` behind the same binary sniff, so the security posture is unchanged and the free-text `kind` column needs no migration.

## Web

- `highlight.js` core with only the 13 grammars the adapter can emit (~60KB min vs the full ~190-grammar build). Extension-to-grammar mapping lives in `src/lib/highlight.ts`; `.ssl` and `.rc` highlight as C.
- New `SourceCode` component renders highlighted markup in the lightbox viewer and the gallery excerpt cards, falling back to plain text for unknown extensions or files over 512KB (hljs stalls on megabyte inputs).
- Palette is CSS variables in `globals.css` with light and dark values.
- "Source code" gallery section between Video and Text; file tree rows tag as `src`.

## GUIs

Both native GUIs get the new section and treat source like text when opening: in-app preview on macOS, Notepad on Windows, preserving the never-shell-execute rule for scripts from untrusted discs.

Existing ingests keep `kind: "text"` on source files until re-analyzed; the kind is stamped at extraction time.

Verified end to end by seeding a local build with sample `.c`/`.ssl`/`MAKEFILE` assets: the assets page server-renders the Source code section with correctly highlighted excerpts per grammar. Adapter tests 5/5, web tests 19/19, `next build` clean, Windows GUI cross-checks under `x86_64-pc-windows-gnu`, macOS app builds.