### PR TITLE
Drop weak text-only similarity matches

### DIFF
--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -117,6 +117,10 @@ export async function findAudioSimilar(
 
 const clamp01 = (v: number) => (v < 0 ? 0 : v > 1 ? 1 : v);
 
+// A build whose *only* signal is semantic text must clear this to be listed at all —
+// weak text-only cosine neighbors are noise, not evidence of a related build.
+const TEXT_ONLY_MIN = 0.7;
+
 /**
  * Collapse the per-tier similarity lists (+ text neighbors) into one per-build matrix
  * of similarities in [0,1], for weighted fusion + filtering on the client. Distances
@@ -143,7 +147,10 @@ export function fuseSimilar(s: SimilarityResult, text: EmbeddingHit[]): FusedBui
   for (const x of s.exe_similar) add(x.sha256, x.name, x.system, "tlsh", clamp01(1 - x.distance / TLSH_MAX_DISTANCE));
   for (const x of s.audio_neighbors) add(x.sha256, x.name, x.system, "audio", clamp01(x.best));
   for (const x of text) add(x.sha256, x.name, x.system, "text", clamp01(x.cosine));
-  return [...map.values()];
+  return [...map.values()].filter((e) => {
+    const keys = Object.keys(e.scores) as TierKey[];
+    return keys.length !== 1 || keys[0] !== "text" || (e.scores.text ?? 0) >= TEXT_ONLY_MIN;
+  });
 }
 
 /**

--- a/web/tests/lib.test.ts
+++ b/web/tests/lib.test.ts
@@ -103,6 +103,29 @@ test("a tier absent from either build is dropped from the denominator (not penal
   assert.equal(fusedScore({ files: 0.5 }, ap2), 0.5);
 });
 
+// --- fusion filtering ---------------------------------------------------------
+
+import { fuseSimilar } from "../src/lib/queries";
+import type { SimilarityResult } from "../src/lib/types";
+
+const emptySimilarity = (): SimilarityResult => ({
+  identical_content: [], shared_files: [], similar_chunks: [], resemblance: [], exe_imports: [], exe_similar: [], audio_neighbors: [],
+});
+
+test("text-only neighbors below 70% are dropped; others survive", () => {
+  const s = emptySimilarity();
+  s.shared_files = [{ sha256: "c".repeat(64), name: "files+weak text", system: "test", jaccard: 0.4 }];
+  const fused = fuseSimilar(s, [
+    { sha256: "a".repeat(64), name: "weak text only", system: "test", cosine: 0.6 },
+    { sha256: "b".repeat(64), name: "strong text only", system: "test", cosine: 0.8 },
+    { sha256: "c".repeat(64), name: "files+weak text", system: "test", cosine: 0.6 },
+  ]);
+  const shas = fused.map((f) => f.sha256);
+  assert.ok(!shas.includes("a".repeat(64)), "weak text-only neighbor dropped");
+  assert.ok(shas.includes("b".repeat(64)), "text-only neighbor at ≥0.7 kept");
+  assert.ok(shas.includes("c".repeat(64)), "weak text kept when another tier also matched");
+});
+
 // --- asset ingest semantics -------------------------------------------------
 // ingestRecord against a fake Queryable: assets == null means "extraction never
 // ran" and must not touch existing build_asset rows; only an extracted list


### PR DESCRIPTION
Builds whose only similarity signal is the semantic-text tier must now score at least 70% cosine to appear in Similar builds. Weak text-only neighbors were surfacing as noise: with every other tier inapplicable, renormalization inflated a mediocre cosine into a plausible-looking fused score.

The filter runs server-side in `fuseSimilar`, so dropped candidates never ship to the client and the tier filter chips can't resurrect them. A sub-70% text score still counts when the build also matched any other tier — only text-*only* entries are affected. Threshold is the `TEXT_ONLY_MIN` constant in `queries.ts`.

Adds a test covering the three cases: weak text-only dropped, strong text-only kept, weak text plus shared-files kept.