### PR TITLE
Add social link previews

### DIFF
--- a/web/src/app/builds/[buildId]/assets/[[...path]]/page.tsx
+++ b/web/src/app/builds/[buildId]/assets/[[...path]]/page.tsx
@@ -1,8 +1,11 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
+import type { Pool } from "pg";
 import { getPool } from "@/lib/db";
-import { getBuildAssets, resolveBuild } from "@/lib/queries";
+import { getBuildAssets, resolveBuild, type BuildAsset } from "@/lib/queries";
 import { assetTotals, orderAssets, readAssetExcerpt } from "@/lib/assets";
+import { humanSize } from "@/lib/meta";
 import { canonicalBuildId, parseBuildParam, safeDecodeSegment } from "@/lib/slug";
 import AssetGallery from "../../AssetGallery";
 import AssetViewerHost from "../../AssetViewerHost";
@@ -17,6 +20,64 @@ export function generateStaticParams(): Array<{ buildId: string; path: string[] 
 // Excerpt reads are tiny (2KB head per file) but keep them bounded on builds
 // with pathological text counts; cards past the cap still open in the viewer.
 const MAX_EXCERPT_READS = 200;
+
+// Stored asset paths carry a leading "/" that URL segments drop.
+async function findAsset(pool: Pool, buildSha: string, relPath: string): Promise<BuildAsset | null> {
+  const r = await pool.query(
+    `SELECT path, sha256, size::float8 AS size, mime, kind FROM build_asset
+     WHERE build_sha256=$1 AND (path=$2 OR path='/'||$2) LIMIT 1`,
+    [buildSha, relPath]
+  );
+  return (r.rows[0] as BuildAsset) ?? null;
+}
+
+// Unfurl metadata: the gallery inherits the build's card; a deep-linked asset
+// gets its file name as the title, and image assets unfurl as the image itself.
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ buildId: string; path?: string[] }>;
+}): Promise<Metadata> {
+  const { buildId, path } = await params;
+  const parsed = parseBuildParam(buildId);
+  if (!parsed) return {};
+  const pool = getPool();
+  const resolved = await resolveBuild(pool, parsed.hex, parsed.slug);
+  if (!resolved) return {};
+  const href = `/builds/${canonicalBuildId(resolved.sha256, resolved.name)}`;
+
+  // The build's generated card (see ../opengraph-image.tsx). Referenced
+  // explicitly: the file convention doesn't cascade into this nested segment.
+  const card = `${href}/opengraph-image`;
+
+  const relPath = (path ?? []).map(safeDecodeSegment).join("/");
+  const asset = relPath ? await findAsset(pool, resolved.sha256, relPath) : null;
+  if (!asset) {
+    const title = `Assets · ${resolved.name}`;
+    return {
+      title,
+      alternates: { canonical: `${href}/assets` },
+      openGraph: { title, url: `${href}/assets`, siteName: "Hidden Palace", images: [card] },
+      twitter: { card: "summary_large_image" },
+    };
+  }
+
+  const name = asset.path.split("/").pop() || asset.path;
+  const description = `${resolved.name} · ${humanSize(asset.size)} · ${asset.mime}`;
+  return {
+    title: name,
+    description,
+    alternates: { canonical: `${href}/assets/${relPath.split("/").map(encodeURIComponent).join("/")}` },
+    openGraph: {
+      title: name,
+      description,
+      siteName: "Hidden Palace",
+      // Image assets unfurl as themselves; everything else gets the build card.
+      images: [asset.kind === "image" ? `/api/asset/${asset.sha256}` : card],
+    },
+    twitter: { card: "summary_large_image" },
+  };
+}
 
 // /builds/<id>/assets — the full gallery; /builds/<id>/assets/<path…> — the
 // same gallery with the viewer open on that file (the URL the lightbox writes).

--- a/web/src/app/builds/[buildId]/opengraph-image.tsx
+++ b/web/src/app/builds/[buildId]/opengraph-image.tsx
@@ -1,0 +1,153 @@
+// Social-preview card for a build (og:image / twitter:image), rendered with
+// satori via next/og. Next's file convention wires it into <meta> for this
+// segment and everything below it, so asset deep links inherit it too.
+//
+// Dark info card: wordmark, title, fact chips, short id — plus a screenshot
+// pane when the build has a PNG/JPEG asset whose bytes are in the blob store
+// (largest first: big files are screenshots, tiny ones are icons/textures).
+
+import { readFile } from "node:fs/promises";
+import { ImageResponse } from "next/og";
+import { assetBlobPath } from "@/lib/assets";
+import { getPool } from "@/lib/db";
+import { buildFacts, displayTitle } from "@/lib/meta";
+import { getBuildMeta, resolveBuild, type BuildMetaRow } from "@/lib/queries";
+import { parseBuildParam, SHORT_SHA_LEN } from "@/lib/slug";
+
+export const runtime = "nodejs";
+export const alt = "Build summary card";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// Satori decodes the screenshot in-process — skip pathological blobs.
+const MAX_SHOT_BYTES = 8_000_000;
+
+async function findScreenshot(sha256: string): Promise<string | null> {
+  const r = await getPool().query(
+    `SELECT sha256, mime FROM build_asset
+     WHERE build_sha256=$1 AND kind='image' AND mime IN ('image/png','image/jpeg')
+       AND size <= $2
+     ORDER BY size DESC LIMIT 4`,
+    [sha256, MAX_SHOT_BYTES]
+  );
+  // A row's blob can be missing (metadata ingested before the bundle carrying
+  // the bytes) — fall through to the next-largest candidate.
+  for (const row of r.rows as Array<{ sha256: string; mime: string }>) {
+    try {
+      const bytes = await readFile(assetBlobPath(row.sha256));
+      return `data:${row.mime};base64,${bytes.toString("base64")}`;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+function Card({ meta, shot }: { meta: BuildMetaRow; shot: string | null }) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        background: "#0a0a0a",
+        color: "#fafafa",
+      }}
+    >
+      <div
+        style={{
+          flex: 1,
+          minWidth: 0,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: 56,
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div style={{ fontSize: 26, letterSpacing: 6, color: "#737373" }}>HIDDEN PALACE</div>
+          <div
+            style={{
+              marginTop: 30,
+              fontSize: 54,
+              lineHeight: 1.15,
+              lineClamp: 3,
+              display: "block",
+            }}
+          >
+            {displayTitle(meta)}
+          </div>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 26 }}>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 14 }}>
+            {buildFacts(meta).map((f) => (
+              <div
+                key={f}
+                style={{
+                  border: "1px solid #333333",
+                  borderRadius: 10,
+                  padding: "8px 20px",
+                  fontSize: 27,
+                  color: "#d4d4d4",
+                }}
+              >
+                {f}
+              </div>
+            ))}
+          </div>
+          {/* One template string: satori treats mixed expression/text as
+              multiple children and then demands display:flex. */}
+          <div style={{ fontSize: 23, color: "#525252" }}>
+            {`${meta.sha256.slice(0, SHORT_SHA_LEN)} · hiddenpalace.org`}
+          </div>
+        </div>
+      </div>
+      {shot && (
+        <div
+          style={{
+            width: 480,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: "#171717",
+            borderLeft: "1px solid #262626",
+            padding: 24,
+          }}
+        >
+          <img
+            src={shot}
+            alt=""
+            style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Materialize the PNG so satori failures (e.g. an undecodable blob) are
+// catchable — then retry without the screenshot instead of 500ing the unfurl.
+async function render(meta: BuildMetaRow, shot: string | null): Promise<Response> {
+  const img = new ImageResponse(<Card meta={meta} shot={shot} />, size);
+  const buf = await img.arrayBuffer();
+  return new Response(buf, {
+    headers: { "Content-Type": contentType, "Cache-Control": "public, max-age=3600" },
+  });
+}
+
+export default async function OgImage({ params }: { params: Promise<{ buildId: string }> }) {
+  const { buildId } = await params;
+  const parsed = parseBuildParam(buildId);
+  if (!parsed) return new Response("not found", { status: 404 });
+  const pool = getPool();
+  const resolved = await resolveBuild(pool, parsed.hex, parsed.slug);
+  const meta = resolved && (await getBuildMeta(pool, resolved.sha256));
+  if (!meta) return new Response("not found", { status: 404 });
+
+  const shot = await findScreenshot(meta.sha256);
+  try {
+    return await render(meta, shot);
+  } catch {
+    return await render(meta, null);
+  }
+}

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -1,11 +1,13 @@
 import { Fragment } from "react";
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
 import { buildTree, initialExpanded, pruneToExpanded, treeCounts } from "@/lib/filetree";
-import { getBuild, getBuildAssets, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, resolveBuild } from "@/lib/queries";
+import { getBuild, getBuildAssets, getBuildMeta, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, resolveBuild } from "@/lib/queries";
 import { assetTotals, orderAssets, readAssetExcerpt } from "@/lib/assets";
+import { buildDescription, displayTitle } from "@/lib/meta";
 import { canonicalBuildId, parseBuildParam } from "@/lib/slug";
 import type { BuildRecord } from "@/lib/types";
 import SimilarBuilds from "./SimilarBuilds";
@@ -88,6 +90,31 @@ function metaSections(record: BuildRecord): MetaSection[] {
   }
 
   return sections;
+}
+
+// Social-preview metadata (og:*/twitter:*) so shared build links unfurl with
+// the build's title, facts, and the generated card (opengraph-image.tsx).
+export async function generateMetadata({ params }: { params: Promise<{ buildId: string }> }): Promise<Metadata> {
+  const { buildId } = await params;
+  const parsed = parseBuildParam(buildId);
+  if (!parsed) return {};
+  const pool = getPool();
+  const resolved = await resolveBuild(pool, parsed.hex, parsed.slug);
+  if (!resolved) return {};
+  const meta = await getBuildMeta(pool, resolved.sha256);
+  if (!meta) return {};
+  const href = `/builds/${canonicalBuildId(meta.sha256, meta.name)}`;
+  const title = displayTitle(meta);
+  const description = buildDescription(meta);
+  return {
+    title,
+    description,
+    alternates: { canonical: href },
+    // siteName repeated here: a deeper segment's openGraph replaces the
+    // layout's whole object (Next merges per-field, not deep).
+    openGraph: { title, description, url: href, siteName: "Hidden Palace" },
+    twitter: { card: "summary_large_image" },
+  };
 }
 
 export default async function BuildPage({ params }: { params: Promise<{ buildId: string }> }) {

--- a/web/src/app/builds/page.tsx
+++ b/web/src/app/builds/page.tsx
@@ -1,9 +1,15 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { getPool } from "@/lib/db";
 import { listBuildsPage, type BuildSortKey } from "@/lib/queries";
 import BuildsBrowser from "./BuildsBrowser";
 
 export const runtime = "nodejs";
+
+export const metadata: Metadata = {
+  title: "Builds",
+  description: "Browse and search every build in the Hidden Palace library.",
+};
 
 const PER_PAGE = 100;
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -12,9 +12,15 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+// metadataBase makes every relative og:image/canonical URL absolute — link
+// unfurlers (Discord, Slack, Twitter) reject relative image URLs. SITE_URL
+// overrides for non-production hosts; the default is where hpwiki:6800 is
+// publicly proxied.
 export const metadata: Metadata = {
-  title: "Curator",
-  description: "Curator",
+  metadataBase: new URL(process.env.SITE_URL ?? "https://hiddenpalace.org"),
+  title: { default: "Curator", template: "%s · Hidden Palace" },
+  description: "The Hidden Palace build library — browsable, searchable game builds with file listings, similarity matching, and viewable assets.",
+  openGraph: { siteName: "Hidden Palace", type: "website" },
 };
 
 export default function RootLayout({

--- a/web/src/lib/meta.ts
+++ b/web/src/lib/meta.ts
@@ -1,0 +1,33 @@
+// Shared strings for social-preview metadata (build pages + OG card images).
+
+import type { BuildMetaRow } from "./queries";
+
+export function humanSize(bytes?: number | null): string {
+  if (bytes == null) return "—";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let v = Number(bytes);
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return i === 0 ? `${bytes} B` : `${v.toFixed(1)} ${units[i]}`;
+}
+
+/** The heading users see: the extractor's title when present, else the dump name. */
+export function displayTitle(m: BuildMetaRow): string {
+  return m.title || m.name;
+}
+
+/** "system · date" and "N files · SIZE" facts, used as chips on the OG card. */
+export function buildFacts(m: BuildMetaRow): string[] {
+  const facts = [m.system || "unknown system", `${m.file_count} files`, humanSize(m.total_size)];
+  const day = m.build_date?.match(/^(\d{4}-\d{2}-\d{2})/)?.[1];
+  if (day) facts.push(day);
+  return facts;
+}
+
+/** One-line unfurl description. */
+export function buildDescription(m: BuildMetaRow): string {
+  return buildFacts(m).join(" · ");
+}

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -575,6 +575,29 @@ export async function resolveBuild(
   return null;
 }
 
+export interface BuildMetaRow {
+  sha256: string;
+  name: string;
+  system: string;
+  file_count: number;
+  total_size: number;
+  build_date: string | null;
+  /** Display title from the canonical record, when the system extractor found one. */
+  title: string | null;
+}
+
+/// The handful of scalar fields social-preview metadata needs — the full
+/// record (MBs of jsonb) stays out of generateMetadata.
+export async function getBuildMeta(pool: Pool, sha256: string): Promise<BuildMetaRow | null> {
+  const r = await pool.query(
+    `SELECT sha256, name, system, file_count, total_size, build_date,
+            record->'info'->>'title' AS title
+     FROM builds WHERE sha256=$1`,
+    [sha256]
+  );
+  return (r.rows[0] as BuildMetaRow) ?? null;
+}
+
 /// Fetch one stored build (with its full canonical record) by sha256.
 export async function getBuild(pool: Pool, sha256: string): Promise<BuildRow | null> {
   const r = await pool.query(


### PR DESCRIPTION
Build pages now carry full Open Graph and Twitter Card metadata, so links shared on Discord, Slack, Twitter, and similar unfurl with the build's title, a facts line (system, file count, size, build date), the canonical URL, and a generated 1200x630 card image. The card is rendered server-side with next/og via the opengraph-image file convention: dark layout matching the site, with wordmark, title, fact chips, and short id. When the build has PNG/JPEG assets whose bytes are in the blob store, the card gains a screenshot pane — it prefers the largest image (big files are screenshots, tiny ones are icons/textures) and falls through to the next candidate when a blob's bytes haven't been ingested yet. A satori decode failure degrades to the info-only card instead of failing the unfurl.

Asset deep links (/builds/<id>/assets/<path>) unfurl with the file name as title and build name, size, and mime as description. Image assets unfurl as the actual image via /api/asset/<sha> (already served with proper content-type and immutable caching); audio, video, and text fall back to the build's card, referenced explicitly because the file convention does not cascade into the nested assets segment. The assets gallery and the /builds index get titles and descriptions too.

metadataBase defaults to https://hiddenpalace.org (overridable via SITE_URL), making every og:image and canonical URL absolute, which unfurlers require. Metadata lookups use a new light getBuildMeta query — scalar columns only, so bot fetches never detoast the multi-MB jsonb records. Note that a page-level openGraph object replaces the layout's whole object rather than deep-merging, so siteName is repeated where openGraph is customized.

Verified on a local production build: meta tags on all page variants, both card variants rendered, 404s for unknown builds, and shared full-sha URLs unfurling correctly through the 308 redirect. Most builds will show the info-only card until the asset backfill lands more blobs on the server.