### PR TITLE
Convert BMP assets to PNG for previews

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,14 +9,18 @@
       "version": "0.1.0",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
+        "@types/pngjs": "^6.0.5",
+        "bmp-js": "^0.1.0",
         "highlight.js": "^11.11.1",
         "next": "16.2.6",
         "pg": "^8.21.0",
+        "pngjs": "^7.0.0",
         "react": "19.2.4",
         "react-dom": "19.2.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/bmp-js": "^0.1.2",
         "@types/node": "^20",
         "@types/pg": "^8.20.0",
         "@types/react": "^19",
@@ -2081,6 +2085,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/bmp-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@types/bmp-js/-/bmp-js-0.1.2.tgz",
+      "integrity": "sha512-BF6u+M+KySDBKfr1DQOT3+z42n4/tq62uf9ong4i2SLLpa7mJqPwEmKbNgMzlVliT/jtE6elxyD/0X1mja8jLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2121,6 +2135,15 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -3064,6 +3087,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
     },
     "node_modules/boolean": {
       "version": "3.2.0",
@@ -6217,6 +6246,15 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,14 +12,18 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
+    "@types/pngjs": "^6.0.5",
+    "bmp-js": "^0.1.0",
     "highlight.js": "^11.11.1",
     "next": "16.2.6",
     "pg": "^8.21.0",
+    "pngjs": "^7.0.0",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/bmp-js": "^0.1.2",
     "@types/node": "^20",
     "@types/pg": "^8.20.0",
     "@types/react": "^19",

--- a/web/src/app/api/asset/[sha256]/png/route.ts
+++ b/web/src/app/api/asset/[sha256]/png/route.ts
@@ -1,0 +1,62 @@
+import { readFile } from "node:fs/promises";
+import type { NextRequest } from "next/server";
+import { assetBlobPath } from "@/lib/assets";
+import { getPool } from "@/lib/db";
+import { bmpToPng, pngConvertible, WEB_SAFE_IMAGE } from "@/lib/imgpng";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// GET /api/asset/<sha256>/png — the asset converted to PNG, for og:image use
+// on formats unfurlers won't render (today: BMP). Web-safe formats redirect to
+// the raw asset route; content-addressed, so responses cache hard.
+
+const CACHE = "public, max-age=31536000, immutable";
+
+// BMPs are uncompressed; bound what the in-process decoder will chew on.
+const MAX_CONVERT_BYTES = 32_000_000;
+
+export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const r = await getPool().query(
+    "SELECT path, mime, size::float8 AS size FROM build_asset WHERE sha256=$1 LIMIT 1",
+    [sha256]
+  );
+  const meta = r.rows[0] as { path: string; mime: string; size: number } | undefined;
+  if (!meta) return Response.json({ error: "not found" }, { status: 404 });
+
+  if (WEB_SAFE_IMAGE.test(meta.mime)) {
+    return Response.redirect(new URL(`/api/asset/${sha256}`, _request.url), 308);
+  }
+  if (!pngConvertible(meta.mime) || meta.size > MAX_CONVERT_BYTES) {
+    return Response.json({ error: `no PNG conversion for ${meta.mime}` }, { status: 415 });
+  }
+
+  let bytes: Buffer;
+  try {
+    bytes = await readFile(assetBlobPath(sha256));
+  } catch {
+    return Response.json({ error: "asset bytes not in store" }, { status: 404 });
+  }
+
+  let png: Buffer;
+  try {
+    png = bmpToPng(bytes);
+  } catch {
+    return Response.json({ error: "undecodable image" }, { status: 415 });
+  }
+
+  const base = (meta.path.split("/").pop() || sha256).replace(/\.[^.]*$/, "");
+  const asciiName = base.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+  return new Response(new Uint8Array(png), {
+    headers: {
+      "Content-Type": "image/png",
+      "Content-Disposition": `inline; filename="${asciiName}.png"`,
+      "Cache-Control": CACHE,
+      ETag: `"${sha256}-png"`,
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/web/src/app/builds/[buildId]/assets/[[...path]]/page.tsx
+++ b/web/src/app/builds/[buildId]/assets/[[...path]]/page.tsx
@@ -5,6 +5,7 @@ import type { Pool } from "pg";
 import { getPool } from "@/lib/db";
 import { getBuildAssets, resolveBuild, type BuildAsset } from "@/lib/queries";
 import { assetTotals, orderAssets, readAssetExcerpt } from "@/lib/assets";
+import { pngConvertible, WEB_SAFE_IMAGE } from "@/lib/imgpng";
 import { humanSize } from "@/lib/meta";
 import { canonicalBuildId, parseBuildParam, safeDecodeSegment } from "@/lib/slug";
 import AssetGallery from "../../AssetGallery";
@@ -72,8 +73,16 @@ export async function generateMetadata({
       title: name,
       description,
       siteName: "Hidden Palace",
-      // Image assets unfurl as themselves; everything else gets the build card.
-      images: [asset.kind === "image" ? `/api/asset/${asset.sha256}` : card],
+      // Image assets unfurl as themselves — directly when the format is
+      // web-safe, via PNG conversion when it isn't (BMP); everything else
+      // (audio/video/text, ico/svg) gets the build card.
+      images: [
+        asset.kind === "image" && WEB_SAFE_IMAGE.test(asset.mime)
+          ? `/api/asset/${asset.sha256}`
+          : asset.kind === "image" && pngConvertible(asset.mime)
+            ? `/api/asset/${asset.sha256}/png`
+            : card,
+      ],
     },
     twitter: { card: "summary_large_image" },
   };

--- a/web/src/app/builds/[buildId]/opengraph-image.tsx
+++ b/web/src/app/builds/[buildId]/opengraph-image.tsx
@@ -10,6 +10,7 @@ import { readFile } from "node:fs/promises";
 import { ImageResponse } from "next/og";
 import { assetBlobPath } from "@/lib/assets";
 import { getPool } from "@/lib/db";
+import { bmpToPng } from "@/lib/imgpng";
 import { buildFacts, displayTitle } from "@/lib/meta";
 import { getBuildMeta, resolveBuild, type BuildMetaRow } from "@/lib/queries";
 import { parseBuildParam, SHORT_SHA_LEN } from "@/lib/slug";
@@ -25,16 +26,20 @@ const MAX_SHOT_BYTES = 8_000_000;
 async function findScreenshot(sha256: string): Promise<string | null> {
   const r = await getPool().query(
     `SELECT sha256, mime FROM build_asset
-     WHERE build_sha256=$1 AND kind='image' AND mime IN ('image/png','image/jpeg')
+     WHERE build_sha256=$1 AND kind='image' AND mime IN ('image/png','image/jpeg','image/bmp')
        AND size <= $2
      ORDER BY size DESC LIMIT 4`,
     [sha256, MAX_SHOT_BYTES]
   );
   // A row's blob can be missing (metadata ingested before the bundle carrying
-  // the bytes) — fall through to the next-largest candidate.
+  // the bytes) or undecodable — fall through to the next-largest candidate.
   for (const row of r.rows as Array<{ sha256: string; mime: string }>) {
     try {
       const bytes = await readFile(assetBlobPath(row.sha256));
+      // satori can't decode BMP — hand it PNG bytes instead.
+      if (row.mime === "image/bmp") {
+        return `data:image/png;base64,${bmpToPng(bytes).toString("base64")}`;
+      }
       return `data:${row.mime};base64,${bytes.toString("base64")}`;
     } catch {
       continue;

--- a/web/src/lib/imgpng.ts
+++ b/web/src/lib/imgpng.ts
@@ -1,0 +1,95 @@
+// BMP → PNG conversion for social previews. Link unfurlers (Discord, Slack,
+// Twitter) and satori (the OG card renderer) only handle web image formats,
+// but dumps carry raw BMP screenshots — convert those on the fly; formats we
+// can't convert (ico, svg) fall back to the build's generated card.
+
+import bmp from "bmp-js";
+import { PNG } from "pngjs";
+
+/** Formats unfurlers render directly as og:image. */
+export const WEB_SAFE_IMAGE = /^image\/(png|jpe?g|gif|webp)$/;
+
+/** Mimes /api/asset/<sha>/png can convert. */
+export function pngConvertible(mime: string): boolean {
+  return mime === "image/bmp";
+}
+
+// Refuse to decode absurd dimensions (decode allocates width*height*4 up
+// front, and headers are attacker-controlled bytes).
+const MAX_PIXELS = 16_000_000;
+
+// The standard BGRA channel masks — what every mainstream tool writes when it
+// uses BI_BITFIELDS on 24/32bpp instead of plain BI_RGB.
+const STD_MASKS = { r: 0xff0000, g: 0xff00, b: 0xff };
+
+/**
+ * Rewrite a BMP into the one layout bmp-js actually parses: 40-byte
+ * BITMAPINFOHEADER, palette, pixels — with nothing in between. bmp-js never
+ * seeks to the header's declared pixel-data offset, so V4/V5 headers (124
+ * bytes from e.g. sips/Photoshop) decode shifted by the extra header bytes.
+ * Its BI_BITFIELDS path is also broken (reads masks, then ignores them), so
+ * standard-mask bitfields are converted to plain BI_RGB and anything with
+ * exotic masks is rejected.
+ */
+function normalizeBmp(bytes: Buffer): Buffer {
+  if (bytes.length < 54 || bytes.toString("latin1", 0, 2) !== "BM") {
+    throw new Error("not a BMP");
+  }
+  const dataOffset = bytes.readUInt32LE(10);
+  const dibSize = bytes.readUInt32LE(14);
+  const bpp = bytes.readUInt16LE(28);
+  const originalCompress = bytes.readUInt32LE(30);
+  let compress = originalCompress;
+
+  if (compress === 3) {
+    // Masks sit at absolute 54 in both layouts (after a 40-byte header, or as
+    // the V4/V5 header fields at DIB offset 40).
+    const [r, g, b] = [54, 58, 62].map((o) => bytes.readUInt32LE(o));
+    if (r !== STD_MASKS.r || g !== STD_MASKS.g || b !== STD_MASKS.b) {
+      throw new Error("unsupported BMP channel masks");
+    }
+    compress = 0;
+  }
+
+  const colors = bytes.readUInt32LE(46);
+  const paletteLen = bpp < 15 ? (colors === 0 ? 1 << bpp : colors) * 4 : 0;
+  const canonicalOffset = 14 + 40 + paletteLen;
+  if (dibSize === 40 && compress === originalCompress && dataOffset === canonicalOffset) {
+    return bytes; // already the layout bmp-js expects
+  }
+
+  const fileHeader = Buffer.from(bytes.subarray(0, 14));
+  fileHeader.writeUInt32LE(canonicalOffset, 10);
+  const dib = Buffer.from(bytes.subarray(14, 54));
+  dib.writeUInt32LE(40, 0);
+  dib.writeUInt32LE(compress, 16);
+  const palette = bytes.subarray(14 + dibSize, 14 + dibSize + paletteLen);
+  return Buffer.concat([fileHeader, dib, palette, bytes.subarray(dataOffset)]);
+}
+
+/** Decode a BMP and re-encode as PNG. Throws on malformed input. */
+export function bmpToPng(bytes: Buffer): Buffer {
+  const normalized = normalizeBmp(bytes);
+  const w = normalized.readInt32LE(18);
+  const h = Math.abs(normalized.readInt32LE(22));
+  if (w <= 0 || h === 0 || w * h > MAX_PIXELS) {
+    throw new Error(`BMP dimensions out of range: ${w}x${h}`);
+  }
+  const { width, height, data } = bmp.decode(normalized); // ABGR per pixel
+  const png = new PNG({ width, height });
+  let maxAlpha = 0;
+  for (let i = 0; i < data.length; i += 4) {
+    const a = data[i];
+    if (a > maxAlpha) maxAlpha = a;
+    png.data[i] = data[i + 3];
+    png.data[i + 1] = data[i + 2];
+    png.data[i + 2] = data[i + 1];
+    png.data[i + 3] = a;
+  }
+  // Alpha-less BMPs (24bpp and lower) decode with alpha 0 everywhere; that
+  // means opaque, not an invisible image.
+  if (maxAlpha === 0) {
+    for (let i = 3; i < png.data.length; i += 4) png.data[i] = 255;
+  }
+  return PNG.sync.write(png);
+}

--- a/web/tests/imgpng.test.ts
+++ b/web/tests/imgpng.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PNG } from "pngjs";
+import { bmpToPng, pngConvertible, WEB_SAFE_IMAGE } from "../src/lib/imgpng";
+
+// Hand-crafted 2x1 24bpp BMP: left pixel pure red, right pixel pure blue
+// (rows are BGR on disk, padded to 4 bytes) — pins the ABGR→RGBA swizzle.
+function tinyBmp(): Buffer {
+  const row = Buffer.from([0x00, 0x00, 0xff, 0xff, 0x00, 0x00, 0, 0]);
+  const dib = Buffer.alloc(40);
+  dib.writeUInt32LE(40, 0); // header size
+  dib.writeInt32LE(2, 4); // width
+  dib.writeInt32LE(1, 8); // height
+  dib.writeUInt16LE(1, 12); // planes
+  dib.writeUInt16LE(24, 14); // bpp
+  dib.writeUInt32LE(row.length, 20); // image size
+  const hdr = Buffer.alloc(14);
+  hdr.write("BM");
+  hdr.writeUInt32LE(14 + 40 + row.length, 2);
+  hdr.writeUInt32LE(54, 10); // pixel data offset
+  return Buffer.concat([hdr, dib, row]);
+}
+
+test("bmpToPng keeps channel order and makes 24bpp opaque", () => {
+  const png = PNG.sync.read(bmpToPng(tinyBmp()));
+  assert.equal(png.width, 2);
+  assert.equal(png.height, 1);
+  assert.deepEqual([...png.data.subarray(0, 4)], [255, 0, 0, 255]); // red, opaque
+  assert.deepEqual([...png.data.subarray(4, 8)], [0, 0, 255, 255]); // blue, opaque
+});
+
+// 2x1 32bpp BMP with a 124-byte V5 header and standard-mask BI_BITFIELDS
+// (what sips/Photoshop write) — pins the header normalization: bmp-js alone
+// mis-decodes these by reading extended-header bytes as pixels.
+function tinyBmpV5(): Buffer {
+  const row = Buffer.from([0x00, 0x00, 0xff, 0xff, 0xff, 0x00, 0x00, 0xff]); // BGRA: red, blue
+  const dib = Buffer.alloc(124);
+  dib.writeUInt32LE(124, 0); // V5 header size
+  dib.writeInt32LE(2, 4); // width
+  dib.writeInt32LE(1, 8); // height
+  dib.writeUInt16LE(1, 12); // planes
+  dib.writeUInt16LE(32, 14); // bpp
+  dib.writeUInt32LE(3, 16); // BI_BITFIELDS
+  dib.writeUInt32LE(row.length, 20);
+  dib.writeUInt32LE(0xff0000, 40); // R mask
+  dib.writeUInt32LE(0xff00, 44); // G mask
+  dib.writeUInt32LE(0xff, 48); // B mask
+  dib.writeUInt32LE(0xff000000, 52); // A mask
+  const hdr = Buffer.alloc(14);
+  hdr.write("BM");
+  hdr.writeUInt32LE(14 + 124 + row.length, 2);
+  hdr.writeUInt32LE(14 + 124, 10); // pixel data offset past the V5 header
+  return Buffer.concat([hdr, dib, row]);
+}
+
+test("bmpToPng handles V5-header bitfields BMPs (sips/Photoshop output)", () => {
+  const png = PNG.sync.read(bmpToPng(tinyBmpV5()));
+  assert.equal(png.width, 2);
+  assert.deepEqual([...png.data.subarray(0, 4)], [255, 0, 0, 255]); // red
+  assert.deepEqual([...png.data.subarray(4, 8)], [0, 0, 255, 255]); // blue
+});
+
+test("bmpToPng rejects exotic channel masks", () => {
+  const weird = tinyBmpV5();
+  weird.writeUInt32LE(0xf800, 14 + 40); // RGB565-style red mask
+  assert.throws(() => bmpToPng(weird), /masks/);
+});
+
+test("bmpToPng throws on garbage and absurd dimensions", () => {
+  assert.throws(() => bmpToPng(Buffer.from("not a bmp")));
+  const huge = tinyBmp();
+  huge.writeInt32LE(1_000_000, 18); // width
+  huge.writeInt32LE(1_000_000, 22); // height
+  assert.throws(() => bmpToPng(huge), /dimensions/);
+});
+
+test("web-safe and convertible mime classification", () => {
+  for (const m of ["image/png", "image/jpeg", "image/gif", "image/webp"]) {
+    assert.ok(WEB_SAFE_IMAGE.test(m), m);
+  }
+  for (const m of ["image/bmp", "image/x-icon", "image/svg+xml", "image/tiff"]) {
+    assert.ok(!WEB_SAFE_IMAGE.test(m), m);
+  }
+  assert.ok(pngConvertible("image/bmp"));
+  assert.ok(!pngConvertible("image/x-icon"));
+  assert.ok(!pngConvertible("image/svg+xml"));
+});


### PR DESCRIPTION
Link unfurlers (Discord, Slack, Twitter) and satori (the OG card renderer) don't handle BMP, so BMP screenshots — common in dumps — rendered as nothing in social previews. A new GET /api/asset/<sha256>/png converts BMP assets to PNG on the fly: content-addressed and immutable-cached like the raw asset route, with web-safe formats 308-redirecting to it. Asset deep links point og:image at the conversion for BMPs, the OG card's screenshot pane now includes BMP candidates (converted to a PNG data URI before satori sees them), and formats we can't convert (ico, svg) fall back to the build card instead of an og:image URL that won't render.

The conversion is pure JS (bmp-js + pngjs, no native deps), but bmp-js needed two workarounds. It never seeks to the header's declared pixel-data offset, so any BMP with a V4/V5 header — what sips or Photoshop write — decodes shifted by the extra header bytes, producing color-garbled output. And its BI_BITFIELDS path reads the channel masks then ignores them. A normalizer rewrites incoming BMPs into the one layout bmp-js parses correctly (plain 40-byte BITMAPINFOHEADER, palette, pixels), converts standard-mask bitfields to plain BI_RGB, and rejects exotic masks cleanly; vintage BMPs with plain headers pass through untouched. Alpha-less BMPs decode with a zeroed alpha channel, which is forced opaque so images don't unfurl invisible. The route caps input at 32MB and the decoder refuses absurd header-declared dimensions, since decode allocates width*height*4 up front from attacker-controlled bytes.

Tests cover the channel swizzle and normalization with hand-crafted fixtures: 24bpp plain-header, 32bpp V5 bitfields, exotic-mask rejection, and the dimension guard. Verified end-to-end against a staged BMP asset: pixel-perfect PNG from the route, correct og:image on the deep link, and the card pane rendering the converted screenshot.

Deploy note: adds bmp-js and pngjs, so the next deploy needs npm install (deploy.sh redeploy --deps).