### PR TITLE
Add hex previews for unidentified files

### DIFF
--- a/crates/curator-core/src/db.rs
+++ b/crates/curator-core/src/db.rs
@@ -263,6 +263,7 @@ mod tests {
             chunk_signature: None,
             resemblance: None,
             assets: None,
+            asset_profile: 0,
         }
     }
 

--- a/crates/curator-core/src/lib.rs
+++ b/crates/curator-core/src/lib.rs
@@ -84,14 +84,16 @@ impl Analyzer {
         // 1. Image identity (single streaming read in Rust).
         let image = fingerprint::hash_image(path, &observer)?;
 
-        // 2. Cache short-circuit. Pre-assets records (assets == None) get topped
-        // up here — extraction alone, no re-hash — so re-running analyze over an
-        // existing collection backfills its asset store.
+        // 2. Cache short-circuit. Records whose assets predate the current
+        // ASSET_PROFILE (or never ran, assets == None) get topped up here —
+        // extraction alone, no re-hash — so re-running analyze over an existing
+        // collection backfills its asset store.
         if let Some(mut record) = self.cache.load(&image.sha256)? {
             observer.on_event(Event::Message(format!("cache hit {}", image.sha256)));
-            if record.assets.is_none() {
+            if record.assets.is_none() || record.asset_profile < schema::ASSET_PROFILE {
                 if let Some(assets) = self.extract_assets(path, &observer)? {
                     record.assets = Some(assets);
+                    record.asset_profile = schema::ASSET_PROFILE;
                     let xml = render::to_dat_xml(&record);
                     let jp = self.cache.store(&record, &xml)?;
                     self.db.upsert_build(&record, &jp.to_string_lossy())?;
@@ -158,10 +160,12 @@ impl Analyzer {
         let sidecar = fingerprint::chunk_sidecar(&raw.files);
         let contents = fingerprint::build_tree(&raw.files);
 
-        // Asset pass: pull browser-viewable files (images/audio/text ≤ 20MB) into
-        // the content-addressed store. Enrichment only — a failure is reported and
-        // leaves `assets` unset (None), so the next analyze retries it.
+        // Asset pass: pull browser-viewable files (images/audio/text ≤ 20MB) whole
+        // and every other file's head snippet into the content-addressed store.
+        // Enrichment only — a failure is reported and leaves `assets` unset
+        // (None), so the next analyze retries it.
         let assets = self.extract_assets(path, &observer)?;
+        let asset_profile = if assets.is_some() { schema::ASSET_PROFILE } else { 0 };
 
         let record = BuildRecord {
             record_schema_version: schema::RECORD_SCHEMA_VERSION,
@@ -197,6 +201,7 @@ impl Analyzer {
             chunk_signature,
             resemblance,
             assets,
+            asset_profile,
         };
 
         // 5. Render, cache, index.

--- a/crates/curator-core/src/schema.rs
+++ b/crates/curator-core/src/schema.rs
@@ -11,6 +11,11 @@ use serde::{Deserialize, Serialize};
 pub const RECORD_SCHEMA_VERSION: u32 = 1;
 /// Algorithm manifest in force. See `fingerprint::profile`.
 pub const FINGERPRINT_PROFILE: &str = "v1";
+/// Asset-extraction generation. 1 = browser-viewable kinds only (implicit in
+/// records that predate the field, which deserialize to 0); 2 = also head
+/// snippets (`kind: "binary"`) for every file that isn't viewable. A record
+/// below the current value gets its assets re-extracted on the next analyze.
+pub const ASSET_PROFILE: u32 = 2;
 
 /// A fully analyzed disc image / container — image-independent and self-describing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,11 +41,16 @@ pub struct BuildRecord {
     /// Byte-shingle resemblance signature (OPH). Survives many small scattered edits.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resemblance: Option<Signature>,
-    /// Browser-viewable files extracted into the asset store (images, audio,
-    /// text ≤ 20MB). `None` = extraction never ran (pre-assets record — analyze
-    /// tops it up on the next cache hit); `Some(vec![])` = ran, nothing viewable.
+    /// Files extracted into the asset store: browser-viewable ones whole
+    /// (images, audio, text ≤ 20MB), everything else as a raw head snippet for
+    /// the hex view. `None` = extraction never ran (pre-assets record — analyze
+    /// tops it up on the next cache hit); `Some(vec![])` = ran, nothing kept.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assets: Option<Vec<AssetRef>>,
+    /// [`ASSET_PROFILE`] the assets were extracted under; analyze re-extracts
+    /// when it lags the current constant, so collections backfill on re-runs.
+    #[serde(default)]
+    pub asset_profile: u32,
 }
 
 /// One extracted asset: where it sat on the disc and how to serve it. The blob
@@ -52,7 +62,7 @@ pub struct AssetRef {
     pub sha256: String,
     pub size: u64,
     pub mime: String,
-    pub kind: String, // "image" | "audio" | "video" | "source" | "text"
+    pub kind: String, // "image" | "audio" | "video" | "source" | "text" | "binary" (head snippet)
 }
 
 /// Image-level identity. `sha256` is the primary key everywhere.
@@ -355,6 +365,7 @@ mod tests {
             chunk_signature: None,
             resemblance: None,
             assets: None,
+            asset_profile: 0,
         };
         let j = serde_json::to_string(&rec).unwrap();
         assert!(!j.contains("\"header\""), "empty header should be skipped: {j}");

--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -964,12 +964,13 @@ mod app {
     }
 
     /// Display order + section titles for asset kinds — mirrors the web build pages.
-    const ASSET_KINDS: [(&str, &str); 5] = [
+    const ASSET_KINDS: [(&str, &str); 6] = [
         ("image", "Images"),
         ("audio", "Audio"),
         ("video", "Video"),
         ("source", "Source code"),
         ("text", "Text"),
+        ("binary", "Unidentified"),
     ];
 
     /// Fill the grouped ListView with the loaded build's assets (one group per kind)
@@ -983,7 +984,7 @@ mod app {
                 rows: vec![(
                     "Status".into(),
                     if st.assets_extracted {
-                        "No browser-viewable assets in this build.".into()
+                        "No extractable assets in this build.".into()
                     } else {
                         "Asset extraction hasn't run for this build — re-analyze the image.".into()
                     },
@@ -1856,7 +1857,8 @@ mod app {
     /// temp copy carrying the original filename (store blobs are extensionless, so
     /// the shell can't pick a handler for them directly). Text and source kinds
     /// always open in Notepad: handing a `.bat`/`.cmd`/`.js` from an untrusted
-    /// disc to the shell's default verb would execute it.
+    /// disc to the shell's default verb would execute it. Binary kinds
+    /// (unidentified files' head snippets) open in Notepad as a hex dump.
     unsafe fn open_asset_at(hwnd: HWND, idx: usize) {
         ensure_reader(hwnd);
         let (asset, blob) = {
@@ -1869,7 +1871,12 @@ mod app {
             set_status(hwnd, "Asset not in the local store — re-analyze the image to extract it.");
             return;
         };
-        let path = match materialize_asset(&asset, &blob) {
+        let staged = if asset.kind == "binary" {
+            materialize_hexdump(&asset, &blob)
+        } else {
+            materialize_asset(&asset, &blob)
+        };
+        let path = match staged {
             Ok(p) => p,
             Err(e) => {
                 set_status(hwnd, &format!("Couldn't stage asset: {e}"));
@@ -1877,7 +1884,7 @@ mod app {
             }
         };
         let path_str = path.to_string_lossy().into_owned();
-        let launched = if matches!(asset.kind.as_str(), "text" | "source") {
+        let launched = if matches!(asset.kind.as_str(), "text" | "source" | "binary") {
             let args = wide(&format!("\"{path_str}\""));
             ShellExecuteW(hwnd, w!("open"), w!("notepad.exe"), PCWSTR(args.as_ptr()), PCWSTR::null(), SW_SHOWNORMAL)
         } else {
@@ -1915,6 +1922,46 @@ mod app {
             std::fs::copy(blob, &dest).map_err(|e| e.to_string())?;
         }
         Ok(dest)
+    }
+
+    /// Render an unidentified file's head-snippet blob as an xxd-style dump in a
+    /// temp .txt for Notepad (the raw bytes would be garbage there). Layout
+    /// lives here, display-side — the store keeps the raw bytes.
+    fn materialize_hexdump(asset: &AssetRef, blob: &std::path::Path) -> std::result::Result<PathBuf, String> {
+        let dir = std::env::temp_dir().join("curator-assets").join(&asset.sha256);
+        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        let dest = dir.join("hexdump.txt");
+        if !dest.exists() {
+            let data = std::fs::read(blob).map_err(|e| e.to_string())?;
+            std::fs::write(&dest, hexdump(&data)).map_err(|e| e.to_string())?;
+        }
+        Ok(dest)
+    }
+
+    /// Classic xxd layout: 8-hex offset, 16 bytes as 2-byte groups, ASCII gutter.
+    fn hexdump(data: &[u8]) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::with_capacity(data.len() * 5);
+        for (i, row) in data.chunks(16).enumerate() {
+            let _ = write!(out, "{:08x}: ", i * 16);
+            for j in 0..16 {
+                match row.get(j) {
+                    Some(b) => {
+                        let _ = write!(out, "{b:02x}");
+                    }
+                    None => out.push_str("  "),
+                }
+                if j % 2 == 1 {
+                    out.push(' ');
+                }
+            }
+            out.push(' ');
+            for &b in row {
+                out.push(if (0x20..0x7f).contains(&b) { b as char } else { '.' });
+            }
+            out.push_str("\r\n");
+        }
+        out
     }
 
     // ---- web service: Find Similar / Submit ----

--- a/macos/Sources/CuratorApp/AppModel.swift
+++ b/macos/Sources/CuratorApp/AppModel.swift
@@ -32,12 +32,14 @@ enum DetailTab: Hashable {
 }
 
 /// An in-app preview of one text asset (never shell-opened — a `.sh`/`.bat`/`.js`
-/// from an untrusted disc must not reach an app that might execute it).
+/// from an untrusted disc must not reach an app that might execute it) or of an
+/// unidentified file's head snippet rendered as a hex dump.
 struct AssetTextPreview: Identifiable {
     let id: String // asset sha256
     let name: String
     let text: String
-    let truncated: Bool
+    /// Caption under the preview (truncation / snippet notice), if any.
+    let note: String?
 }
 
 /// Forwards UniFFI progress callbacks (delivered on a background thread) to a main-actor sink.
@@ -332,10 +334,15 @@ final class AppModel: ObservableObject {
     /// copy carrying the original filename (blobs are extensionless, so the
     /// store path alone can't pick a handler). Text and source kinds preview
     /// in-app only: shell-opening a `.sh`/`.bat`/`.js` from an untrusted disc
-    /// could hand it to something that executes it.
+    /// could hand it to something that executes it. Binary kinds (unidentified
+    /// files' head snippets) preview in-app as a hex dump.
     func openAsset(_ asset: AssetInfo) {
         guard let blob = asset.blobPath else {
             status = "Asset not in the local store — re-analyze the image to extract it."
+            return
+        }
+        if asset.kind == "binary" {
+            previewHexAsset(asset, blob: blob)
             return
         }
         if asset.kind == "text" || asset.kind == "source" {
@@ -368,8 +375,51 @@ final class AppModel: ObservableObject {
             id: asset.sha256,
             name: (asset.path as NSString).lastPathComponent,
             text: text,
-            truncated: asset.size > UInt64(capBytes)
+            note: asset.size > UInt64(capBytes) ? "Preview truncated to the first 256 KB." : nil
         )
+    }
+
+    /// The analyzer stores only this much of an unidentified file (viewable.py
+    /// SNIPPET_BYTES) — a blob this long is (almost surely) a truncated head.
+    private static let snippetBytes = 2048
+
+    /// Show an unidentified file's stored head snippet as an xxd-style hex dump.
+    private func previewHexAsset(_ asset: AssetInfo, blob: String) {
+        guard let data = FileManager.default.contents(atPath: blob) else {
+            status = "Couldn't read asset from the local store."
+            return
+        }
+        assetPreview = AssetTextPreview(
+            id: asset.sha256,
+            name: (asset.path as NSString).lastPathComponent,
+            text: hexDump(data),
+            note: asset.size >= UInt64(Self.snippetBytes)
+                ? "Unidentified file — only its first 2 KB is stored." : nil
+        )
+    }
+
+    /// Classic xxd layout: 8-hex offset, 16 bytes as 2-byte groups, ASCII gutter.
+    /// Rendered at display time from the raw stored bytes, so the layout can
+    /// change without re-analyzing anything.
+    private func hexDump(_ data: Data) -> String {
+        var out = ""
+        var offset = 0
+        while offset < data.count {
+            let end = min(offset + 16, data.count)
+            out += String(format: "%08x: ", offset)
+            for j in 0..<16 {
+                out += offset + j < end ? String(format: "%02x", data[data.startIndex + offset + j]) : "  "
+                if j % 2 == 1 { out += " " }
+            }
+            out += " "
+            for i in offset..<end {
+                let b = data[data.startIndex + i]
+                out.append(b >= 0x20 && b < 0x7f ? Character(UnicodeScalar(b)) : ".")
+            }
+            out += "\n"
+            offset = end
+        }
+        return out
     }
 
     /// Copy a blob into a per-asset temp dir under its original filename so

--- a/macos/Sources/CuratorApp/ContentView.swift
+++ b/macos/Sources/CuratorApp/ContentView.swift
@@ -467,7 +467,7 @@ struct DocumentView: View {
 // MARK: - Assets (browser-viewable files extracted from the build)
 
 /// Display order for asset kinds — mirrors the web build pages.
-private let assetKindOrder = ["image", "audio", "video", "source", "text"]
+private let assetKindOrder = ["image", "audio", "video", "source", "text", "binary"]
 
 private func assetKindIcon(_ kind: String) -> String {
     switch kind {
@@ -475,12 +475,17 @@ private func assetKindIcon(_ kind: String) -> String {
     case "audio": return "music.note"
     case "video": return "film"
     case "source": return "chevron.left.forwardslash.chevron.right"
+    case "binary": return "number"
     default: return "doc.text"
     }
 }
 
 private func assetKindTitle(_ kind: String) -> String {
-    kind == "source" ? "Source code" : kind.capitalized
+    switch kind {
+    case "source": return "Source code"
+    case "binary": return "Unidentified"
+    default: return kind.capitalized
+    }
 }
 
 struct AssetsView: View {
@@ -501,7 +506,7 @@ struct AssetsView: View {
                 systemImage: "photo.on.rectangle",
                 message: summary.assets == nil
                     ? "Asset extraction hasn't run for this build yet — re-analyze the image to extract viewable files."
-                    : "This build carries no browser-viewable images, audio, video, source, or text."
+                    : "This build carries no extractable assets."
             )
         } else {
             ScrollView {
@@ -600,7 +605,7 @@ struct AssetMenu: View {
     let asset: AssetInfo
 
     var body: some View {
-        Button(asset.kind == "text" || asset.kind == "source" ? "Preview" : "Open") { model.openAsset(asset) }
+        Button(["text", "source", "binary"].contains(asset.kind) ? "Preview" : "Open") { model.openAsset(asset) }
         Button("Copy SHA-256") {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(asset.sha256, forType: .string)
@@ -608,7 +613,8 @@ struct AssetMenu: View {
     }
 }
 
-/// In-app viewer for text assets (they are never handed to the shell).
+/// In-app viewer for text assets (they are never handed to the shell) and for
+/// unidentified files' head snippets rendered as hex dumps.
 struct AssetTextSheet: View {
     let preview: AssetTextPreview
     @Environment(\.dismiss) private var dismiss
@@ -626,8 +632,8 @@ struct AssetTextSheet: View {
             .frame(minWidth: 480, minHeight: 240, maxHeight: 480)
             .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
             HStack {
-                if preview.truncated {
-                    Text("Preview truncated to the first 256 KB.")
+                if let note = preview.note {
+                    Text(note)
                         .font(.caption).foregroundStyle(.secondary)
                 }
                 Spacer()

--- a/ps2exe-adapter/curator_adapter/cli.py
+++ b/ps2exe-adapter/curator_adapter/cli.py
@@ -705,27 +705,44 @@ def _extract_assets(reader, out_dir, manager):
 
     # Candidate list first, bytes second — the same two-step the hashing pass
     # uses, so one-pass archive streams see opens in iterator order only.
+    # Every non-empty file is a candidate: viewable types ship whole, everything
+    # else (unknown extension, oversized, sniff mismatch below) ships as a raw
+    # head snippet the UIs render as a hex view.
     entries = []
     for f in reader.iso_iterator(reader.get_root_dir(), recursive=True, include_dirs=False):
         path = _clean_path(reader.get_file_path(f))
-        classified = viewable.classify(path)
-        if classified is None:
-            continue
         try:
             size = int(reader.get_file_size(f))
         except Exception:  # noqa: BLE001
             size = None
-        if size is not None and (size == 0 or size > viewable.MAX_ASSET_SIZE):
+        if size == 0:
             continue
+        classified = viewable.classify(path)
+        if classified is not None and size is not None and size > viewable.MAX_ASSET_SIZE:
+            classified = None  # too big to serve whole — keep the head snippet only
         entries.append((f, path, classified))
 
     out = []
     with manager.counter(total=len(entries), desc="Extracting assets", unit="files") as pbar:
-        for f, path, (kind, mime) in entries:
-            data = _read_capped(reader, f, viewable.MAX_ASSET_SIZE)
+        for f, path, classified in entries:
+            if classified is None:
+                head = _read_head(reader, f, viewable.SNIPPET_BYTES)
+                asset = (head, viewable.SNIPPET_MIME, viewable.SNIPPET_KIND) if head else None
+            else:
+                kind, mime = classified
+                data = _read_capped(reader, f, viewable.MAX_ASSET_SIZE)
+                if data and viewable.sniff(data[: viewable.SNIFF_BYTES], mime):
+                    asset = (data, mime, kind)
+                elif data:
+                    # Extension claimed a viewable type but the bytes disagree —
+                    # keep the head snippet, same as any unidentified file.
+                    asset = (data[: viewable.SNIPPET_BYTES], viewable.SNIPPET_MIME, viewable.SNIPPET_KIND)
+                else:
+                    asset = None
             pbar.update()
-            if not data or not viewable.sniff(data[: viewable.SNIFF_BYTES], mime):
+            if asset is None:
                 continue
+            data, mime, kind = asset
             sha = hashlib.sha256(data).hexdigest()
             _store_blob(out_dir, sha, data)
             out.append({"path": path, "sha256": sha, "size": len(data), "mime": mime, "kind": kind})
@@ -753,6 +770,27 @@ def _read_capped(reader, f, cap):
         logging.getLogger("curator-adapter").debug("asset read failed: %s", e)
         return None
     return bytes(buf)
+
+
+def _read_head(reader, f, n):
+    """The file's first `n` bytes (the whole file when shorter), or None when
+    unreadable or empty."""
+    buf = bytearray()
+    try:
+        fh = reader.open_file(f)
+        is_ctx = hasattr(fh, "__enter__")
+        if is_ctx:
+            fh.__enter__()
+        try:
+            while len(buf) < n and (chunk := fh.read(min(65536, n - len(buf)))):
+                buf.extend(chunk)
+        finally:
+            with contextlib.suppress(Exception):
+                fh.__exit__(None, None, None) if is_ctx else fh.close()
+    except Exception as e:  # noqa: BLE001
+        logging.getLogger("curator-adapter").debug("asset head read failed: %s", e)
+        return None
+    return bytes(buf) if buf else None
 
 
 def _store_blob(out_dir, sha, data):

--- a/ps2exe-adapter/curator_adapter/viewable.py
+++ b/ps2exe-adapter/curator_adapter/viewable.py
@@ -6,11 +6,18 @@ served as text/plain — never text/html — so a crafted HTML file in a dump
 can't script against the web origin.
 """
 
-# Hard cap on extracted asset size. Files past this are skipped outright.
+# Hard cap on extracted asset size. Files past this fall back to a head snippet.
 MAX_ASSET_SIZE = 20 * 1024 * 1024
 
 # How many leading bytes sniffing needs (SVG tag scan is the long pole).
 SNIFF_BYTES = 4096
+
+# Files nothing below claims (plus sniff failures and oversized candidates) are
+# still shipped: their leading bytes go into the store raw, so the UIs can show
+# a hex view — and change how they render it without re-analyzing collections.
+SNIPPET_BYTES = 2048
+SNIPPET_KIND = "binary"
+SNIPPET_MIME = "application/octet-stream"
 
 _IMAGE = {
     "png": "image/png",

--- a/ps2exe-adapter/tests/test_assets.py
+++ b/ps2exe-adapter/tests/test_assets.py
@@ -1,0 +1,87 @@
+import hashlib
+import io
+
+from curator_adapter import viewable
+from curator_adapter.cli import _extract_assets
+from curator_adapter.progress import ProgressManager
+
+
+class FakeReader:
+    """Minimal reader: files as {path: bytes}."""
+
+    def __init__(self, files):
+        self.files = list(files.items())
+
+    def get_root_dir(self):
+        return None
+
+    def iso_iterator(self, _root, recursive=True, include_dirs=False):
+        return iter(range(len(self.files)))
+
+    def get_file_path(self, f):
+        return self.files[f][0]
+
+    def get_file_size(self, f):
+        return len(self.files[f][1])
+
+    def open_file(self, f):
+        return io.BytesIO(self.files[f][1])
+
+
+def extract(files, tmp_path):
+    out = _extract_assets(FakeReader(files), str(tmp_path), ProgressManager())
+    return {a["path"]: a for a in out}
+
+
+def blob(tmp_path, sha):
+    return (tmp_path / sha[:2] / sha).read_bytes()
+
+
+def test_viewable_files_ship_whole(tmp_path):
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+    assets = extract({"/GFX/TITLE.PNG": png}, tmp_path)
+    a = assets["/GFX/TITLE.PNG"]
+    assert (a["kind"], a["mime"], a["size"]) == ("image", "image/png", len(png))
+    assert blob(tmp_path, a["sha256"]) == png
+
+
+def test_unidentified_files_ship_head_snippet(tmp_path):
+    data = bytes(range(256)) * 20  # 5120 bytes of binary
+    assets = extract({"/DATA/GAME.TIM": data}, tmp_path)
+    a = assets["/DATA/GAME.TIM"]
+    assert (a["kind"], a["mime"]) == (viewable.SNIPPET_KIND, viewable.SNIPPET_MIME)
+    assert a["size"] == viewable.SNIPPET_BYTES
+    head = data[: viewable.SNIPPET_BYTES]
+    assert a["sha256"] == hashlib.sha256(head).hexdigest()
+    assert blob(tmp_path, a["sha256"]) == head
+
+
+def test_snippet_of_short_file_is_whole_file(tmp_path):
+    data = b"MZ\x90\x00tiny"
+    assets = extract({"/BOOT.XBE": data}, tmp_path)
+    a = assets["/BOOT.XBE"]
+    assert a["kind"] == viewable.SNIPPET_KIND
+    assert a["size"] == len(data)
+    assert blob(tmp_path, a["sha256"]) == data
+
+
+def test_sniff_mismatch_falls_back_to_snippet(tmp_path):
+    renamed = b"MZ\x00\x01\x02\x03" + bytes(range(1, 32)) * 100  # binary named .TXT
+    assets = extract({"/README.TXT": renamed}, tmp_path)
+    a = assets["/README.TXT"]
+    assert a["kind"] == viewable.SNIPPET_KIND
+    assert a["size"] == viewable.SNIPPET_BYTES
+    assert blob(tmp_path, a["sha256"]) == renamed[: viewable.SNIPPET_BYTES]
+
+
+def test_oversized_viewable_demoted_to_snippet(tmp_path, monkeypatch):
+    monkeypatch.setattr(viewable, "MAX_ASSET_SIZE", 64)
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 200
+    assets = extract({"/BIG.PNG": png}, tmp_path)
+    a = assets["/BIG.PNG"]
+    assert a["kind"] == viewable.SNIPPET_KIND
+    assert blob(tmp_path, a["sha256"]) == png[: viewable.SNIPPET_BYTES]
+
+
+def test_empty_files_are_skipped(tmp_path):
+    assert extract({"/EMPTY.BIN": b""}, tmp_path) == {}

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -60,16 +60,18 @@ CREATE INDEX idx_files_sha1      ON files(sha1);
 CREATE INDEX idx_files_md5       ON files(md5);
 CREATE INDEX idx_files_sha256    ON files(sha256);
 
--- ── per-build viewable assets (images/audio/text ≤ 20MB) ─────────────────────
+-- ── per-build extracted assets ────────────────────────────────────────────────
 -- Metadata for the build page's inline asset viewer; the bytes live in the
 -- content-addressed blob store on disk (ASSET_STORE_DIR), filled at ingest.
+-- Browser-viewable files (images/audio/text ≤ 20MB) are stored whole; every
+-- other file's first 2KB is stored raw (kind 'binary') for the hex view.
 CREATE TABLE build_asset (
     build_sha256 TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE,
     path         TEXT NOT NULL,           -- full path within the build (matches files.path)
     sha256       TEXT NOT NULL,           -- content hash = key into the blob store
-    size         BIGINT NOT NULL,
+    size         BIGINT NOT NULL,         -- stored blob size (a head snippet's, not the file's)
     mime         TEXT NOT NULL,           -- as served; text is always text/plain
-    kind         TEXT NOT NULL,           -- image|audio|video|source|text
+    kind         TEXT NOT NULL,           -- image|audio|video|source|text|binary
     PRIMARY KEY (build_sha256, path)
 );
 CREATE INDEX idx_build_asset_sha256 ON build_asset(sha256);

--- a/web/src/app/builds/[buildId]/AssetGallery.tsx
+++ b/web/src/app/builds/[buildId]/AssetGallery.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 // Grouped preview of a build's viewable assets: image thumbnails, audio embeds
-// with waveforms, small video players, text excerpt cards. The server page
-// passes an already-capped subset plus the full per-kind totals; when a kind is
+// with waveforms, small video players, text excerpt cards, hex-preview cards
+// for unidentified files' head snippets. The server page passes an
+// already-capped subset plus the full per-kind totals; when a kind is
 // truncated, a "view all" affordance links to <buildHref>/assets.
 // Images and text open the page's AssetViewerHost lightbox (shared with the
 // file tree), which also deep-links the asset in the URL.
@@ -19,6 +20,7 @@ const SECTIONS: { kind: string; title: string }[] = [
   { kind: "video", title: "Video" },
   { kind: "source", title: "Source code" },
   { kind: "text", title: "Text" },
+  { kind: "binary", title: "Unidentified" },
 ];
 
 function baseName(path: string): string {
@@ -106,7 +108,7 @@ export default function AssetGallery({
               </div>
             )}
 
-            {(kind === "source" || kind === "text") && (
+            {(kind === "source" || kind === "text" || kind === "binary") && (
               <div className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
                 {group.map((a) => (
                   <button
@@ -121,6 +123,7 @@ export default function AssetGallery({
                       </span>
                       <span className="shrink-0 text-[10px] text-neutral-400">{humanSize(a.size)}</span>
                     </div>
+                    {/* Binary cards preview the head snippet as spaced hex pairs. */}
                     <pre className="mt-1.5 line-clamp-4 whitespace-pre-wrap break-words font-mono text-[11px] leading-4 text-neutral-500">
                       {kind === "source" ? (
                         <SourceCode path={a.path} text={excerpts[a.path] ?? ""} />

--- a/web/src/app/builds/[buildId]/AssetViewer.tsx
+++ b/web/src/app/builds/[buildId]/AssetViewer.tsx
@@ -5,6 +5,7 @@
 // once seen comes back from browser cache). ← → step through the list, Esc closes.
 
 import { useEffect, useState } from "react";
+import { hexDump } from "@/lib/hexdump";
 import SourceCode from "./SourceCode";
 
 /** Mirrors queries.ts BuildAsset — redeclared here so client components don't
@@ -14,7 +15,7 @@ export interface ViewableAsset {
   sha256: string;
   size: number;
   mime: string;
-  kind: string; // image | audio | video | source | text
+  kind: string; // image | audio | video | source | text | binary
 }
 
 export function assetUrl(a: ViewableAsset): string {
@@ -74,6 +75,48 @@ function TextBody({ asset }: { asset: ViewableAsset }) {
   );
 }
 
+// The analyzer stores only this much of an unidentified file (viewable.py
+// SNIPPET_BYTES) — a blob exactly this long is (almost surely) a truncated head.
+const SNIPPET_BYTES = 2048;
+
+// Unidentified files: xxd-style hex view over the stored head snippet. The
+// blob is raw bytes, so this rendering can evolve without re-analysis.
+function HexBody({ asset }: { asset: ViewableAsset }) {
+  const url = assetUrl(asset);
+  const [state, setState] = useState<Uint8Array | "loading" | "error">("loading");
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const buf = await res.arrayBuffer();
+        if (!cancelled) setState(new Uint8Array(buf));
+      } catch {
+        if (!cancelled) setState("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (state === "loading") return <p className="p-6 text-sm text-neutral-400">Loading…</p>;
+  if (state === "error") return <p className="p-6 text-sm text-red-500">Failed to load file.</p>;
+  return (
+    <div className="max-h-[70vh] overflow-auto rounded bg-white p-4 dark:bg-neutral-900">
+      <pre className="whitespace-pre font-mono text-xs leading-5 text-neutral-800 dark:text-neutral-200">
+        {hexDump(state)}
+      </pre>
+      {asset.size >= SNIPPET_BYTES && (
+        <p className="mt-3 text-xs text-neutral-400">
+          Unidentified file — only its first 2 KB is stored.
+        </p>
+      )}
+    </div>
+  );
+}
+
 function Body({ asset }: { asset: ViewableAsset }) {
   const [failed, setFailed] = useState(false);
   const url = assetUrl(asset);
@@ -104,6 +147,8 @@ function Body({ asset }: { asset: ViewableAsset }) {
           onError={() => setFailed(true)}
         />
       );
+    case "binary":
+      return <HexBody asset={asset} />;
     default:
       return <TextBody asset={asset} />;
   }

--- a/web/src/app/builds/[buildId]/FileTree.tsx
+++ b/web/src/app/builds/[buildId]/FileTree.tsx
@@ -12,7 +12,7 @@ import { type ViewableAsset } from "./AssetViewer";
 import { useOpenAsset } from "./AssetViewerHost";
 
 // Chip label on viewable file rows, by asset kind.
-const KIND_TAG: Record<string, string> = { image: "img", audio: "aud", video: "vid", source: "src", text: "txt" };
+const KIND_TAG: Record<string, string> = { image: "img", audio: "aud", video: "vid", source: "src", text: "txt", binary: "hex" };
 
 function humanSize(bytes?: number): string {
   if (bytes == null) return "—";

--- a/web/src/app/builds/[buildId]/assets/[[...path]]/page.tsx
+++ b/web/src/app/builds/[buildId]/assets/[[...path]]/page.tsx
@@ -4,7 +4,7 @@ import { notFound, permanentRedirect } from "next/navigation";
 import type { Pool } from "pg";
 import { getPool } from "@/lib/db";
 import { getBuildAssets, resolveBuild, type BuildAsset } from "@/lib/queries";
-import { assetTotals, orderAssets, readAssetExcerpt } from "@/lib/assets";
+import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
 import { pngConvertible, WEB_SAFE_IMAGE } from "@/lib/imgpng";
 import { humanSize } from "@/lib/meta";
 import { canonicalBuildId, parseBuildParam, safeDecodeSegment } from "@/lib/slug";
@@ -112,14 +112,7 @@ export default async function BuildAssetsPage({
 
   const assets = await getBuildAssets(pool, sha256);
   const ordered = orderAssets(assets);
-  const excerpts = Object.fromEntries(
-    await Promise.all(
-      ordered
-        .filter((a) => a.kind === "source" || a.kind === "text")
-        .slice(0, MAX_EXCERPT_READS)
-        .map(async (a) => [a.path, (await readAssetExcerpt(a.sha256)) ?? ""] as const)
-    )
-  );
+  const excerpts = await assetExcerpts(ordered, MAX_EXCERPT_READS);
 
   // Deep link: open the viewer on the named file. Unknown paths (e.g. a file
   // that exists but isn't viewable) just render the plain gallery.

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -6,7 +6,7 @@ import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
 import { buildTree, initialExpanded, pruneToExpanded, treeCounts } from "@/lib/filetree";
 import { getBuild, getBuildAssets, getBuildMeta, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, resolveBuild } from "@/lib/queries";
-import { assetTotals, orderAssets, readAssetExcerpt } from "@/lib/assets";
+import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
 import { buildDescription, displayTitle } from "@/lib/meta";
 import { canonicalBuildId, parseBuildParam } from "@/lib/slug";
 import type { BuildRecord } from "@/lib/types";
@@ -17,7 +17,7 @@ import AssetViewerHost from "./AssetViewerHost";
 
 // The assets section previews at most this many items per kind; the rest live
 // on /builds/<id>/assets.
-const ASSET_PREVIEW_PER_KIND = { image: 30, audio: 20, video: 10, source: 10, text: 10 };
+const ASSET_PREVIEW_PER_KIND = { image: 30, audio: 20, video: 10, source: 10, text: 10, binary: 9 };
 
 export const runtime = "nodejs";
 // The corpus only changes at ingest; render once and serve cached for an hour
@@ -151,15 +151,9 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
   for (const f of fused) f.caps = caps.get(f.sha256) ?? [];
 
   // Preview subset for the assets section, plus server-read excerpts for its
-  // source/text cards (tiny head reads from the local blob store).
+  // source/text/binary cards (tiny head reads from the local blob store).
   const previewAssets = orderAssets(assets, ASSET_PREVIEW_PER_KIND);
-  const excerpts = Object.fromEntries(
-    await Promise.all(
-      previewAssets
-        .filter((a) => a.kind === "source" || a.kind === "text")
-        .map(async (a) => [a.path, (await readAssetExcerpt(a.sha256)) ?? ""] as const)
-    )
-  );
+  const excerpts = await assetExcerpts(previewAssets);
 
   // Ship only the initially-visible subtree; FileTree lazily fetches the rest.
   const tree = buildTree(build.record.contents);
@@ -183,7 +177,7 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
         <Chip>{build.file_count} files</Chip>
         <Chip>{humanSize(build.total_size)}</Chip>
         <Chip>profile {build.fingerprint_profile}</Chip>
-        {assets.length > 0 && <Chip>{assets.length} viewable</Chip>}
+        {assets.length > 0 && <Chip>{assets.length} assets</Chip>}
       </div>
 
       <dl className="mt-4 grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-sm">
@@ -222,7 +216,7 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
       {assets.length > 0 && (
         <section className="mt-8">
           <h2 className="text-lg font-medium">
-            Assets <span className="text-sm font-normal text-neutral-400">({assets.length} viewable)</span>
+            Assets <span className="text-sm font-normal text-neutral-400">({assets.length})</span>
           </h2>
           <AssetGallery buildHref={href} assets={previewAssets} totals={assetTotals(assets)} excerpts={excerpts} />
         </section>

--- a/web/src/lib/assets.ts
+++ b/web/src/lib/assets.ts
@@ -4,6 +4,7 @@
 
 import path from "node:path";
 import { open } from "node:fs/promises";
+import { hexPreview } from "./hexdump";
 
 /** Root of the blob store. Blobs live at `<root>/<sha256[:2]>/<sha256>`. */
 export function assetStoreDir(): string {
@@ -23,7 +24,7 @@ export function assetStagingPath(sha256: string): string {
 }
 
 /** Display order for asset kinds on the build pages. */
-export const ASSET_KIND_ORDER = ["image", "audio", "video", "source", "text"] as const;
+export const ASSET_KIND_ORDER = ["image", "audio", "video", "source", "text", "binary"] as const;
 
 /** Per-kind asset counts. */
 export function assetTotals(assets: { kind: string }[]): Record<string, number> {
@@ -43,21 +44,54 @@ export function orderAssets<T extends { kind: string }>(
   return ASSET_KIND_ORDER.flatMap((k) => assets.filter((a) => a.kind === k).slice(0, cap(k)));
 }
 
-/** Leading bytes of a text blob decoded as lossy UTF-8 for an excerpt card, or
- *  null when the blob is missing from the store. */
-export async function readAssetExcerpt(sha256: string, maxBytes = 2048): Promise<string | null> {
+/** Leading bytes of a blob, or null when it is missing from the store. */
+export async function readAssetBytes(sha256: string, maxBytes = 2048): Promise<Buffer | null> {
   let fh;
   try {
     fh = await open(assetBlobPath(sha256), "r");
     const buf = Buffer.alloc(maxBytes);
     const { bytesRead } = await fh.read(buf, 0, maxBytes, 0);
-    return new TextDecoder("utf-8", { fatal: false })
-      .decode(buf.subarray(0, bytesRead))
-      .replace(/\u0000/g, "")
-      .replace(/\r\n?/g, "\n");
+    return buf.subarray(0, bytesRead);
   } catch {
     return null;
   } finally {
     await fh?.close();
   }
+}
+
+/** Leading bytes of a text blob decoded as lossy UTF-8 for an excerpt card, or
+ *  null when the blob is missing from the store. */
+export async function readAssetExcerpt(sha256: string, maxBytes = 2048): Promise<string | null> {
+  const buf = await readAssetBytes(sha256, maxBytes);
+  if (buf === null) return null;
+  return new TextDecoder("utf-8", { fatal: false })
+    .decode(buf)
+    .replace(/\u0000/g, "")
+    .replace(/\r\n?/g, "\n");
+}
+
+/** Kinds whose gallery cards carry a server-read preview of the blob's head. */
+const EXCERPT_KINDS = new Set(["source", "text", "binary"]);
+
+/** path -> preview text for the gallery cards: a lossy-UTF-8 excerpt for
+ *  source/text, spaced hex pairs for binary head snippets. Reads are tiny but
+ *  `cap` bounds them on builds with pathological file counts. */
+export async function assetExcerpts(
+  assets: { path: string; sha256: string; kind: string }[],
+  cap = Infinity
+): Promise<Record<string, string>> {
+  return Object.fromEntries(
+    await Promise.all(
+      assets
+        .filter((a) => EXCERPT_KINDS.has(a.kind))
+        .slice(0, cap)
+        .map(async (a) => {
+          if (a.kind === "binary") {
+            const bytes = await readAssetBytes(a.sha256, 96);
+            return [a.path, bytes ? hexPreview(bytes) : ""] as const;
+          }
+          return [a.path, (await readAssetExcerpt(a.sha256)) ?? ""] as const;
+        })
+    )
+  );
 }

--- a/web/src/lib/hexdump.ts
+++ b/web/src/lib/hexdump.ts
@@ -1,0 +1,28 @@
+// Hex renderings of raw asset bytes (client- and server-safe, no node deps).
+// Display-side only: the store keeps the raw head bytes of unidentified files,
+// so these layouts can change without re-analyzing any collection.
+
+/** Compact spaced hex pairs ("4d 5a 90 00 …") for gallery preview cards. */
+export function hexPreview(bytes: Uint8Array, maxBytes = 96): string {
+  const n = Math.min(bytes.length, maxBytes);
+  const pairs: string[] = [];
+  for (let i = 0; i < n; i++) pairs.push(bytes[i].toString(16).padStart(2, "0"));
+  return pairs.join(" ") + (bytes.length > n ? " …" : "");
+}
+
+/** Classic xxd layout: 8-hex offset, 16 bytes as 2-byte groups, ASCII gutter. */
+export function hexDump(bytes: Uint8Array): string {
+  const lines: string[] = [];
+  for (let off = 0; off < bytes.length; off += 16) {
+    const row = bytes.subarray(off, off + 16);
+    let hex = "";
+    for (let j = 0; j < 16; j++) {
+      hex += j < row.length ? row[j].toString(16).padStart(2, "0") : "  ";
+      if (j % 2 === 1) hex += " ";
+    }
+    let ascii = "";
+    for (const b of row) ascii += b >= 0x20 && b < 0x7f ? String.fromCharCode(b) : ".";
+    lines.push(`${off.toString(16).padStart(8, "0")}: ${hex} ${ascii}`);
+  }
+  return lines.join("\n");
+}

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -529,13 +529,13 @@ export async function listBuildsPage(pool: Pool, opts: BuildsPageOpts = {}): Pro
   };
 }
 
-/** One viewable asset of a build, for the build page's inline viewer. */
+/** One extracted asset of a build, for the build page's inline viewer. */
 export interface BuildAsset {
   path: string;
   sha256: string;
   size: number;
   mime: string;
-  kind: string; // image | audio | video | source | text
+  kind: string; // image | audio | video | source | text | binary (head snippet)
 }
 
 /// A build's viewable assets, in path order (one indexed lookup).

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -58,17 +58,20 @@ export interface BuildRecord {
   resemblance?: Signature | null;
   exe_fp?: { tlsh?: string; imphash?: string } | null;
   media?: MediaFp[];
-  /** Browser-viewable files in the blob store. Absent = extraction never ran. */
+  /** Extracted files in the blob store (viewable ones whole, the rest as head
+   *  snippets). Absent = extraction never ran. */
   assets?: AssetRef[] | null;
+  /** Asset-extraction generation (see curator-core ASSET_PROFILE). */
+  asset_profile?: number;
 }
 
-/** One extracted viewable asset; the bytes live in the store under `sha256`. */
+/** One extracted asset; the bytes live in the store under `sha256`. */
 export interface AssetRef {
   path: string;
   sha256: string;
   size: number;
   mime: string;
-  kind: string; // "image" | "audio" | "video" | "source" | "text"
+  kind: string; // "image" | "audio" | "video" | "source" | "text" | "binary" (head snippet)
 }
 
 export interface MediaFp {


### PR DESCRIPTION
Files the asset pass couldn't classify were dropped entirely. Now every non-empty file ships an asset: viewable types whole as before, everything else as its raw first 2KB (new kind, binary) in the content-addressed blob store.

The UIs render the bytes at display time (xxd-style lightbox on the web, in-app preview on macOS, Notepad hexdump on Windows), so the display can change without re-analysis. A new asset_profile field lets re-analyze backfill existing collections, with no migrations or new dependencies. Corpus builds pick up snippets after a re-analyze and re-export.