### PR TITLE
Support TGA files as image assets

### DIFF
--- a/crates/curator-core/src/lib.rs
+++ b/crates/curator-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod fingerprint;
 pub mod progress;
 pub mod render;
 pub mod schema;
+pub mod tga;
 
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/crates/curator-core/src/schema.rs
+++ b/crates/curator-core/src/schema.rs
@@ -13,9 +13,10 @@ pub const RECORD_SCHEMA_VERSION: u32 = 1;
 pub const FINGERPRINT_PROFILE: &str = "v1";
 /// Asset-extraction generation. 1 = browser-viewable kinds only (implicit in
 /// records that predate the field, which deserialize to 0); 2 = also head
-/// snippets (`kind: "binary"`) for every file that isn't viewable. A record
-/// below the current value gets its assets re-extracted on the next analyze.
-pub const ASSET_PROFILE: u32 = 2;
+/// snippets (`kind: "binary"`) for every file that isn't viewable; 3 = TGA
+/// classified as an image (previously a head snippet). A record below the
+/// current value gets its assets re-extracted on the next analyze.
+pub const ASSET_PROFILE: u32 = 3;
 
 /// A fully analyzed disc image / container — image-independent and self-describing.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/curator-core/src/tga.rs
+++ b/crates/curator-core/src/tga.rs
@@ -1,0 +1,273 @@
+//! TGA (Truevision Targa) → BMP conversion.
+//!
+//! Stock Windows has no TGA handler, so the Windows GUI stages TGA image
+//! assets as 32bpp BMP before handing them to the shell. Covers what game
+//! dumps carry: 8bpp grayscale and color-mapped, 15/16bpp, 24/32bpp, raw and
+//! RLE, either vertical origin.
+
+/// Refuse to decode absurd dimensions (decode allocates width*height*4 up
+/// front, and headers are attacker-controlled bytes). Matches the web
+/// converter's cap (web/src/lib/imgpng.ts).
+const MAX_PIXELS: u32 = 16_000_000;
+
+struct Decoded {
+    width: usize,
+    height: usize,
+    /// RGBA, row 0 = top.
+    data: Vec<u8>,
+}
+
+/// Expand a 5-bit channel to 8 bits by bit replication.
+fn scale5(c: u16) -> u8 {
+    ((c << 3) | (c >> 2)) as u8
+}
+
+/// One pixel or palette entry in the file's layout → RGBA. Formats without an
+/// alpha channel yield 0 — decode() flips an all-zero alpha plane to opaque.
+fn unpack(p: &[u8], bits: u8) -> [u8; 4] {
+    match bits {
+        15 | 16 => {
+            let v = u16::from_le_bytes([p[0], p[1]]);
+            [scale5(v >> 10 & 31), scale5(v >> 5 & 31), scale5(v & 31), 0]
+        }
+        24 => [p[2], p[1], p[0], 0],
+        _ => [p[2], p[1], p[0], p[3]], // 32
+    }
+}
+
+fn decode(b: &[u8]) -> Result<Decoded, String> {
+    if b.len() < 18 {
+        return Err("not a TGA".into());
+    }
+    let id_len = b[0] as usize;
+    let cmap_type = b[1];
+    let image_type = b[2];
+    let cmap_first = u16::from_le_bytes([b[3], b[4]]) as usize;
+    let cmap_len = u16::from_le_bytes([b[5], b[6]]) as usize;
+    let cmap_bits = b[7];
+    let width = u16::from_le_bytes([b[12], b[13]]) as u32;
+    let height = u16::from_le_bytes([b[14], b[15]]) as u32;
+    let depth = b[16];
+    let desc = b[17];
+
+    if cmap_type > 1 || !matches!(image_type, 1 | 2 | 3 | 9 | 10 | 11) {
+        return Err("not a TGA".into());
+    }
+    if !matches!(depth, 8 | 15 | 16 | 24 | 32) {
+        return Err(format!("unsupported TGA depth {depth}"));
+    }
+    if width == 0 || height == 0 || width * height > MAX_PIXELS {
+        return Err(format!("TGA dimensions out of range: {width}x{height}"));
+    }
+    let color_mapped = matches!(image_type, 1 | 9);
+    let gray = matches!(image_type, 3 | 11);
+    if color_mapped && (cmap_type != 1 || depth != 8) {
+        return Err("unsupported color-mapped TGA layout".into());
+    }
+
+    let mut off = 18 + id_len;
+
+    // The palette rides along even when a truecolor image merely carries one;
+    // decode entries to RGBA only when pixels actually index into it.
+    let mut palette: Vec<[u8; 4]> = Vec::new();
+    if cmap_type == 1 {
+        if !matches!(cmap_bits, 15 | 16 | 24 | 32) {
+            return Err(format!("unsupported TGA palette depth {cmap_bits}"));
+        }
+        let entry_bytes = (cmap_bits as usize + 7) / 8;
+        let end = off + cmap_len * entry_bytes;
+        if end > b.len() {
+            return Err("truncated TGA".into());
+        }
+        if color_mapped {
+            palette = (0..cmap_len)
+                .map(|i| unpack(&b[off + i * entry_bytes..], cmap_bits))
+                .collect();
+        }
+        off = end;
+    }
+
+    let bpp = (depth as usize + 7) / 8;
+    let count = (width * height) as usize;
+    let mut px = vec![0u8; count * 4]; // RGBA in file scan order
+
+    let to_rgba = |p: &[u8]| -> Result<[u8; 4], String> {
+        if color_mapped {
+            let idx = (p[0] as usize)
+                .checked_sub(cmap_first)
+                .and_then(|i| palette.get(i))
+                .ok_or("TGA palette index out of range")?;
+            Ok(*idx)
+        } else if gray {
+            Ok([p[0], p[0], p[0], 0])
+        } else {
+            Ok(unpack(p, depth))
+        }
+    };
+
+    if image_type >= 9 {
+        // RLE: header byte per packet — bit 7 = run, low 7 bits = count-1.
+        let mut i = 0;
+        while i < count {
+            let hdr = *b.get(off).ok_or("truncated TGA")?;
+            off += 1;
+            let n = (hdr as usize & 0x7f) + 1;
+            if i + n > count {
+                return Err("corrupt TGA RLE stream".into());
+            }
+            if hdr & 0x80 != 0 {
+                let rgba = to_rgba(b.get(off..off + bpp).ok_or("truncated TGA")?)?;
+                off += bpp;
+                for j in i..i + n {
+                    px[j * 4..j * 4 + 4].copy_from_slice(&rgba);
+                }
+            } else {
+                for j in i..i + n {
+                    let rgba = to_rgba(b.get(off..off + bpp).ok_or("truncated TGA")?)?;
+                    off += bpp;
+                    px[j * 4..j * 4 + 4].copy_from_slice(&rgba);
+                }
+            }
+            i += n;
+        }
+    } else {
+        for j in 0..count {
+            let rgba = to_rgba(b.get(off..off + bpp).ok_or("truncated TGA")?)?;
+            off += bpp;
+            px[j * 4..j * 4 + 4].copy_from_slice(&rgba);
+        }
+    }
+
+    // Alpha-less formats decode with alpha 0 everywhere; that means opaque,
+    // not an invisible image (same convention as the web BMP converter).
+    if px.iter().skip(3).step_by(4).all(|&a| a == 0) {
+        px.iter_mut().skip(3).step_by(4).for_each(|a| *a = 255);
+    }
+
+    // Reorder scan lines to top-down; descriptor bit 5 = top origin,
+    // bit 4 = right-to-left.
+    let (w, h) = (width as usize, height as usize);
+    let top_origin = desc & 0x20 != 0;
+    let right_to_left = desc & 0x10 != 0;
+    let mut data = vec![0u8; count * 4];
+    for row in 0..h {
+        let y = if top_origin { row } else { h - 1 - row };
+        for col in 0..w {
+            let x = if right_to_left { w - 1 - col } else { col };
+            let src = (row * w + col) * 4;
+            let dst = (y * w + x) * 4;
+            data[dst..dst + 4].copy_from_slice(&px[src..src + 4]);
+        }
+    }
+    Ok(Decoded { width: w, height: h, data })
+}
+
+/// Decode a TGA and re-encode as a 32bpp bottom-up BMP. Errors on malformed
+/// input — callers fall back to staging the raw file.
+pub fn tga_to_bmp(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let img = decode(bytes)?;
+    let row_bytes = img.width * 4; // 32bpp rows need no padding
+    let pixel_bytes = row_bytes * img.height;
+    let mut out = Vec::with_capacity(54 + pixel_bytes);
+    out.extend_from_slice(b"BM");
+    out.extend_from_slice(&((54 + pixel_bytes) as u32).to_le_bytes());
+    out.extend_from_slice(&[0; 4]); // reserved
+    out.extend_from_slice(&54u32.to_le_bytes()); // pixel data offset
+    out.extend_from_slice(&40u32.to_le_bytes()); // BITMAPINFOHEADER
+    out.extend_from_slice(&(img.width as i32).to_le_bytes());
+    out.extend_from_slice(&(img.height as i32).to_le_bytes()); // positive = bottom-up
+    out.extend_from_slice(&1u16.to_le_bytes()); // planes
+    out.extend_from_slice(&32u16.to_le_bytes()); // bpp
+    out.extend_from_slice(&0u32.to_le_bytes()); // BI_RGB
+    out.extend_from_slice(&(pixel_bytes as u32).to_le_bytes());
+    out.extend_from_slice(&[0; 16]); // ppm + palette counts, all zero
+    for y in (0..img.height).rev() {
+        let row = &img.data[y * row_bytes..(y + 1) * row_bytes];
+        for p in row.chunks_exact(4) {
+            out.extend_from_slice(&[p[2], p[1], p[0], p[3]]);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 18-byte header for a bare truecolor TGA.
+    fn header(image_type: u8, w: u16, h: u16, depth: u8, desc: u8) -> Vec<u8> {
+        let mut hd = vec![0u8; 18];
+        hd[2] = image_type;
+        hd[12..14].copy_from_slice(&w.to_le_bytes());
+        hd[14..16].copy_from_slice(&h.to_le_bytes());
+        hd[16] = depth;
+        hd[17] = desc;
+        hd
+    }
+
+    /// BGRA pixel at (x, y from top) of a 32bpp bottom-up BMP.
+    fn bmp_px(bmp: &[u8], w: usize, h: usize, x: usize, y: usize) -> [u8; 4] {
+        let o = 54 + ((h - 1 - y) * w + x) * 4;
+        [bmp[o], bmp[o + 1], bmp[o + 2], bmp[o + 3]]
+    }
+
+    #[test]
+    fn raw_24bpp_bottom_origin() {
+        // 2x2, bottom origin: file rows are bottom-up. Top-left ends up red.
+        let mut tga = header(2, 2, 2, 24, 0);
+        tga.extend_from_slice(&[
+            0, 255, 0, 255, 255, 255, // bottom row: green, white (BGR)
+            0, 0, 255, 255, 0, 0, // top row: red, blue
+        ]);
+        let bmp = tga_to_bmp(&tga).unwrap();
+        assert_eq!(&bmp[..2], b"BM");
+        assert_eq!(bmp_px(&bmp, 2, 2, 0, 0), [0, 0, 255, 255]); // red
+        assert_eq!(bmp_px(&bmp, 2, 2, 1, 0), [255, 0, 0, 255]); // blue
+        assert_eq!(bmp_px(&bmp, 2, 2, 0, 1), [0, 255, 0, 255]); // green
+    }
+
+    #[test]
+    fn rle_32bpp_top_origin_alpha() {
+        // 3x1 RLE, top origin: a run of two half-transparent reds + one literal blue.
+        let mut tga = header(10, 3, 1, 32, 0x20);
+        tga.extend_from_slice(&[0x81, 0, 0, 255, 128, 0x00, 255, 0, 0, 255]);
+        let bmp = tga_to_bmp(&tga).unwrap();
+        assert_eq!(bmp_px(&bmp, 3, 1, 0, 0), [0, 0, 255, 128]);
+        assert_eq!(bmp_px(&bmp, 3, 1, 1, 0), [0, 0, 255, 128]);
+        assert_eq!(bmp_px(&bmp, 3, 1, 2, 0), [255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn color_mapped_8bpp() {
+        // 2x1 indexed: palette entry 0 = magenta, 1 = cyan (24-bit BGR entries).
+        let mut tga = header(1, 2, 1, 8, 0x20);
+        tga[1] = 1; // color map present
+        tga[5..7].copy_from_slice(&2u16.to_le_bytes());
+        tga[7] = 24;
+        tga.extend_from_slice(&[255, 0, 255, 255, 255, 0]);
+        tga.extend_from_slice(&[0, 1]);
+        let bmp = tga_to_bmp(&tga).unwrap();
+        assert_eq!(bmp_px(&bmp, 2, 1, 0, 0), [255, 0, 255, 255]); // magenta
+        assert_eq!(bmp_px(&bmp, 2, 1, 1, 0), [255, 255, 0, 255]); // cyan
+    }
+
+    #[test]
+    fn sixteen_bpp_scaling() {
+        // 1x1, 16bpp ARGB1555 pure white — 5-bit channels must scale to 255.
+        let mut tga = header(2, 1, 1, 16, 0x20);
+        tga.extend_from_slice(&0x7fffu16.to_le_bytes());
+        let bmp = tga_to_bmp(&tga).unwrap();
+        assert_eq!(bmp_px(&bmp, 1, 1, 0, 0), [255, 255, 255, 255]);
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(tga_to_bmp(b"not a tga at all").is_err());
+        let mut huge = header(2, 65535, 65535, 24, 0);
+        huge.extend_from_slice(&[0; 3]);
+        assert!(tga_to_bmp(&huge).is_err());
+        // Truncated pixel data.
+        let short = header(2, 4, 4, 24, 0);
+        assert!(tga_to_bmp(&short).is_err());
+    }
+}

--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -1855,7 +1855,8 @@ mod app {
 
     /// Open the asset at `assets[idx]`. Media kinds go to their default app via a
     /// temp copy carrying the original filename (store blobs are extensionless, so
-    /// the shell can't pick a handler for them directly). Text and source kinds
+    /// the shell can't pick a handler for them directly); TGA images are staged
+    /// as BMP because stock Windows has no TGA handler. Text and source kinds
     /// always open in Notepad: handing a `.bat`/`.cmd`/`.js` from an untrusted
     /// disc to the shell's default verb would execute it. Binary kinds
     /// (unidentified files' head snippets) open in Notepad as a hex dump.
@@ -1873,6 +1874,8 @@ mod app {
         };
         let staged = if asset.kind == "binary" {
             materialize_hexdump(&asset, &blob)
+        } else if asset.mime == "image/x-tga" {
+            materialize_tga(&asset, &blob)
         } else {
             materialize_asset(&asset, &blob)
         };
@@ -1899,10 +1902,8 @@ mod app {
         }
     }
 
-    /// Copy a blob into a per-asset temp dir under its original (sanitized)
-    /// filename so the shell can pick a handler by extension. Content-addressed,
-    /// so an existing copy is reused.
-    fn materialize_asset(asset: &AssetRef, blob: &std::path::Path) -> std::result::Result<PathBuf, String> {
+    /// The asset's original filename, sanitized for use in a Windows path.
+    fn safe_asset_name(asset: &AssetRef) -> String {
         let base = asset.path.rsplit('/').next().unwrap_or_default();
         let safe: String = base
             .chars()
@@ -1914,23 +1915,50 @@ mod app {
                 }
             })
             .collect();
-        let name = if safe.trim_matches(['.', ' ']).is_empty() { asset.sha256.clone() } else { safe };
+        if safe.trim_matches(['.', ' ']).is_empty() { asset.sha256.clone() } else { safe }
+    }
+
+    /// The asset's per-sha temp dir, created on demand.
+    fn asset_temp_dir(asset: &AssetRef) -> std::result::Result<PathBuf, String> {
         let dir = std::env::temp_dir().join("curator-assets").join(&asset.sha256);
         std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
-        let dest = dir.join(name);
+        Ok(dir)
+    }
+
+    /// Copy a blob into a per-asset temp dir under its original (sanitized)
+    /// filename so the shell can pick a handler by extension. Content-addressed,
+    /// so an existing copy is reused.
+    fn materialize_asset(asset: &AssetRef, blob: &std::path::Path) -> std::result::Result<PathBuf, String> {
+        let dest = asset_temp_dir(asset)?.join(safe_asset_name(asset));
         if !dest.exists() {
             std::fs::copy(blob, &dest).map_err(|e| e.to_string())?;
         }
         Ok(dest)
     }
 
+    /// Stage a TGA image as a 32bpp BMP the shell can open — stock Windows has
+    /// no TGA handler. An undecodable file is staged raw instead, so users with
+    /// a TGA-capable viewer installed can still try it.
+    fn materialize_tga(asset: &AssetRef, blob: &std::path::Path) -> std::result::Result<PathBuf, String> {
+        let dest = asset_temp_dir(asset)?.join(format!("{}.bmp", safe_asset_name(asset)));
+        if dest.exists() {
+            return Ok(dest);
+        }
+        let data = std::fs::read(blob).map_err(|e| e.to_string())?;
+        match curator_core::tga::tga_to_bmp(&data) {
+            Ok(bmp) => {
+                std::fs::write(&dest, bmp).map_err(|e| e.to_string())?;
+                Ok(dest)
+            }
+            Err(_) => materialize_asset(asset, blob),
+        }
+    }
+
     /// Render an unidentified file's head-snippet blob as an xxd-style dump in a
     /// temp .txt for Notepad (the raw bytes would be garbage there). Layout
     /// lives here, display-side — the store keeps the raw bytes.
     fn materialize_hexdump(asset: &AssetRef, blob: &std::path::Path) -> std::result::Result<PathBuf, String> {
-        let dir = std::env::temp_dir().join("curator-assets").join(&asset.sha256);
-        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
-        let dest = dir.join("hexdump.txt");
+        let dest = asset_temp_dir(asset)?.join("hexdump.txt");
         if !dest.exists() {
             let data = std::fs::read(blob).map_err(|e| e.to_string())?;
             std::fs::write(&dest, hexdump(&data)).map_err(|e| e.to_string())?;

--- a/ps2exe-adapter/curator_adapter/viewable.py
+++ b/ps2exe-adapter/curator_adapter/viewable.py
@@ -25,6 +25,7 @@ _IMAGE = {
     "jpeg": "image/jpeg",
     "gif": "image/gif",
     "bmp": "image/bmp",
+    "tga": "image/x-tga",
     "webp": "image/webp",
     "ico": "image/x-icon",
     "svg": "image/svg+xml",
@@ -102,11 +103,29 @@ def _looks_text(head):
     return weird <= len(head) // 20
 
 
+def _tga_header(head):
+    """TGA has no leading magic — check the 18-byte header for plausibility."""
+    if len(head) < 18:
+        return False
+    cmap_type, image_type = head[1], head[2]
+    if cmap_type not in (0, 1):
+        return False
+    if image_type not in (1, 2, 3, 9, 10, 11):
+        return False
+    # Color-mapped image types require a color map with a sane entry size.
+    if image_type in (1, 9) and (cmap_type != 1 or head[7] not in (15, 16, 24, 32)):
+        return False
+    width = head[12] | head[13] << 8
+    height = head[14] | head[15] << 8
+    return width > 0 and height > 0 and head[16] in (8, 15, 16, 24, 32)
+
+
 _MAGIC = {
     "image/png": lambda h: h.startswith(b"\x89PNG\r\n\x1a\n"),
     "image/jpeg": lambda h: h.startswith(b"\xff\xd8\xff"),
     "image/gif": lambda h: h.startswith((b"GIF87a", b"GIF89a")),
     "image/bmp": lambda h: h.startswith(b"BM"),
+    "image/x-tga": _tga_header,
     "image/webp": lambda h: h[:4] == b"RIFF" and h[8:12] == b"WEBP",
     "image/x-icon": lambda h: h.startswith((b"\x00\x00\x01\x00", b"\x00\x00\x02\x00")),
     "image/svg+xml": lambda h: _looks_text(h) and b"<svg" in h.lower(),

--- a/ps2exe-adapter/tests/test_assets.py
+++ b/ps2exe-adapter/tests/test_assets.py
@@ -45,6 +45,17 @@ def test_viewable_files_ship_whole(tmp_path):
     assert blob(tmp_path, a["sha256"]) == png
 
 
+def test_tga_ships_as_image_and_imposter_degrades(tmp_path):
+    # Bare 2x1 24bpp truecolor TGA — no magic bytes, header checks only.
+    tga = bytes([0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 0, 24, 0]) + bytes(6)
+    fake = b"Just a text file wearing the extension, longer than a header."
+    assets = extract({"/GFX/LOADING.TGA": tga, "/GFX/FAKE.TGA": fake}, tmp_path)
+    a = assets["/GFX/LOADING.TGA"]
+    assert (a["kind"], a["mime"], a["size"]) == ("image", "image/x-tga", len(tga))
+    assert blob(tmp_path, a["sha256"]) == tga
+    assert assets["/GFX/FAKE.TGA"]["kind"] == viewable.SNIPPET_KIND
+
+
 def test_unidentified_files_ship_head_snippet(tmp_path):
     data = bytes(range(256)) * 20  # 5120 bytes of binary
     assets = extract({"/DATA/GAME.TIM": data}, tmp_path)

--- a/ps2exe-adapter/tests/test_viewable.py
+++ b/ps2exe-adapter/tests/test_viewable.py
@@ -39,6 +39,26 @@ def test_sniff_confirms_magic():
     assert viewable.sniff(b'<?xml version="1.0"?><svg xmlns="x">', "image/svg+xml")
 
 
+def test_sniff_tga_header_plausibility():
+    assert viewable.classify("/GFX/LOADING.TGA") == ("image", "image/x-tga")
+    # 18-byte header: bare 2x1 24bpp truecolor, then a 16-color color-mapped image.
+    truecolor = bytes([0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 1, 0, 24, 0])
+    assert viewable.sniff(truecolor, "image/x-tga")
+    cmapped = bytes([0, 1, 1, 0, 0, 16, 0, 24, 0, 0, 0, 0, 2, 0, 1, 0, 8, 0])
+    assert viewable.sniff(cmapped, "image/x-tga")
+    # No magic to lean on, so the header fields must reject imposters:
+    # zero dimensions, junk image type, junk depth, text, short reads.
+    assert not viewable.sniff(bytes(18), "image/x-tga")
+    assert not viewable.sniff(b"An 18+ byte readme that is not an image.", "image/x-tga")
+    assert not viewable.sniff(truecolor[:12], "image/x-tga")
+    bad_type = bytearray(truecolor)
+    bad_type[2] = 7
+    assert not viewable.sniff(bytes(bad_type), "image/x-tga")
+    bad_depth = bytearray(truecolor)
+    bad_depth[16] = 13
+    assert not viewable.sniff(bytes(bad_depth), "image/x-tga")
+
+
 def test_sniff_text_accepts_legacy_encodings_rejects_binary():
     # Shift-JIS bytes are >= 0x80 — must pass the text heuristic.
     assert viewable.sniff("日本語のテキスト".encode("shift_jis"), "text/plain")

--- a/web/src/app/api/asset/[sha256]/png/route.ts
+++ b/web/src/app/api/asset/[sha256]/png/route.ts
@@ -2,18 +2,20 @@ import { readFile } from "node:fs/promises";
 import type { NextRequest } from "next/server";
 import { assetBlobPath } from "@/lib/assets";
 import { getPool } from "@/lib/db";
-import { bmpToPng, pngConvertible, WEB_SAFE_IMAGE } from "@/lib/imgpng";
+import { pngConvertible, toPng, WEB_SAFE_IMAGE } from "@/lib/imgpng";
 import { isSha256 } from "@/lib/validate";
 
 export const runtime = "nodejs";
 
 // GET /api/asset/<sha256>/png — the asset converted to PNG, for og:image use
-// on formats unfurlers won't render (today: BMP). Web-safe formats redirect to
-// the raw asset route; content-addressed, so responses cache hard.
+// on formats unfurlers won't render and inline display of formats browsers
+// won't (today: BMP and TGA). Web-safe formats redirect to the raw asset
+// route; content-addressed, so responses cache hard.
 
 const CACHE = "public, max-age=31536000, immutable";
 
-// BMPs are uncompressed; bound what the in-process decoder will chew on.
+// Bound what the in-process decoder will chew on (decoded size is capped
+// separately by the converters' MAX_PIXELS).
 const MAX_CONVERT_BYTES = 32_000_000;
 
 export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
@@ -43,7 +45,7 @@ export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256
 
   let png: Buffer;
   try {
-    png = bmpToPng(bytes);
+    png = toPng(meta.mime, bytes);
   } catch {
     return Response.json({ error: "undecodable image" }, { status: 415 });
   }

--- a/web/src/app/builds/[buildId]/AssetGallery.tsx
+++ b/web/src/app/builds/[buildId]/AssetGallery.tsx
@@ -9,7 +9,7 @@
 // file tree), which also deep-links the asset in the URL.
 
 import Link from "next/link";
-import { assetUrl, humanSize, type ViewableAsset } from "./AssetViewer";
+import { assetUrl, humanSize, imageSrc, type ViewableAsset } from "./AssetViewer";
 import { useOpenAsset } from "./AssetViewerHost";
 import AudioEmbed from "./AudioEmbed";
 import SourceCode from "./SourceCode";
@@ -70,7 +70,7 @@ export default function AssetGallery({
                   >
                     {/* Not next/image: blobs are local, immutable, hard-cached (see AssetViewer). */}
                     {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={assetUrl(a)} alt={a.path} loading="lazy" className="h-full w-full object-contain" />
+                    <img src={imageSrc(a)} alt={a.path} loading="lazy" className="h-full w-full object-contain" />
                   </button>
                 ))}
                 {more > 0 && (

--- a/web/src/app/builds/[buildId]/AssetViewer.tsx
+++ b/web/src/app/builds/[buildId]/AssetViewer.tsx
@@ -22,6 +22,14 @@ export function assetUrl(a: ViewableAsset): string {
   return `/api/asset/${a.sha256}`;
 }
 
+/** Where <img> should point: browsers render every image mime we extract
+ *  except TGA, which goes through the server's PNG conversion. Kept in sync
+ *  with pngConvertible (imgpng.ts) — not imported: that module pulls the
+ *  decoders into the client bundle. */
+export function imageSrc(a: ViewableAsset): string {
+  return a.mime === "image/x-tga" ? `${assetUrl(a)}/png` : assetUrl(a);
+}
+
 export function humanSize(bytes: number): string {
   const units = ["B", "KB", "MB", "GB", "TB"];
   let v = bytes;
@@ -130,7 +138,7 @@ function Body({ asset }: { asset: ViewableAsset }) {
         // cache headers — optimization would only re-encode them.
         // eslint-disable-next-line @next/next/no-img-element
         <img
-          src={url}
+          src={imageSrc(asset)}
           alt={asset.path}
           className="max-h-[75vh] max-w-[90vw] rounded object-contain"
           onError={() => setFailed(true)}

--- a/web/src/app/builds/[buildId]/opengraph-image.tsx
+++ b/web/src/app/builds/[buildId]/opengraph-image.tsx
@@ -3,14 +3,14 @@
 // segment and everything below it, so asset deep links inherit it too.
 //
 // Dark info card: wordmark, title, fact chips, short id — plus a screenshot
-// pane when the build has a PNG/JPEG asset whose bytes are in the blob store
-// (largest first: big files are screenshots, tiny ones are icons/textures).
+// pane when the build has a PNG/JPEG/BMP/TGA asset whose bytes are in the blob
+// store (largest first: big files are screenshots, tiny ones are icons/textures).
 
 import { readFile } from "node:fs/promises";
 import { ImageResponse } from "next/og";
 import { assetBlobPath } from "@/lib/assets";
 import { getPool } from "@/lib/db";
-import { bmpToPng } from "@/lib/imgpng";
+import { pngConvertible, toPng } from "@/lib/imgpng";
 import { buildFacts, displayTitle } from "@/lib/meta";
 import { getBuildMeta, resolveBuild, type BuildMetaRow } from "@/lib/queries";
 import { parseBuildParam, SHORT_SHA_LEN } from "@/lib/slug";
@@ -26,7 +26,8 @@ const MAX_SHOT_BYTES = 8_000_000;
 async function findScreenshot(sha256: string): Promise<string | null> {
   const r = await getPool().query(
     `SELECT sha256, mime FROM build_asset
-     WHERE build_sha256=$1 AND kind='image' AND mime IN ('image/png','image/jpeg','image/bmp')
+     WHERE build_sha256=$1 AND kind='image'
+       AND mime IN ('image/png','image/jpeg','image/bmp','image/x-tga')
        AND size <= $2
      ORDER BY size DESC LIMIT 4`,
     [sha256, MAX_SHOT_BYTES]
@@ -36,9 +37,9 @@ async function findScreenshot(sha256: string): Promise<string | null> {
   for (const row of r.rows as Array<{ sha256: string; mime: string }>) {
     try {
       const bytes = await readFile(assetBlobPath(row.sha256));
-      // satori can't decode BMP — hand it PNG bytes instead.
-      if (row.mime === "image/bmp") {
-        return `data:image/png;base64,${bmpToPng(bytes).toString("base64")}`;
+      // satori can't decode BMP or TGA — hand it PNG bytes instead.
+      if (pngConvertible(row.mime)) {
+        return `data:image/png;base64,${toPng(row.mime, bytes).toString("base64")}`;
       }
       return `data:${row.mime};base64,${bytes.toString("base64")}`;
     } catch {

--- a/web/src/lib/imgpng.ts
+++ b/web/src/lib/imgpng.ts
@@ -1,7 +1,9 @@
-// BMP → PNG conversion for social previews. Link unfurlers (Discord, Slack,
-// Twitter) and satori (the OG card renderer) only handle web image formats,
-// but dumps carry raw BMP screenshots — convert those on the fly; formats we
-// can't convert (ico, svg) fall back to the build's generated card.
+// BMP/TGA → PNG conversion. Link unfurlers (Discord, Slack, Twitter) and
+// satori (the OG card renderer) only handle web image formats, but dumps carry
+// raw BMP and TGA screenshots — convert those on the fly; formats we can't
+// convert (ico, svg) fall back to the build's generated card. Browsers render
+// BMP natively but not TGA, so the viewer and gallery also route TGA through
+// /api/asset/<sha>/png.
 
 import bmp from "bmp-js";
 import { PNG } from "pngjs";
@@ -11,7 +13,12 @@ export const WEB_SAFE_IMAGE = /^image\/(png|jpe?g|gif|webp)$/;
 
 /** Mimes /api/asset/<sha>/png can convert. */
 export function pngConvertible(mime: string): boolean {
-  return mime === "image/bmp";
+  return mime === "image/bmp" || mime === "image/x-tga";
+}
+
+/** Convert a pngConvertible asset to PNG. Throws on malformed input. */
+export function toPng(mime: string, bytes: Buffer): Buffer {
+  return mime === "image/x-tga" ? tgaToPng(bytes) : bmpToPng(bytes);
 }
 
 // Refuse to decode absurd dimensions (decode allocates width*height*4 up
@@ -90,6 +97,141 @@ export function bmpToPng(bytes: Buffer): Buffer {
   // means opaque, not an invisible image.
   if (maxAlpha === 0) {
     for (let i = 3; i < png.data.length; i += 4) png.data[i] = 255;
+  }
+  return PNG.sync.write(png);
+}
+
+// TGA decode, hand-rolled: the format is trivial and the npm decoders are as
+// unmaintained as bmp-js. Covers what game dumps carry — 8bpp grayscale and
+// color-mapped, 15/16bpp, 24/32bpp, raw and RLE, either vertical origin.
+// Mirrors curator-core/src/tga.rs (the Windows GUI's TGA→BMP staging).
+
+/** Expand a 5-bit channel to 8 bits by bit replication. */
+function scale5(c: number): number {
+  return (c << 3) | (c >> 2);
+}
+
+/** One pixel or palette entry in the file's layout → [r,g,b,a]. Formats
+ *  without an alpha channel yield 0 — tgaToPng flips an all-zero alpha plane
+ *  to opaque. */
+function unpackTga(bytes: Buffer, o: number, bits: number): [number, number, number, number] {
+  if (bits === 15 || bits === 16) {
+    const v = bytes.readUInt16LE(o);
+    return [scale5((v >> 10) & 31), scale5((v >> 5) & 31), scale5(v & 31), 0];
+  }
+  if (bits === 24) return [bytes[o + 2], bytes[o + 1], bytes[o], 0];
+  return [bytes[o + 2], bytes[o + 1], bytes[o], bytes[o + 3]]; // 32
+}
+
+/** Decode a TGA and re-encode as PNG. Throws on malformed input. */
+export function tgaToPng(bytes: Buffer): Buffer {
+  if (bytes.length < 18) throw new Error("not a TGA");
+  const idLen = bytes[0];
+  const cmapType = bytes[1];
+  const imageType = bytes[2];
+  const cmapFirst = bytes.readUInt16LE(3);
+  const cmapLen = bytes.readUInt16LE(5);
+  const cmapBits = bytes[7];
+  const width = bytes.readUInt16LE(12);
+  const height = bytes.readUInt16LE(14);
+  const depth = bytes[16];
+  const desc = bytes[17];
+
+  if (cmapType > 1 || ![1, 2, 3, 9, 10, 11].includes(imageType)) throw new Error("not a TGA");
+  if (![8, 15, 16, 24, 32].includes(depth)) throw new Error(`unsupported TGA depth ${depth}`);
+  if (width === 0 || height === 0 || width * height > MAX_PIXELS) {
+    throw new Error(`TGA dimensions out of range: ${width}x${height}`);
+  }
+  const colorMapped = imageType === 1 || imageType === 9;
+  const gray = imageType === 3 || imageType === 11;
+  if (colorMapped && (cmapType !== 1 || depth !== 8)) {
+    throw new Error("unsupported color-mapped TGA layout");
+  }
+
+  let off = 18 + idLen;
+
+  // The palette rides along even when a truecolor image merely carries one;
+  // decode entries only when pixels actually index into it.
+  const palette: Array<[number, number, number, number]> = [];
+  if (cmapType === 1) {
+    if (![15, 16, 24, 32].includes(cmapBits)) {
+      throw new Error(`unsupported TGA palette depth ${cmapBits}`);
+    }
+    const entryBytes = (cmapBits + 7) >> 3;
+    const end = off + cmapLen * entryBytes;
+    if (end > bytes.length) throw new Error("truncated TGA");
+    if (colorMapped) {
+      for (let i = 0; i < cmapLen; i++) palette.push(unpackTga(bytes, off + i * entryBytes, cmapBits));
+    }
+    off = end;
+  }
+
+  const bpp = (depth + 7) >> 3;
+  const count = width * height;
+  const px = Buffer.alloc(count * 4); // RGBA in file scan order
+
+  const readPixel = (o: number): [number, number, number, number] => {
+    if (o + bpp > bytes.length) throw new Error("truncated TGA");
+    if (colorMapped) {
+      const entry = palette[bytes[o] - cmapFirst];
+      if (!entry) throw new Error("TGA palette index out of range");
+      return entry;
+    }
+    if (gray) return [bytes[o], bytes[o], bytes[o], 0];
+    return unpackTga(bytes, o, depth);
+  };
+
+  const put = (i: number, [r, g, b, a]: [number, number, number, number]) => {
+    px[i * 4] = r;
+    px[i * 4 + 1] = g;
+    px[i * 4 + 2] = b;
+    px[i * 4 + 3] = a;
+  };
+
+  if (imageType >= 9) {
+    // RLE: header byte per packet — bit 7 = run, low 7 bits = count-1.
+    let i = 0;
+    while (i < count) {
+      if (off >= bytes.length) throw new Error("truncated TGA");
+      const hdr = bytes[off++];
+      const n = (hdr & 0x7f) + 1;
+      if (i + n > count) throw new Error("corrupt TGA RLE stream");
+      if (hdr & 0x80) {
+        const p = readPixel(off);
+        off += bpp;
+        for (let j = i; j < i + n; j++) put(j, p);
+      } else {
+        for (let j = i; j < i + n; j++) {
+          put(j, readPixel(off));
+          off += bpp;
+        }
+      }
+      i += n;
+    }
+  } else {
+    for (let j = 0; j < count; j++) {
+      put(j, readPixel(off));
+      off += bpp;
+    }
+  }
+
+  // Alpha-less formats decode with alpha 0 everywhere; that means opaque, not
+  // an invisible image (same convention as bmpToPng).
+  let maxAlpha = 0;
+  for (let i = 3; i < px.length; i += 4) if (px[i] > maxAlpha) maxAlpha = px[i];
+  if (maxAlpha === 0) for (let i = 3; i < px.length; i += 4) px[i] = 255;
+
+  // Reorder scan lines to top-down; descriptor bit 5 = top origin,
+  // bit 4 = right-to-left.
+  const topOrigin = (desc & 0x20) !== 0;
+  const rightToLeft = (desc & 0x10) !== 0;
+  const png = new PNG({ width, height });
+  for (let row = 0; row < height; row++) {
+    const y = topOrigin ? row : height - 1 - row;
+    for (let col = 0; col < width; col++) {
+      const x = rightToLeft ? width - 1 - col : col;
+      px.copy(png.data, (y * width + x) * 4, (row * width + col) * 4, (row * width + col) * 4 + 4);
+    }
   }
   return PNG.sync.write(png);
 }

--- a/web/tests/imgpng.test.ts
+++ b/web/tests/imgpng.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { PNG } from "pngjs";
-import { bmpToPng, pngConvertible, WEB_SAFE_IMAGE } from "../src/lib/imgpng";
+import { bmpToPng, pngConvertible, tgaToPng, toPng, WEB_SAFE_IMAGE } from "../src/lib/imgpng";
 
 // Hand-crafted 2x1 24bpp BMP: left pixel pure red, right pixel pure blue
 // (rows are BGR on disk, padded to 4 bytes) — pins the ABGR→RGBA swizzle.
@@ -78,10 +78,82 @@ test("web-safe and convertible mime classification", () => {
   for (const m of ["image/png", "image/jpeg", "image/gif", "image/webp"]) {
     assert.ok(WEB_SAFE_IMAGE.test(m), m);
   }
-  for (const m of ["image/bmp", "image/x-icon", "image/svg+xml", "image/tiff"]) {
+  for (const m of ["image/bmp", "image/x-tga", "image/x-icon", "image/svg+xml", "image/tiff"]) {
     assert.ok(!WEB_SAFE_IMAGE.test(m), m);
   }
   assert.ok(pngConvertible("image/bmp"));
+  assert.ok(pngConvertible("image/x-tga"));
   assert.ok(!pngConvertible("image/x-icon"));
   assert.ok(!pngConvertible("image/svg+xml"));
+});
+
+// 18-byte TGA header for a bare (palette-less) image.
+function tgaHeader(imageType: number, w: number, h: number, depth: number, desc: number): Buffer {
+  const hd = Buffer.alloc(18);
+  hd[2] = imageType;
+  hd.writeUInt16LE(w, 12);
+  hd.writeUInt16LE(h, 14);
+  hd[16] = depth;
+  hd[17] = desc;
+  return hd;
+}
+
+test("tgaToPng flips bottom-origin rows and makes 24bpp opaque", () => {
+  // 2x2 bottom-origin: file rows run bottom-up, so the file's second row
+  // (red, blue — BGR on disk) must come out as the top of the PNG.
+  const tga = Buffer.concat([
+    tgaHeader(2, 2, 2, 24, 0),
+    Buffer.from([0, 255, 0, 255, 255, 255, 0, 0, 255, 255, 0, 0]),
+  ]);
+  const png = PNG.sync.read(tgaToPng(tga));
+  assert.equal(png.width, 2);
+  assert.equal(png.height, 2);
+  assert.deepEqual([...png.data.subarray(0, 4)], [255, 0, 0, 255]); // red
+  assert.deepEqual([...png.data.subarray(4, 8)], [0, 0, 255, 255]); // blue
+  assert.deepEqual([...png.data.subarray(8, 12)], [0, 255, 0, 255]); // green
+});
+
+test("tgaToPng decodes RLE packets and keeps real alpha", () => {
+  // 3x1 top-origin RLE: a run of two half-transparent reds + one literal blue.
+  const tga = Buffer.concat([
+    tgaHeader(10, 3, 1, 32, 0x20),
+    Buffer.from([0x81, 0, 0, 255, 128, 0x00, 255, 0, 0, 255]),
+  ]);
+  const png = PNG.sync.read(tgaToPng(tga));
+  assert.deepEqual([...png.data.subarray(0, 4)], [255, 0, 0, 128]);
+  assert.deepEqual([...png.data.subarray(4, 8)], [255, 0, 0, 128]);
+  assert.deepEqual([...png.data.subarray(8, 12)], [0, 0, 255, 255]);
+});
+
+test("tgaToPng resolves color-mapped pixels through the palette", () => {
+  // 2x1 indexed: palette entry 0 = magenta, 1 = cyan (24-bit BGR entries).
+  const hd = tgaHeader(1, 2, 1, 8, 0x20);
+  hd[1] = 1; // color map present
+  hd.writeUInt16LE(2, 5); // 2 entries
+  hd[7] = 24;
+  const tga = Buffer.concat([hd, Buffer.from([255, 0, 255, 255, 255, 0]), Buffer.from([0, 1])]);
+  const png = PNG.sync.read(tgaToPng(tga));
+  assert.deepEqual([...png.data.subarray(0, 4)], [255, 0, 255, 255]); // magenta
+  assert.deepEqual([...png.data.subarray(4, 8)], [0, 255, 255, 255]); // cyan
+});
+
+test("tgaToPng expands 5-bit channels to full range", () => {
+  // 1x1 16bpp ARGB1555 pure white — 5-bit channels must scale to 255.
+  const px = Buffer.alloc(2);
+  px.writeUInt16LE(0x7fff, 0);
+  const png = PNG.sync.read(tgaToPng(Buffer.concat([tgaHeader(2, 1, 1, 16, 0x20), px])));
+  assert.deepEqual([...png.data.subarray(0, 4)], [255, 255, 255, 255]);
+});
+
+test("tgaToPng throws on garbage, absurd dimensions, and truncation", () => {
+  assert.throws(() => tgaToPng(Buffer.from("definitely not a tga")));
+  const huge = Buffer.concat([tgaHeader(2, 65535, 65535, 24, 0), Buffer.alloc(4)]);
+  assert.throws(() => tgaToPng(huge), /dimensions/);
+  assert.throws(() => tgaToPng(tgaHeader(2, 4, 4, 24, 0)), /truncated/);
+});
+
+test("toPng dispatches by mime", () => {
+  const tga = Buffer.concat([tgaHeader(2, 1, 1, 24, 0x20), Buffer.from([0, 0, 255])]);
+  assert.deepEqual([...PNG.sync.read(toPng("image/x-tga", tga)).data], [255, 0, 0, 255]);
+  assert.deepEqual([...PNG.sync.read(toPng("image/bmp", tinyBmp())).data.subarray(0, 4)], [255, 0, 0, 255]);
 });


### PR DESCRIPTION
TGA files now extract as image assets instead of hex snippets, with header plausibility checks standing in for the magic bytes the format lacks, and the bumped asset profile re-extracts existing records on the next analyze. The web converts TGA to PNG on the fly for thumbnails, the lightbox, and OG cards since browsers cannot render it, the Windows GUI stages a BMP converted in core because stock Windows has no TGA handler, and macOS works unchanged with NSImage decoding TGA natively.