### PR TITLE
Make accepted resubmissions replace live builds

### DIFF
--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -169,6 +169,9 @@ mod app {
         selected_sections: Vec<Section>,
         /// Web service base URL (CURATOR_WEB_URL, default https://hiddenpalace.org).
         web_url: String,
+        /// Optional moderation secret (CURATOR_MODERATION_TOKEN). When set, a submit
+        /// is auto-accepted so it replaces the live build instead of waiting in the queue.
+        moderation_token: String,
         /// The "Recent" submenu and the sha256s backing its items (by position).
         recent_menu: HMENU,
         recent: Vec<String>,
@@ -559,6 +562,7 @@ mod app {
             selected_sections: Vec::new(),
             web_url: std::env::var("CURATOR_WEB_URL")
                 .unwrap_or_else(|_| "https://hiddenpalace.org".to_string()),
+            moderation_token: std::env::var("CURATOR_MODERATION_TOKEN").unwrap_or_default(),
             recent_menu,
             recent: Vec::new(),
             library_mode: false,
@@ -2029,7 +2033,7 @@ mod app {
         // Resolve which of the build's asset blobs exist locally (sha256 → path)
         // up front on the UI thread; the worker uploads whichever the server lacks.
         ensure_reader(hwnd);
-        let (base, sha, local_assets) = {
+        let (base, sha, local_assets, token) = {
             let Some(st) = state(hwnd) else { return };
             let mut local: HashMap<String, PathBuf> = HashMap::new();
             for a in &st.assets {
@@ -2037,7 +2041,12 @@ mod app {
                     local.insert(a.sha256.clone(), p);
                 }
             }
-            (st.web_url.trim_end_matches('/').to_string(), st.last_sha.clone(), local)
+            (
+                st.web_url.trim_end_matches('/').to_string(),
+                st.last_sha.clone(),
+                local,
+                st.moderation_token.clone(),
+            )
         };
         let url = format!("{base}/api/submissions");
         // { "nickname": <json string>, "record": <record> } — embed the raw record JSON.
@@ -2055,10 +2064,17 @@ mod app {
                         .ok()
                         .and_then(|v| v.get("status").and_then(|s| s.as_str()).map(String::from))
                         .unwrap_or_else(|| "queued".into());
-                    let note = match sha {
-                        Some(sha) => upload_missing_assets(hwnd_i, &base, &sha, &local_assets),
+                    let mut note = match &sha {
+                        Some(sha) => upload_missing_assets(hwnd_i, &base, sha, &local_assets),
                         None => String::new(),
                     };
+                    // With a moderation token, finish the job: accept the submission so
+                    // it replaces the live build (assets are uploaded first, above).
+                    if let Some(sha) = &sha {
+                        if !token.is_empty() {
+                            note.push_str(&accept_submission(&base, sha, &token));
+                        }
+                    }
                     format!("Submitted — {status}.{note}")
                 }
                 Ok((code, b)) => format!("Server error {code}: {}", b.trim()),
@@ -2117,6 +2133,20 @@ mod app {
         }
         note.push('.');
         note
+    }
+
+    /// Accept the just-submitted build with the moderation token, so the record
+    /// (and its refreshed assets) replaces the live build immediately. A failure
+    /// degrades to a note — the submission stays queued for manual moderation.
+    unsafe fn accept_submission(base: &str, build_sha: &str, token: &str) -> String {
+        let url = format!("{base}/api/submissions/{build_sha}");
+        let headers = format!("Content-Type: application/json\r\nx-moderation-token: {token}");
+        match http_request("POST", &url, Some(&headers), b"{\"action\":\"accept\"}") {
+            Ok((code, _)) if (200..300).contains(&code) => " Accepted — live build updated.".into(),
+            Ok((401, _)) => " Accept failed: moderation token rejected.".into(),
+            Ok((code, b)) => format!(" Accept failed: server error {code}: {}.", b.trim()),
+            Err(e) => format!(" Accept failed: {e}."),
+        }
     }
 
     /// Upload chunk size — small enough to clear typical proxy body-size limits.

--- a/macos/Sources/CuratorApp/AppModel.swift
+++ b/macos/Sources/CuratorApp/AppModel.swift
@@ -288,7 +288,8 @@ final class AppModel: ObservableObject {
             do {
                 let r = try await service.submit(recordJSON: json, nickname: nick)
                 let assetNote = await uploadMissingAssets(for: summary)
-                serviceMessage = "Submitted \(r.sha256.prefix(12))… — \(r.status).\(assetNote)"
+                let acceptNote = await acceptSubmission(sha256: r.sha256)
+                serviceMessage = "Submitted \(r.sha256.prefix(12))… — \(r.status).\(assetNote)\(acceptNote)"
             } catch {
                 serviceMessage = (error as? LocalizedError)?.errorDescription ?? "\(error)"
             }
@@ -325,6 +326,21 @@ final class AppModel: ObservableObject {
         } catch {
             let detail = (error as? LocalizedError)?.errorDescription ?? "\(error)"
             return " Asset upload failed: \(detail)"
+        }
+    }
+
+    /// With a moderation token configured, finish the job: accept the submission
+    /// so it replaces the live build (assets are uploaded first). Returns a status
+    /// suffix ("" without a token); a failure degrades to a note — the submission
+    /// stays queued for manual moderation.
+    private func acceptSubmission(sha256: String) async -> String {
+        guard service.moderationToken != nil else { return "" }
+        do {
+            try await service.accept(buildSha: sha256)
+            return " Accepted — live build updated."
+        } catch {
+            let detail = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+            return " Accept failed: \(detail)"
         }
     }
 

--- a/macos/Sources/CuratorApp/CuratorService.swift
+++ b/macos/Sources/CuratorApp/CuratorService.swift
@@ -87,10 +87,15 @@ struct CuratorService {
         return c.url ?? URL(fileURLWithPath: "/")
     }()
     let baseURL: URL
+    /// Optional moderation secret (`CURATOR_MODERATION_TOKEN`). When set, a submit
+    /// is auto-accepted so it replaces the live build instead of waiting in the queue.
+    let moderationToken: String?
 
     init() {
         let raw = ProcessInfo.processInfo.environment["CURATOR_WEB_URL"] ?? "https://hiddenpalace.org"
         baseURL = URL(string: raw) ?? CuratorService.defaultBaseURL
+        let token = ProcessInfo.processInfo.environment["CURATOR_MODERATION_TOKEN"] ?? ""
+        moderationToken = token.isEmpty ? nil : token
     }
 
     enum ServiceError: LocalizedError {
@@ -125,6 +130,17 @@ struct CuratorService {
         let body = try JSONSerialization.data(withJSONObject: payload)
         let data = try await post(path: "/api/submissions", body: body)
         return try JSONDecoder().decode(SubmitResult.self, from: data)
+    }
+
+    /// Accept a queued submission with the moderation token, replacing the live build.
+    func accept(buildSha: String) async throws {
+        guard let token = moderationToken else { return }
+        var req = URLRequest(url: baseURL.appendingPathComponent("/api/submissions/\(buildSha)"))
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue(token, forHTTPHeaderField: "x-moderation-token")
+        req.httpBody = Data(#"{"action":"accept"}"#.utf8)
+        _ = try await perform(req)
     }
 
     private struct AssetsStatus: Decodable { let missing: [String] }

--- a/web/src/app/api/submissions/[sha256]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/route.ts
@@ -67,7 +67,9 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
       return Response.json({ error: "not found" }, { status: 404 });
     }
     name = r.rows[0].record.image?.name ?? "";
-    await ingestRecord(c, r.rows[0].record);
+    // Force: an accept must replace the live build wholesale — record, row
+    // columns, and derived tables — even when the record looks unchanged.
+    await ingestRecord(c, r.rows[0].record, { force: true });
     await c.query(
       "UPDATE submission_queue SET status='accepted', reviewed_at=now() WHERE sha256=$1",
       [sha256]

--- a/web/src/lib/ingest.ts
+++ b/web/src/lib/ingest.ts
@@ -65,7 +65,11 @@ function buildDate(rec: BuildRecord): string | null {
   return m ? `${m[1]}-${m[2]}-${m[3]}` : raw;
 }
 
-export async function ingestRecord(db: Queryable, rec: BuildRecord): Promise<void> {
+export async function ingestRecord(
+  db: Queryable,
+  rec: BuildRecord,
+  opts: { force?: boolean } = {}
+): Promise<void> {
   rec = stripNulls(rec);
   const sha = rec.image.sha256;
   const st = rec.structural;
@@ -79,17 +83,30 @@ export async function ingestRecord(db: Queryable, rec: BuildRecord): Promise<voi
   // exactly as it was inserted) means a re-run of the same export touches each
   // unchanged build with a single indexed lookup instead. ingestRecordTx is
   // all-or-nothing, so an existing build row always has consistent derived data.
-  const seen = (await db.query(
-    "SELECT 1 FROM builds WHERE sha256=$1 AND record = $2::jsonb",
-    [sha, JSON.stringify(rec)]
-  )) as { rows: unknown[] };
-  if (seen.rows.length > 0) return;
+  // `force` (moderation accept) bypasses the skip: accepting must be authoritative,
+  // rewriting the row and every derived table even when the record looks unchanged,
+  // so it also repairs derived rows written by older ingest versions.
+  if (!opts.force) {
+    const seen = (await db.query(
+      "SELECT 1 FROM builds WHERE sha256=$1 AND record = $2::jsonb",
+      [sha, JSON.stringify(rec)]
+    )) as { rows: unknown[] };
+    if (seen.rows.length > 0) return;
+  }
 
   await db.query(
     `INSERT INTO builds (sha256,name,system,size,md5,sha1,content_hash,filtered_content_hash,
         file_count,total_size,max_depth,ext_histogram,text_doc,fingerprint_profile,record,build_date)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
-     ON CONFLICT (sha256) DO UPDATE SET record=excluded.record, build_date=excluded.build_date`,
+     ON CONFLICT (sha256) DO UPDATE SET
+        name=excluded.name, system=excluded.system, size=excluded.size,
+        md5=excluded.md5, sha1=excluded.sha1,
+        content_hash=excluded.content_hash,
+        filtered_content_hash=excluded.filtered_content_hash,
+        file_count=excluded.file_count, total_size=excluded.total_size,
+        max_depth=excluded.max_depth, ext_histogram=excluded.ext_histogram,
+        text_doc=excluded.text_doc, fingerprint_profile=excluded.fingerprint_profile,
+        record=excluded.record, build_date=excluded.build_date`,
     [sha, rec.image.name, rec.info?.system ?? "", rec.image.size, rec.image.md5, rec.image.sha1,
      comp.content_hash ?? null, comp.filtered_content_hash ?? null, st.file_count, st.total_size, st.max_depth,
      JSON.stringify(st.ext_histogram ?? {}), capTextDoc(rec.text_doc ?? ""), rec.fingerprint_profile, rec, buildDate(rec)]


### PR DESCRIPTION
Accepting a resubmission did not update the live build. The moderation accept ran the shared ingest, which skips when the queued record matches the stored one and only refreshed record and build_date on conflict, so updated assets never landed. Accept now forces a full re-ingest that upserts every builds column and rewrites all derived tables, while bulk ingest keeps the cheap skip. Both GUIs also gain an optional CURATOR_MODERATION_TOKEN that auto-accepts right after submit and asset upload, so owner submits replace the live build in one step while anonymous submissions still queue.