### PR TITLE
Open a folder as one build

### DIFF
--- a/crates/curator-core/src/fingerprint.rs
+++ b/crates/curator-core/src/fingerprint.rs
@@ -27,13 +27,19 @@ pub fn is_ignored(path: &str) -> bool {
 }
 
 /// Stream the image once, computing md5/sha1/sha256 and emitting progress.
+/// A directory (a folder opened as one build) hashes its track set instead —
+/// see [`hash_dir`].
 pub fn hash_image(path: &str, observer: &Arc<dyn ProgressObserver>) -> Result<ImageInfo> {
-    let name = std::path::Path::new(path)
+    let p = std::path::Path::new(path);
+    if p.is_dir() {
+        return hash_dir(p, observer);
+    }
+    let name = p
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_else(|| path.to_string());
 
-    let mut file = File::open(path)?;
+    let file = File::open(path)?;
     let size = file.metadata()?.len();
 
     const ID: u64 = 0;
@@ -44,35 +50,101 @@ pub fn hash_image(path: &str, observer: &Arc<dyn ProgressObserver>) -> Result<Im
         total: Some(size as f64),
     });
 
-    let mut md5 = Md5::new();
-    let mut sha1 = Sha1::new();
-    let mut sha256 = Sha256::new();
-    let mut buf = vec![0u8; READ_CHUNK];
+    let mut hashers = ImageHashers::new();
+    let done = hashers.consume(file, 0, ID, observer)?;
+    observer.on_event(Event::CounterClose { id: ID });
+
+    Ok(hashers.finish(name, done))
+}
+
+/// Identity for a folder opened as one build: the folder's importable files (its
+/// track set — descriptors and sidecars like `.cue`/`.gdi` are excluded, so a
+/// cue edit or a scan file doesn't change identity), concatenated in natural
+/// name order ("Track 2" before "Track 10", i.e. disc order) and hashed as one
+/// stream. Depends only on the member files' names and bytes, not the folder's
+/// own name or location.
+fn hash_dir(root: &std::path::Path, observer: &Arc<dyn ProgressObserver>) -> Result<ImageInfo> {
+    let name = root
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| root.to_string_lossy().into_owned());
+    let files = crate::dir_image_files(root);
+    if files.is_empty() {
+        return Err(crate::error::Error::Unsupported(root.to_string_lossy().into_owned()));
+    }
+
+    let mut total: u64 = 0;
+    for f in &files {
+        total += std::fs::metadata(f)?.len();
+    }
+
+    const ID: u64 = 0;
+    observer.on_event(Event::CounterOpen {
+        id: ID,
+        label: format!("Hashing image {name}"),
+        unit: "B".into(),
+        total: Some(total as f64),
+    });
+
+    let mut hashers = ImageHashers::new();
     let mut done: u64 = 0;
-    loop {
-        if observer.is_cancelled() {
-            observer.on_event(Event::CounterClose { id: ID });
-            return Err(crate::error::Error::Cancelled);
-        }
-        let n = file.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
-        md5.update(&buf[..n]);
-        sha1.update(&buf[..n]);
-        sha256.update(&buf[..n]);
-        done += n as u64;
-        observer.on_event(Event::Progress { id: ID, count: done as f64 });
+    for f in &files {
+        done = hashers.consume(File::open(f)?, done, ID, observer)?;
     }
     observer.on_event(Event::CounterClose { id: ID });
 
-    Ok(ImageInfo {
-        name,
-        size,
-        md5: hex::encode(md5.finalize()),
-        sha1: hex::encode(sha1.finalize()),
-        sha256: hex::encode(sha256.finalize()),
-    })
+    Ok(hashers.finish(name, done))
+}
+
+/// The md5+sha1+sha256 triple an image identity is built from, fed one reader
+/// at a time (a single image file, or each track of a folder build in turn).
+struct ImageHashers {
+    md5: Md5,
+    sha1: Sha1,
+    sha256: Sha256,
+}
+
+impl ImageHashers {
+    fn new() -> Self {
+        ImageHashers { md5: Md5::new(), sha1: Sha1::new(), sha256: Sha256::new() }
+    }
+
+    /// Stream `reader` into all three hashers, advancing the progress counter
+    /// from `done`. Returns the new byte count.
+    fn consume(
+        &mut self,
+        mut reader: impl Read,
+        mut done: u64,
+        counter_id: u64,
+        observer: &Arc<dyn ProgressObserver>,
+    ) -> Result<u64> {
+        let mut buf = vec![0u8; READ_CHUNK];
+        loop {
+            if observer.is_cancelled() {
+                observer.on_event(Event::CounterClose { id: counter_id });
+                return Err(crate::error::Error::Cancelled);
+            }
+            let n = reader.read(&mut buf)?;
+            if n == 0 {
+                return Ok(done);
+            }
+            self.md5.update(&buf[..n]);
+            self.sha1.update(&buf[..n]);
+            self.sha256.update(&buf[..n]);
+            done += n as u64;
+            observer.on_event(Event::Progress { id: counter_id, count: done as f64 });
+        }
+    }
+
+    fn finish(self, name: String, size: u64) -> ImageInfo {
+        ImageInfo {
+            name,
+            size,
+            md5: hex::encode(self.md5.finalize()),
+            sha1: hex::encode(self.sha1.finalize()),
+            sha256: hex::encode(self.sha256.finalize()),
+        }
+    }
 }
 
 /// Content composites from the adapter's per-file sha1s.

--- a/crates/curator-core/src/lib.rs
+++ b/crates/curator-core/src/lib.rs
@@ -76,7 +76,10 @@ impl Analyzer {
         })
     }
 
-    /// Analyze one image/container. Idempotent: a known sha256 is served from cache.
+    /// Analyze one image/container, or a folder holding one build split across
+    /// files (a multi-track dump — identity comes from the track set, see
+    /// [`fingerprint::hash_image`]). Idempotent: a known sha256 is served from
+    /// cache.
     pub fn analyze(
         &self,
         path: &str,
@@ -515,6 +518,168 @@ fn asset_blob_in(store: &Path, sha256: &str) -> Option<PathBuf> {
     path.is_file().then_some(path)
 }
 
+/// Descriptor files that lay out one disc's tracks. Exactly one at a folder's top
+/// level marks the folder as a single multi-track build (see
+/// [`folder_is_single_build`]).
+const DISC_DESCRIPTOR_EXTENSIONS: &[&str] = &["cue", "gdi", "ccd"];
+
+/// Whether `root` holds ONE dump split across files (a multi-track disc) rather
+/// than a collection of separate images. True when the folder's top level has
+/// exactly one `.cue`/`.gdi`/`.ccd` descriptor and at least one importable file,
+/// or no descriptor but two or more importable files all named like tracks of one
+/// set ("Track 1.bin", "Game (Track 02).bin", …) with a matching prefix. A folder
+/// whose subdirectories hold importable files is a collection, never a single
+/// build. `Open Folder as Build` bypasses this check — it's for routing drops and
+/// batch imports.
+pub fn folder_is_single_build(root: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(root) else { return false };
+    let mut descriptors = 0usize;
+    let mut stems: Vec<String> = Vec::new(); // lowercased stems of importable files
+    for entry in entries.flatten() {
+        let path = entry.path();
+        match entry.file_type() {
+            Ok(ft) if ft.is_dir() => {
+                if !list_importable_files(&path).is_empty() {
+                    return false;
+                }
+            }
+            Ok(ft) if ft.is_file() => {
+                let ext = path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .map(|e| e.to_ascii_lowercase());
+                if ext.as_deref().is_some_and(|e| DISC_DESCRIPTOR_EXTENSIONS.contains(&e)) {
+                    descriptors += 1;
+                } else if looks_importable(&path) {
+                    stems.push(
+                        path.file_stem()
+                            .unwrap_or_default()
+                            .to_string_lossy()
+                            .to_ascii_lowercase(),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+    if stems.is_empty() {
+        return false;
+    }
+    match descriptors {
+        1 => true,
+        0 => stems.len() >= 2 && is_track_set(&stems),
+        _ => false, // several descriptors ⇒ several discs
+    }
+}
+
+/// True when every stem ends in a track-number suffix and the prefixes before it
+/// all match — the naming of one split dump.
+fn is_track_set(stems: &[String]) -> bool {
+    let mut prefix: Option<&str> = None;
+    for stem in stems {
+        let Some(p) = strip_track_suffix(stem) else { return false };
+        if *prefix.get_or_insert(p) != p {
+            return false;
+        }
+    }
+    true
+}
+
+/// For a (lowercased) stem like "game (track 12)", the prefix before the track
+/// suffix ("game"), or `None` when the stem doesn't end in one. "track" must sit
+/// at the stem's start or after a separator, so "backtrack 2" doesn't count.
+fn strip_track_suffix(stem: &str) -> Option<&str> {
+    let base = stem.trim_end().trim_end_matches(')');
+    let no_digits = base.trim_end_matches(|c: char| c.is_ascii_digit());
+    if no_digits.len() == base.len() {
+        return None; // no trailing digits
+    }
+    let s = no_digits.trim_end_matches([' ', '_', '-', '#', '.']).strip_suffix("track")?;
+    if !s.is_empty() && !s.ends_with([' ', '-', '_', '(', '.']) {
+        return None;
+    }
+    Some(s.trim_end_matches(['(', ' ', '-', '_', '.']))
+}
+
+/// The files that constitute a folder-as-one-build's disc image: its importable
+/// files in natural name order ("Track 2" before "Track 10"), so identity hashing
+/// concatenates the tracks in disc order.
+pub fn dir_image_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = list_importable_files(root);
+    files.sort_by(|a, b| natural_cmp(&a.to_string_lossy(), &b.to_string_lossy()));
+    files
+}
+
+/// Case-insensitive ordering that compares embedded digit runs by numeric value,
+/// with a raw tiebreak so the order is total and deterministic.
+fn natural_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    let (ab, bb) = (a.as_bytes(), b.as_bytes());
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < ab.len() && j < bb.len() {
+        if ab[i].is_ascii_digit() && bb[j].is_ascii_digit() {
+            let (si, sj) = (i, j);
+            while i < ab.len() && ab[i].is_ascii_digit() {
+                i += 1;
+            }
+            while j < bb.len() && bb[j].is_ascii_digit() {
+                j += 1;
+            }
+            let da = trim_leading_zeros(&ab[si..i]);
+            let db = trim_leading_zeros(&bb[sj..j]);
+            match da.len().cmp(&db.len()).then_with(|| da.cmp(db)) {
+                Ordering::Equal => {}
+                other => return other,
+            }
+        } else {
+            match ab[i].to_ascii_lowercase().cmp(&bb[j].to_ascii_lowercase()) {
+                Ordering::Equal => {
+                    i += 1;
+                    j += 1;
+                }
+                other => return other,
+            }
+        }
+    }
+    (ab.len() - i).cmp(&(bb.len() - j)).then_with(|| a.cmp(b))
+}
+
+fn trim_leading_zeros(digits: &[u8]) -> &[u8] {
+    let start = digits.iter().position(|&b| b != b'0').unwrap_or(digits.len() - 1);
+    &digits[start..]
+}
+
+/// Import units under `root`: like [`list_importable_files`], but a directory
+/// holding one build split across files (see [`folder_is_single_build`]) comes
+/// back as a single unit instead of its member files, so batch import analyzes
+/// it as one build. When `root` itself is such a folder, it is the sole unit.
+pub fn list_import_units(root: &Path) -> Vec<PathBuf> {
+    if folder_is_single_build(root) {
+        return vec![root.to_path_buf()];
+    }
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else { continue };
+        for entry in entries.flatten() {
+            match entry.file_type() {
+                Ok(ft) if ft.is_dir() => {
+                    let path = entry.path();
+                    if folder_is_single_build(&path) {
+                        out.push(path);
+                    } else {
+                        stack.push(path);
+                    }
+                }
+                Ok(ft) if ft.is_file() && looks_importable(&entry.path()) => out.push(entry.path()),
+                _ => {}
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
 /// Recursively collect importable files under `root`, depth-first, sorted for a
 /// deterministic order. Non-disc files (per ps2exe's blocklist) and symlinks are
 /// skipped; unreadable directories are silently skipped. Backs the GUIs' folder
@@ -572,6 +737,127 @@ mod walk_tests {
         let root = std::env::temp_dir().join("curator-walk-nope-zzz");
         let _ = std::fs::remove_dir_all(&root);
         assert!(list_importable_files(&root).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod folder_build_tests {
+    use super::{dir_image_files, folder_is_single_build, list_import_units, natural_cmp};
+    use std::path::{Path, PathBuf};
+
+    fn scratch(name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!("curator-fb-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn touch(root: &Path, rel: &str) {
+        let p = root.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, b"x").unwrap();
+    }
+
+    #[test]
+    fn cue_plus_tracks_is_single_build() {
+        let root = scratch("cue");
+        touch(&root, "Track 1.bin");
+        touch(&root, "Track 2.bin");
+        touch(&root, "disc.cue");
+        assert!(folder_is_single_build(&root));
+        assert_eq!(list_import_units(&root), vec![root.clone()]);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn track_named_bins_without_cue_are_single_build() {
+        let root = scratch("nocue");
+        touch(&root, "Track 1.bin");
+        touch(&root, "Track 2.bin");
+        assert!(folder_is_single_build(&root));
+
+        // Redump-style naming with a shared prefix counts too.
+        let root2 = scratch("redump");
+        touch(&root2, "Game (USA) (Track 1).bin");
+        touch(&root2, "Game (USA) (Track 02).bin");
+        assert!(folder_is_single_build(&root2));
+
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&root2);
+    }
+
+    #[test]
+    fn collections_are_not_single_builds() {
+        // Two descriptors ⇒ two discs.
+        let root = scratch("twodiscs");
+        touch(&root, "disc1.cue");
+        touch(&root, "disc1.bin");
+        touch(&root, "disc2.cue");
+        touch(&root, "disc2.bin");
+        assert!(!folder_is_single_build(&root));
+
+        // Unrelated loose images, no descriptor.
+        let root2 = scratch("loose");
+        touch(&root2, "game-a.iso");
+        touch(&root2, "game-b.iso");
+        assert!(!folder_is_single_build(&root2));
+
+        // A single lone image isn't a *split* build; "backtrack" isn't "track".
+        let root3 = scratch("lone");
+        touch(&root3, "backtrack 1.bin");
+        touch(&root3, "backtrack 2.bin");
+        assert!(!folder_is_single_build(&root3));
+
+        // A subdirectory with importable content ⇒ collection.
+        let root4 = scratch("nested");
+        touch(&root4, "disc.cue");
+        touch(&root4, "Track 1.bin");
+        touch(&root4, "extras/bonus.iso");
+        assert!(!folder_is_single_build(&root4));
+
+        for r in [root, root2, root3, root4] {
+            let _ = std::fs::remove_dir_all(&r);
+        }
+    }
+
+    #[test]
+    fn import_units_group_single_build_dirs() {
+        let root = scratch("units");
+        touch(&root, "loose.iso");
+        touch(&root, "dump/Track 1.bin");
+        touch(&root, "dump/Track 2.bin");
+        touch(&root, "dump/disc.cue");
+        touch(&root, "other/a.chd");
+        touch(&root, "other/b.chd");
+        let rel: Vec<String> = list_import_units(&root)
+            .iter()
+            .map(|p| p.strip_prefix(&root).unwrap().to_string_lossy().replace('\\', "/"))
+            .collect();
+        assert_eq!(rel, ["dump", "loose.iso", "other/a.chd", "other/b.chd"]);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn dir_image_files_use_natural_track_order() {
+        let root = scratch("order");
+        for name in ["Track 1.bin", "Track 2.bin", "Track 10.bin", "disc.cue"] {
+            touch(&root, name);
+        }
+        let names: Vec<String> = dir_image_files(&root)
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, ["Track 1.bin", "Track 2.bin", "Track 10.bin"]);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn natural_cmp_orders_numbers_by_value() {
+        use std::cmp::Ordering;
+        assert_eq!(natural_cmp("track 2", "track 10"), Ordering::Less);
+        assert_eq!(natural_cmp("Track 02", "track 2"), Ordering::Less); // total order tiebreak
+        assert_eq!(natural_cmp("a", "ab"), Ordering::Less);
+        assert_eq!(natural_cmp("b1", "a2"), Ordering::Greater);
     }
 }
 

--- a/crates/curator-ffi/src/lib.rs
+++ b/crates/curator-ffi/src/lib.rs
@@ -260,6 +260,14 @@ impl ProgressObserver for ListenerObserver {
     }
 }
 
+/// Whether `root` is a folder holding ONE build split across files (a multi-track
+/// dump) rather than a collection of separate images — the UI routes such folders
+/// to `analyze` instead of batch import. See `curator_core::folder_is_single_build`.
+#[uniffi::export]
+pub fn folder_is_single_build(root: String) -> bool {
+    curator_core::folder_is_single_build(std::path::Path::new(&root))
+}
+
 // ---- Engine ----
 
 /// The analysis engine. Construct once; methods are thread-safe.
@@ -347,10 +355,12 @@ impl Engine {
         Ok(self.reader.lock().unwrap_or_else(|e| e.into_inner()).list_systems()?)
     }
 
-    /// Recursively list every file under `root`, sorted. Used by folder import:
-    /// the UI walks the tree, then calls `analyze` on each and skips non-discs.
+    /// Recursively list the import units under `root`, sorted: importable files,
+    /// except that a folder holding one build split across files (a multi-track
+    /// dump) comes back as a single unit. Used by folder import: the UI walks the
+    /// list, then calls `analyze` on each and skips non-discs.
     pub fn list_files(&self, root: String) -> Result<Vec<String>, CuratorError> {
-        Ok(curator_core::list_importable_files(std::path::Path::new(&root))
+        Ok(curator_core::list_import_units(std::path::Path::new(&root))
             .into_iter()
             .map(|p| p.to_string_lossy().into_owned())
             .collect())

--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -82,6 +82,7 @@ mod app {
     const IDM_EXPORT: usize = 10;
     const IDM_BROWSE: usize = 11;
     const IDM_VIEW_ASSETS: usize = 12;
+    const IDM_OPEN_DIR_BUILD: usize = 13;
     const IDM_RECENT_BASE: usize = 2000;
     const MAX_RECENT: u32 = 15;
 
@@ -589,6 +590,7 @@ mod app {
         let file = CreatePopupMenu().unwrap_or_default();
         let recent = CreatePopupMenu().unwrap_or_default();
         let _ = AppendMenuW(file, MF_STRING, IDM_OPEN, w!("&Open Image…\tCtrl+O"));
+        let _ = AppendMenuW(file, MF_STRING, IDM_OPEN_DIR_BUILD, w!("Open Folder as &Build…"));
         let _ = AppendMenuW(file, MF_STRING, IDM_OPEN_FOLDER, w!("&Import Folder (recursive)…"));
         let _ = AppendMenuW(file, MF_POPUP, recent.0 as usize, w!("Open &Recent"));
         let _ = AppendMenuW(file, MF_STRING, IDM_BROWSE, w!("&Browse Library…\tCtrl+B"));
@@ -654,9 +656,22 @@ mod app {
                     start_analysis(hwnd, path);
                 }
             }
+            IDM_OPEN_DIR_BUILD => {
+                // Force the whole folder through as ONE build (a split multi-track
+                // dump), regardless of the single-build heuristic.
+                if let Some(dir) = pick_folder(hwnd) {
+                    start_analysis(hwnd, dir);
+                }
+            }
             IDM_OPEN_FOLDER => {
                 if let Some(dir) = pick_folder(hwnd) {
-                    start_import(hwnd, expand_inputs(vec![dir]));
+                    let units = expand_inputs(vec![dir]);
+                    // A folder that is itself one split build analyzes as one unit.
+                    match units.len() {
+                        0 => set_status(hwnd, "Nothing to import."),
+                        1 => start_analysis(hwnd, units.into_iter().next().unwrap()),
+                        _ => start_import(hwnd, units),
+                    }
                 }
             }
             IDM_CANCEL => {
@@ -1252,8 +1267,8 @@ mod app {
         }
     }
 
-    /// WM_DROPFILES: analyze a single dropped file, or batch-import when multiple
-    /// items (or a folder) are dropped.
+    /// WM_DROPFILES: analyze a single dropped file (or a folder that is one split
+    /// multi-track build), or batch-import when the drop expands to several units.
     unsafe fn on_drop(hwnd: HWND, wparam: WPARAM) {
         let hdrop = HDROP(wparam.0 as *mut core::ffi::c_void);
         let count = DragQueryFileW(hdrop, u32::MAX, None);
@@ -1275,14 +1290,16 @@ mod app {
         }
     }
 
-    /// Expand dropped/selected paths to a flat file list: directories are walked
-    /// recursively; plain files pass through. Order is deterministic.
+    /// Expand dropped/selected paths to a flat list of import units: directories
+    /// are walked recursively, except that a folder holding one build split across
+    /// files (a multi-track dump) stays a single unit and analyzes as one build.
+    /// Plain files pass through. Order is deterministic.
     fn expand_inputs(paths: Vec<String>) -> Vec<String> {
         let mut out = Vec::new();
         for p in paths {
             let path = std::path::Path::new(&p);
             if path.is_dir() {
-                for f in curator_core::list_importable_files(path) {
+                for f in curator_core::list_import_units(path) {
                     out.push(f.to_string_lossy().into_owned());
                 }
             } else if path.is_file() {

--- a/macos/Sources/CuratorApp/AppModel.swift
+++ b/macos/Sources/CuratorApp/AppModel.swift
@@ -475,13 +475,28 @@ final class AppModel: ObservableObject {
         }
     }
 
-    /// Analyze a single file, or recursively import a dropped/chosen folder.
+    /// Analyze a single file, or a folder that holds one build split across files
+    /// (a multi-track dump); recursively import any other dropped/chosen folder.
     func open(url: URL) {
         var isDir: ObjCBool = false
         FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
-        if isDir.boolValue {
+        if isDir.boolValue && !folderIsSingleBuild(root: url.path) {
             importFolder(url: url)
         } else {
+            analyze(url: url)
+        }
+    }
+
+    /// Present a folder picker and force the choice through as ONE build (a split
+    /// multi-track dump), regardless of the single-build heuristic.
+    func openFolderAsBuildDialog() {
+        guard !isWorking else { return }
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Open as Build"
+        if panel.runModal() == .OK, let url = panel.url {
             analyze(url: url)
         }
     }

--- a/macos/Sources/CuratorApp/CuratorApp.swift
+++ b/macos/Sources/CuratorApp/CuratorApp.swift
@@ -15,6 +15,9 @@ struct CuratorApp: App {
                 Button("Open…") { model.openDialog() }
                     .keyboardShortcut("o", modifiers: .command)
                     .disabled(model.isWorking)
+                Button("Open Folder as Build…") { model.openFolderAsBuildDialog() }
+                    .keyboardShortcut("o", modifiers: [.command, .shift])
+                    .disabled(model.isWorking)
                 Divider()
                 Button("Export Library for Upload…") { model.exportLibrary() }
                     .keyboardShortcut("e", modifiers: .command)

--- a/macos/Sources/CuratorKit/curator_ffi.swift
+++ b/macos/Sources/CuratorKit/curator_ffi.swift
@@ -729,8 +729,10 @@ public protocol EngineProtocol: AnyObject, Sendable {
     func librarySystems() throws  -> [String]
     
     /**
-     * Recursively list every file under `root`, sorted. Used by folder import:
-     * the UI walks the tree, then calls `analyze` on each and skips non-discs.
+     * Recursively list the import units under `root`, sorted: importable files,
+     * except that a folder holding one build split across files (a multi-track
+     * dump) comes back as a single unit. Used by folder import: the UI walks the
+     * list, then calls `analyze` on each and skips non-discs.
      */
     func listFiles(root: String) throws  -> [String]
     
@@ -888,8 +890,10 @@ open func librarySystems()throws  -> [String]  {
 }
     
     /**
-     * Recursively list every file under `root`, sorted. Used by folder import:
-     * the UI walks the tree, then calls `analyze` on each and skips non-discs.
+     * Recursively list the import units under `root`, sorted: importable files,
+     * except that a folder holding one build split across files (a multi-track
+     * dump) comes back as a single unit. Used by folder import: the UI walks the
+     * list, then calls `analyze` on each and skips non-discs.
      */
 open func listFiles(root: String)throws  -> [String]  {
     return try  FfiConverterSequenceString.lift(try rustCallWithError(FfiConverterTypeCuratorError_lift) {
@@ -2033,6 +2037,18 @@ fileprivate struct FfiConverterSequenceTypeLibraryEntry: FfiConverterRustBuffer 
         return seq
     }
 }
+/**
+ * Whether `root` is a folder holding ONE build split across files (a multi-track
+ * dump) rather than a collection of separate images — the UI routes such folders
+ * to `analyze` instead of batch import. See `curator_core::folder_is_single_build`.
+ */
+public func folderIsSingleBuild(root: String) -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_curator_ffi_fn_func_folder_is_single_build(
+        FfiConverterString.lower(root),$0
+    )
+})
+}
 
 private enum InitializationResult {
     case ok
@@ -2048,6 +2064,9 @@ private let initializationResult: InitializationResult = {
     let scaffolding_contract_version = ffi_curator_ffi_uniffi_contract_version()
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
+    }
+    if (uniffi_curator_ffi_checksum_func_folder_is_single_build() != 6360) {
+        return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_curator_ffi_checksum_method_cancelhandle_cancel() != 40201) {
         return InitializationResult.apiChecksumMismatch
@@ -2070,7 +2089,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_curator_ffi_checksum_method_engine_library_systems() != 32687) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_curator_ffi_checksum_method_engine_list_files() != 6362) {
+    if (uniffi_curator_ffi_checksum_method_engine_list_files() != 51427) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_curator_ffi_checksum_method_engine_load_build() != 49667) {

--- a/macos/Sources/curator_ffiFFI/include/curator_ffiFFI.h
+++ b/macos/Sources/curator_ffiFFI/include/curator_ffiFFI.h
@@ -382,6 +382,11 @@ RustBuffer uniffi_curator_ffi_fn_method_engine_search_library(uint64_t ptr, Rust
 void uniffi_curator_ffi_fn_init_callback_vtable_progresslistener(const UniffiVTableCallbackInterfaceProgressListener* _Nonnull vtable
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_FN_FUNC_FOLDER_IS_SINGLE_BUILD
+#define UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_FN_FUNC_FOLDER_IS_SINGLE_BUILD
+int8_t uniffi_curator_ffi_fn_func_folder_is_single_build(RustBuffer root, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_FFI_CURATOR_FFI_RUSTBUFFER_ALLOC
 #define UNIFFI_FFIDEF_FFI_CURATOR_FFI_RUSTBUFFER_ALLOC
 RustBuffer ffi_curator_ffi_rustbuffer_alloc(uint64_t size, RustCallStatus *_Nonnull out_status
@@ -640,6 +645,12 @@ void ffi_curator_ffi_rust_future_free_void(uint64_t handle
 #ifndef UNIFFI_FFIDEF_FFI_CURATOR_FFI_RUST_FUTURE_COMPLETE_VOID
 #define UNIFFI_FFIDEF_FFI_CURATOR_FFI_RUST_FUTURE_COMPLETE_VOID
 void ffi_curator_ffi_rust_future_complete_void(uint64_t handle, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_CHECKSUM_FUNC_FOLDER_IS_SINGLE_BUILD
+#define UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_CHECKSUM_FUNC_FOLDER_IS_SINGLE_BUILD
+uint16_t uniffi_curator_ffi_checksum_func_folder_is_single_build(void
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_CHECKSUM_METHOD_CANCELHANDLE_CANCEL

--- a/ps2exe-adapter/curator_adapter/cli.py
+++ b/ps2exe-adapter/curator_adapter/cli.py
@@ -1,4 +1,5 @@
-"""Analyze a disc image/container with ps2exe and emit canonical-raw JSON on stdout.
+"""Analyze a disc image, container, or folder (a split multi-track dump opened as
+one build) with ps2exe and emit canonical-raw JSON on stdout.
 
 Progress is streamed as NDJSON on stderr (see progress.ProgressManager). All ps2exe
 logging/prints are forced to stderr so stdout carries only the final JSON document.
@@ -154,19 +155,49 @@ def _score_volume(reader):
     return (priority, count)
 
 
-def _enumerate_volumes(fp, basename, parent, mods, manager):
-    """Every leaf filesystem volume reachable from `fp`, paired with the list of
-    archive-member names ('locator') needed to re-reach it (empty = top level).
+def _is_container(reader, mods):
+    """Containers hold member files rather than a filesystem volume: an archive,
+    or a directory (a folder opened as one multi-track build)."""
+    return isinstance(reader, (mods["compressed"], mods["directory"]))
+
+
+@contextlib.contextmanager
+def _source_readers(path, basename, parent_dir, mods, manager):
+    """Top-level path readers for a source. A directory becomes a directory
+    container whose members are the folder's files (so a split multi-track dump
+    processes like an archive of its tracks); a file goes through the factory's
+    magic sniffing."""
+    if os.path.isdir(path):
+        yield [mods["directory"](pathlib.Path(path))]
+    else:
+        with open(path, "rb") as fp:
+            parent = mods["directory"](parent_dir)
+            readers, _exc = mods["factory"].get_iso_path_readers(fp, basename, parent, manager)
+            yield readers
+
+
+def _member_path(reader, entry, mods):
+    """A member's path within its container. Directory members come back as host
+    paths, so relativize them against the container root, with / separators."""
+    path = reader.get_file_path(entry)
+    if isinstance(reader, mods["directory"]):
+        path = os.path.relpath(path, str(reader.get_root_dir())).replace(os.sep, "/")
+    return path
+
+
+def _enumerate_volumes(readers, mods, manager):
+    """Every leaf filesystem volume reachable from the top-level `readers`, paired
+    with the list of container-member names ('locator') needed to re-reach it
+    (empty = top level).
 
     Reading member *directories* in a single archive pass is fine; reading member
     *content* is not, on a one-pass stream. So callers select a volume here, then
     reopen it via `_open_volume` to actually read bytes."""
     factory = mods["factory"]
-    readers, _exc = factory.get_iso_path_readers(fp, basename, parent, manager)
     found = []
 
     def walk(reader, locator, depth):
-        if not isinstance(reader, mods["compressed"]):
+        if not _is_container(reader, mods):
             found.append((locator, reader))
             return
         if depth > 4:
@@ -188,12 +219,12 @@ def _enumerate_volumes(fp, basename, parent, mods, manager):
     return found
 
 
-def _open_volume(fp, basename, parent, locator, vtype, mods, manager):
-    """Reopen the volume identified by (`locator`, `vtype`) on a fresh `fp`, opening
-    *only* the members along `locator`. Touching sibling members first would strand
-    a Dreamcast high-density track's content on a single-pass archive stream."""
+def _open_volume(readers, locator, vtype, mods, manager):
+    """Reopen the volume identified by (`locator`, `vtype`) from fresh top-level
+    `readers`, opening *only* the members along `locator`. Touching sibling members
+    first would strand a Dreamcast high-density track's content on a single-pass
+    archive stream."""
     factory = mods["factory"]
-    readers, _exc = factory.get_iso_path_readers(fp, basename, parent, manager)
 
     def pick(candidates):
         if not candidates:
@@ -202,12 +233,12 @@ def _open_volume(fp, basename, parent, locator, vtype, mods, manager):
         return (match or candidates)[0]
 
     if not locator:
-        fs = [r for r in readers if not isinstance(r, mods["compressed"])]
+        fs = [r for r in readers if not _is_container(r, mods)]
         return pick(fs or readers)
 
     current = readers
     for name in locator:
-        container = next((r for r in current if isinstance(r, mods["compressed"])), None)
+        container = next((r for r in current if _is_container(r, mods)), None)
         if container is None:
             return None
         target = next(
@@ -256,9 +287,8 @@ def _process_streaming(path, basename, parent_dir, locator, vtype, mods, manager
     self-contained volume (PS1/2/3, Saturn, Mega CD, 3DO, combined Dreamcast
     images, …)."""
     factory, base, generic = mods["factory"], mods["base"], mods["generic"]
-    with open(path, "rb") as fp:
-        parent = mods["directory"](parent_dir)
-        reader = _open_volume(fp, basename, parent, locator, vtype, mods, manager)
+    with _source_readers(path, basename, parent_dir, mods, manager) as readers:
+        reader = _open_volume(readers, locator, vtype, mods, manager)
         if reader is None:
             raise SystemExit(f"could not reopen chosen volume in {path!r}")
         system = base.get_system_type(reader) or "unknown"
@@ -304,10 +334,8 @@ def _process_gdrom(path, basename, parent_dir, mods, manager, work):
     reader is seekable (its tracks are mmapped), so we rank candidates by file count
     and hash only the richest."""
     factory, base, generic = mods["factory"], mods["base"], mods["generic"]
-    with open(path, "rb") as fp:
-        parent = mods["directory"](parent_dir)
-        readers, _exc = factory.get_iso_path_readers(fp, basename, parent, manager)
-        container = next((r for r in readers if isinstance(r, mods["compressed"])), None)
+    with _source_readers(path, basename, parent_dir, mods, manager) as readers:
+        container = next((r for r in readers if _is_container(r, mods)), None)
         members = (
             list(container.iso_iterator(container.get_root_dir(), recursive=True, include_dirs=False))
             if container else [None]
@@ -621,9 +649,8 @@ def _select_volume(path, basename, parent_dir, mods, manager):
     high-density volume, not the first (low-density) one the old "first readable"
     pick returned. A non-zero start sector marks that high-density volume, whose
     files may span several tracks needing .cue/.gdi reassembly."""
-    with open(path, "rb") as fp:
-        parent = mods["directory"](parent_dir)
-        candidates = _enumerate_volumes(fp, basename, parent, mods, manager)
+    with _source_readers(path, basename, parent_dir, mods, manager) as readers:
+        candidates = _enumerate_volumes(readers, mods, manager)
         if not candidates:
             raise SystemExit(f"no readable volume found in {path!r} (unsupported format?)")
         locator, chosen = max(candidates, key=lambda c: _score_volume(c[1]))
@@ -656,9 +683,9 @@ def _process(path, basename, parent_dir, mods, manager, work):
 
 def analyze(path):
     mods = _import_ps2exe()
-    factory = mods["factory"]
     manager = ProgressManager()
 
+    path = os.path.normpath(path)  # a folder path may arrive with a trailing slash
     basename = os.path.basename(path)
     parent_dir = pathlib.Path(path).resolve().parent
 
@@ -676,9 +703,7 @@ def analyze(path):
     # content packages trip ps2exe's re-iteration bug (ConsumedArchiveEntry).
     media = []
     if system in AUDIO_SYSTEMS:
-        with open(path, "rb") as fp:
-            parent = mods["directory"](parent_dir)
-            audio_readers, _exc = factory.get_iso_path_readers(fp, basename, parent, manager)
+        with _source_readers(path, basename, parent_dir, mods, manager) as audio_readers:
             media = _scan_audio_tracks(audio_readers, mods, manager)
 
     return {"info": info, "files": files, "media": media, "exe_fp": exe_fp}
@@ -691,6 +716,7 @@ def extract(path, out_dir):
     mods = _import_ps2exe()
     manager = ProgressManager()
 
+    path = os.path.normpath(path)  # a folder path may arrive with a trailing slash
     basename = os.path.basename(path)
     parent_dir = pathlib.Path(path).resolve().parent
 
@@ -862,18 +888,18 @@ AUDIO_SYSTEMS = frozenset({"megacd", "saturn", "ps1", "3do", "cdi", "cd32", "dre
 
 
 def _scan_audio_tracks(readers, mods, manager):
-    """Fingerprint raw CDDA audio tracks.
+    """Fingerprint raw CDDA audio tracks in an archive or folder container.
 
     Two layouts: a single combined .bin described by a .cue (Redump), or one .bin per
     track sitting beside the data track."""
     media = []
-    containers = [r for r in readers if isinstance(r, mods["compressed"])]
+    containers = [r for r in readers if _is_container(r, mods)]
     for r in containers:
         cue_media = _scan_cue_audio(r)
         if cue_media is not None:
             media.extend(cue_media)
         else:
-            media.extend(_scan_member_audio(r))
+            media.extend(_scan_member_audio(r, mods))
     return media
 
 
@@ -889,13 +915,28 @@ def _read_entry(reader, entry, length=None):
             fh.__exit__(None, None, None) if is_ctx else fh.close()
 
 
-def _scan_member_audio(r):
+_NATURAL_SPLIT = re.compile(r"(\d+)")
+
+
+def _natural_key(s):
+    """Sort key comparing embedded digit runs by value ("Track 2" < "Track 10")."""
+    return [int(p) if p.isdigit() else p.lower() for p in _NATURAL_SPLIT.split(s)]
+
+
+def _scan_member_audio(r, mods):
     """Per-member: separate raw-CDDA .bin tracks beside the data track."""
     from . import audio
 
+    entries = r.iso_iterator(r.get_root_dir(), recursive=True, include_dirs=False)
+    if isinstance(r, mods["directory"]):
+        # Directory members come back in filesystem glob order; sort into track
+        # order so media output is deterministic. (Archives keep iteration order —
+        # a one-pass stream must be read in sequence.)
+        entries = sorted(entries, key=lambda e: _natural_key(_member_path(r, e, mods)))
+
     out = []
-    for entry in r.iso_iterator(r.get_root_dir(), recursive=True, include_dirs=False):
-        path = r.get_file_path(entry)
+    for entry in entries:
+        path = _member_path(r, entry, mods)
         try:
             size = int(r.get_file_size(entry))
         except Exception:  # noqa: BLE001
@@ -985,7 +1026,7 @@ def _scan_cue_audio(r):
 def main():
     parser = argparse.ArgumentParser(prog="curator-adapter")
     sub = parser.add_subparsers(dest="command", required=True)
-    p_an = sub.add_parser("analyze", help="analyze a disc image/container")
+    p_an = sub.add_parser("analyze", help="analyze a disc image/container/folder")
     p_an.add_argument("--path", required=True)
     p_ex = sub.add_parser("extract", help="extract browser-viewable assets into a store")
     p_ex.add_argument("--path", required=True)


### PR DESCRIPTION
Opening a folder that holds one dump split across files (Track 1.bin, Track 2.bin, optional cue sheet) now analyzes it as a single build instead of importing each track separately. The adapter treats a directory as a container like an archive, covering volume selection, GD-ROM reassembly, asset extraction and the CDDA audio scan. Identity hashes the track files concatenated in disc order, so a split dump and its combined image produce the same sha256. Both GUIs gain an Open Folder as Build menu item and auto detect track sets on drops and folder imports via a shared core heuristic. Verified end to end with the Sonic CD prototypes in both split track and combined bin+cue layouts.