### PR TITLE
Support CMYK TIFF assets

### DIFF
--- a/web/src/lib/imgpng.ts
+++ b/web/src/lib/imgpng.ts
@@ -241,8 +241,8 @@ export function tgaToPng(bytes: Buffer): Buffer {
 // TIFF decode, hand-rolled like TGA — scoped to the baseline subset dumps
 // carry: either byte order, first IFD only, strip-based chunky layout,
 // uncompressed/PackBits/LZW (with the horizontal predictor), bilevel/
-// grayscale/palette and 8-bit RGB(A). Tiled, planar, and fax/JPEG/deflate
-// files are rejected; callers fall back to the generated card.
+// grayscale/palette and 8-bit RGB(A)/CMYK. Tiled, planar, and fax/JPEG/
+// deflate files are rejected; callers fall back to the generated card.
 
 /** PackBits (TIFF §9): n >= 0 copies n+1 literals, n <= -1 repeats the next
  *  byte 1-n times, -128 is a no-op. */
@@ -354,6 +354,13 @@ function lzwDecode(src: Buffer, expected: number): Buffer {
   return out;
 }
 
+/** Rounded a*b/255 — Pillow's MULDIV255, so CMYK output stays byte-exact
+ *  with `Image.convert("RGB")` (and matches libtiff's tiff2rgba). */
+function mulDiv255(a: number, b: number): number {
+  const t = a * b + 128;
+  return (t + (t >> 8)) >> 8;
+}
+
 /** Undo predictor 2 (horizontal differencing) in place, row by row. */
 function undiff(data: Buffer, rows: number, rowBytes: number, spp: number): void {
   for (let y = 0; y < rows; y++) {
@@ -422,9 +429,15 @@ export function tiffToPng(bytes: Buffer): Buffer {
   const gray = photometric === 0 || photometric === 1;
   const rgb = photometric === 2;
   const paletted = photometric === 3;
+  const cmyk = photometric === 5;
   if (rgb) {
     if ((spp !== 3 && spp !== 4) || bits.some((b) => b !== 8)) {
       throw new Error("unsupported TIFF RGB layout");
+    }
+  } else if (cmyk) {
+    // InkSet (332) 1 = CMYK; anything else names arbitrary ink separations.
+    if (spp !== 4 || bits.some((b) => b !== 8) || tag1(332, 1) !== 1) {
+      throw new Error("unsupported TIFF CMYK layout");
     }
   } else if (gray || paletted) {
     if (spp !== 1 || ![1, 4, 8].includes(bits[0])) {
@@ -450,7 +463,7 @@ export function tiffToPng(bytes: Buffer): Buffer {
     }
   }
 
-  const bitsPerPixel = rgb ? spp * 8 : bits[0];
+  const bitsPerPixel = rgb || cmyk ? spp * 8 : bits[0];
   const rowBytes = (width * bitsPerPixel + 7) >> 3;
   const rowsPerStrip = Math.min(tag1(278, height) || height, height);
   const offsets = tags.get(273);
@@ -482,6 +495,15 @@ export function tiffToPng(bytes: Buffer): Buffer {
         px[o + 1] = data[p + 1];
         px[o + 2] = data[p + 2];
         px[o + 3] = spp === 4 ? data[p + 3] : 255;
+      } else if (cmyk) {
+        // Uncalibrated ink → RGB (any embedded ICC profile is ignored):
+        // channel = (255 - ink) scaled by what black leaves uncovered.
+        const p = base + x * spp;
+        const nk = 255 - data[p + 3];
+        px[o] = nk - mulDiv255(data[p], nk);
+        px[o + 1] = nk - mulDiv255(data[p + 1], nk);
+        px[o + 2] = nk - mulDiv255(data[p + 2], nk);
+        px[o + 3] = 255;
       } else if (paletted) {
         const p = sample1(data, base, x) * 3;
         px[o] = pal[p];

--- a/web/tests/imgpng.test.ts
+++ b/web/tests/imgpng.test.ts
@@ -332,6 +332,86 @@ test("tiffToPng resolves palettes, including 8-bit-quirk colormaps", () => {
   }
 });
 
+test("tiffToPng converts CMYK inks in both byte orders", () => {
+  // 4x1: no ink (white), pure cyan, pure black, and a rounding case —
+  // C=128 under K=128 must match Pillow's MULDIV255 arithmetic exactly.
+  const inks = Buffer.from([0, 0, 0, 0, 255, 0, 0, 0, 0, 0, 0, 255, 128, 0, 0, 128]);
+  for (const le of [true, false]) {
+    const tif = tinyTiff(
+      [
+        [256, 3, [4]],
+        [257, 3, [1]],
+        [258, 3, [8, 8, 8, 8]],
+        [259, 3, [1]],
+        [262, 3, [5]], // Separated (CMYK)
+        [273, 4, [8]],
+        [277, 3, [4]],
+        [279, 4, [16]],
+      ],
+      inks,
+      le
+    );
+    const png = PNG.sync.read(tiffToPng(tif));
+    assert.deepEqual([...png.data.subarray(0, 4)], [255, 255, 255, 255], `le=${le}`);
+    assert.deepEqual([...png.data.subarray(4, 8)], [0, 255, 255, 255], `le=${le}`);
+    assert.deepEqual([...png.data.subarray(8, 12)], [0, 0, 0, 255], `le=${le}`);
+    assert.deepEqual([...png.data.subarray(12, 16)], [63, 127, 127, 255], `le=${le}`);
+  }
+});
+
+test("tiffToPng decodes PackBits CMYK and rejects non-CMYK separations", () => {
+  // 2x1 cyan + black behind one literal PackBits packet — pins the 4-sample
+  // row width through the compressed path.
+  const packed = Buffer.from([7, 255, 0, 0, 0, 0, 0, 0, 255]);
+  const tif = tinyTiff(
+    [
+      [256, 3, [2]],
+      [257, 3, [1]],
+      [258, 3, [8, 8, 8, 8]],
+      [259, 3, [32773]],
+      [262, 3, [5]],
+      [273, 4, [8]],
+      [277, 3, [4]],
+      [279, 4, [packed.length]],
+    ],
+    packed
+  );
+  const png = PNG.sync.read(tiffToPng(tif));
+  assert.deepEqual([...png.data.subarray(0, 4)], [0, 255, 255, 255]);
+  assert.deepEqual([...png.data.subarray(4, 8)], [0, 0, 0, 255]);
+
+  const cmyk1x1 = (extra: Array<[number, number, number[]]>): Buffer =>
+    tinyTiff(
+      [
+        [256, 3, [1]],
+        [257, 3, [1]],
+        [258, 3, [8, 8, 8, 8]],
+        [259, 3, [1]],
+        [262, 3, [5]],
+        [273, 4, [8]],
+        [277, 3, [4]],
+        [279, 4, [4]],
+        ...extra,
+      ],
+      Buffer.from([0, 0, 0, 0])
+    );
+  assert.throws(() => tiffToPng(cmyk1x1([[332, 3, [2]]])), /CMYK/); // InkSet: not CMYK
+  const spp3 = tinyTiff(
+    [
+      [256, 3, [1]],
+      [257, 3, [1]],
+      [258, 3, [8, 8, 8]],
+      [259, 3, [1]],
+      [262, 3, [5]],
+      [273, 4, [8]],
+      [277, 3, [3]],
+      [279, 4, [3]],
+    ],
+    Buffer.from([0, 0, 0])
+  );
+  assert.throws(() => tiffToPng(spp3), /CMYK/);
+});
+
 /** Pack 9-bit LZW codes MSB-first (enough for streams that never grow the
  *  code width). */
 function lzwPack(codes: number[]): Buffer {


### PR DESCRIPTION
Press CDs carry Photoshop-saved CMYK TIFF screenshots (PhotometricInterpretation 5) — the Baldur's Gate 3438 press disc's screen1-8.tiff all decode to 415 today. Adds CMYK to the TIFF decoder: 4x8-bit chunky separations in either byte order, through all supported compressions and the predictor path. Non-CMYK ink sets and other layouts stay rejected.

Ink conversion is the uncalibrated multiplicative form with Pillow's MULDIV255 rounding; output verified byte-exact against Pillow on all eight screenshots from that disc, and the existing suite plus new fixture tests pass.