### PR TITLE
Support PDF and EPS document assets

### DIFF
--- a/crates/curator-core/src/schema.rs
+++ b/crates/curator-core/src/schema.rs
@@ -14,10 +14,10 @@ pub const FINGERPRINT_PROFILE: &str = "v1";
 /// Asset-extraction generation. 1 = browser-viewable kinds only (implicit in
 /// records that predate the field, which deserialize to 0); 2 = also head
 /// snippets (`kind: "binary"`) for every file that isn't viewable; 3 = TGA
-/// classified as an image (previously a head snippet); 4 = TIFF likewise. A
-/// record below the current value gets its assets re-extracted on the next
-/// analyze.
-pub const ASSET_PROFILE: u32 = 4;
+/// classified as an image (previously a head snippet); 4 = TIFF likewise;
+/// 5 = PDF and PostScript (.eps/.ps/.ai) as `kind: "document"`. A record
+/// below the current value gets its assets re-extracted on the next analyze.
+pub const ASSET_PROFILE: u32 = 5;
 
 /// A fully analyzed disc image / container — image-independent and self-describing.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -983,10 +983,11 @@ mod app {
     }
 
     /// Display order + section titles for asset kinds — mirrors the web build pages.
-    const ASSET_KINDS: [(&str, &str); 6] = [
+    const ASSET_KINDS: [(&str, &str); 7] = [
         ("image", "Images"),
         ("audio", "Audio"),
         ("video", "Video"),
+        ("document", "Documents"),
         ("source", "Source code"),
         ("text", "Text"),
         ("binary", "Unidentified"),
@@ -1874,10 +1875,11 @@ mod app {
 
     // ---- asset viewer ----
 
-    /// Open the asset at `assets[idx]`. Media kinds go to their default app via a
-    /// temp copy carrying the original filename (store blobs are extensionless, so
-    /// the shell can't pick a handler for them directly); TGA images are staged
-    /// as BMP because stock Windows has no TGA handler. Text and source kinds
+    /// Open the asset at `assets[idx]`. Media and document kinds go to their
+    /// default app via a temp copy carrying the original filename (store blobs
+    /// are extensionless, so the shell can't pick a handler for them directly)
+    /// — PDFs land in the default PDF viewer; TGA images are staged as BMP
+    /// because stock Windows has no TGA handler. Text and source kinds
     /// always open in Notepad: handing a `.bat`/`.cmd`/`.js` from an untrusted
     /// disc to the shell's default verb would execute it. Binary kinds
     /// (unidentified files' head snippets) open in Notepad as a hex dump.

--- a/macos/Sources/CuratorApp/AppModel.swift
+++ b/macos/Sources/CuratorApp/AppModel.swift
@@ -346,12 +346,13 @@ final class AppModel: ObservableObject {
 
     // MARK: - Asset viewer
 
-    /// Open one extracted asset. Media kinds go to the default app via a temp
-    /// copy carrying the original filename (blobs are extensionless, so the
-    /// store path alone can't pick a handler). Text and source kinds preview
-    /// in-app only: shell-opening a `.sh`/`.bat`/`.js` from an untrusted disc
-    /// could hand it to something that executes it. Binary kinds (unidentified
-    /// files' head snippets) preview in-app as a hex dump.
+    /// Open one extracted asset. Media and document kinds go to the default
+    /// app via a temp copy carrying the original filename (blobs are
+    /// extensionless, so the store path alone can't pick a handler) — PDFs
+    /// land in Preview. Text and source kinds preview in-app only:
+    /// shell-opening a `.sh`/`.bat`/`.js` from an untrusted disc could hand
+    /// it to something that executes it. Binary kinds (unidentified files'
+    /// head snippets) preview in-app as a hex dump.
     func openAsset(_ asset: AssetInfo) {
         guard let blob = asset.blobPath else {
             status = "Asset not in the local store — re-analyze the image to extract it."

--- a/macos/Sources/CuratorApp/ContentView.swift
+++ b/macos/Sources/CuratorApp/ContentView.swift
@@ -467,13 +467,14 @@ struct DocumentView: View {
 // MARK: - Assets (browser-viewable files extracted from the build)
 
 /// Display order for asset kinds — mirrors the web build pages.
-private let assetKindOrder = ["image", "audio", "video", "source", "text", "binary"]
+private let assetKindOrder = ["image", "audio", "video", "document", "source", "text", "binary"]
 
 private func assetKindIcon(_ kind: String) -> String {
     switch kind {
     case "image": return "photo"
     case "audio": return "music.note"
     case "video": return "film"
+    case "document": return "doc.richtext"
     case "source": return "chevron.left.forwardslash.chevron.right"
     case "binary": return "number"
     default: return "doc.text"

--- a/ps2exe-adapter/curator_adapter/viewable.py
+++ b/ps2exe-adapter/curator_adapter/viewable.py
@@ -48,6 +48,18 @@ _VIDEO = {
     "webm": "video/webm",
 }
 
+# Print-format documents. Browsers render PDF natively; PostScript (.eps, .ps,
+# and the classic Illustrator .ai, which is EPS under the hood) is rasterized
+# server-side when Ghostscript is available. .ai needs the sniff more than
+# anything: game discs reuse the extension for AI behavior data (Eternal
+# Champions' 68k blobs, Wild Metal's AIDEF scripts) — only %!PS bytes pass.
+_DOCUMENT = {
+    "pdf": "application/pdf",
+    "eps": "application/postscript",
+    "ps": "application/postscript",
+    "ai": "application/postscript",
+}
+
 # Docs, configs, data — the formats prototype discs actually carry. All are
 # served as text/plain regardless of what they'd mean to a browser (html).
 _TEXT = frozenset(
@@ -70,7 +82,7 @@ _SOURCE = frozenset(
 _SOURCE_NAMES = frozenset({"makefile", "gnumakefile"})
 
 _KINDS = (
-    [(_IMAGE, "image")] + [(_AUDIO, "audio")] + [(_VIDEO, "video")]
+    [(_IMAGE, "image")] + [(_AUDIO, "audio")] + [(_VIDEO, "video")] + [(_DOCUMENT, "document")]
 )
 
 
@@ -140,6 +152,9 @@ _MAGIC = {
     "audio/mp4": lambda h: h[4:8] == b"ftyp",
     "video/mp4": lambda h: h[4:8] == b"ftyp",
     "video/webm": lambda h: h.startswith(b"\x1aE\xdf\xa3"),
+    "application/pdf": lambda h: h.startswith(b"%PDF-"),
+    # ASCII PostScript/EPS, or the DOS EPS binary wrapper around one.
+    "application/postscript": lambda h: h.startswith((b"%!PS", b"\xc5\xd0\xd3\xc6")),
     "text/plain": _looks_text,
 }
 

--- a/ps2exe-adapter/tests/test_assets.py
+++ b/ps2exe-adapter/tests/test_assets.py
@@ -66,6 +66,20 @@ def test_tiff_ships_as_image(tmp_path):
     assert blob(tmp_path, a["sha256"]) == tif
 
 
+def test_documents_ship_whole_and_imposter_degrades(tmp_path):
+    pdf = b"%PDF-1.4\r%\xe2\xe3\xcf\xd3\r\n1 0 obj\r<<>>\rendobj\r%%EOF"
+    eps = b"%!PS-Adobe-3.0 \r\n%%Creator: Adobe Illustrator(TM) 5.0\r\n%%EOF\r\n"
+    fake = b"\x00\x00\x00\x00\x00\x18\x00\x00\x00\x00C\xfa\x02\xae0<" + bytes(50)
+    assets = extract({"/COMIC/BOOK.PDF": pdf, "/ART/CLIP0001.AI": eps, "/BLAD.AI": fake}, tmp_path)
+    a = assets["/COMIC/BOOK.PDF"]
+    assert (a["kind"], a["mime"], a["size"]) == ("document", "application/pdf", len(pdf))
+    assert blob(tmp_path, a["sha256"]) == pdf
+    a = assets["/ART/CLIP0001.AI"]
+    assert (a["kind"], a["mime"], a["size"]) == ("document", "application/postscript", len(eps))
+    # Game data squatting on .ai stays a hex snippet.
+    assert assets["/BLAD.AI"]["kind"] == viewable.SNIPPET_KIND
+
+
 def test_unidentified_files_ship_head_snippet(tmp_path):
     data = bytes(range(256)) * 20  # 5120 bytes of binary
     assets = extract({"/DATA/GAME.TIM": data}, tmp_path)

--- a/ps2exe-adapter/tests/test_viewable.py
+++ b/ps2exe-adapter/tests/test_viewable.py
@@ -69,6 +69,25 @@ def test_sniff_tiff_magic_and_case_insensitive_extension():
     assert not viewable.sniff(b"Not a TIFF at all, honest.", "image/tiff")
 
 
+def test_classify_documents():
+    assert viewable.classify("/COMIC/BOOK.PDF") == ("document", "application/pdf")
+    assert viewable.classify("/ART/LOGO.EPS") == ("document", "application/postscript")
+    assert viewable.classify("/ART/banner.ps") == ("document", "application/postscript")
+    # Classic Illustrator files are EPS under the hood (Visual Park's clipart).
+    assert viewable.classify("/CLIPART/CLIP0001.AI") == ("document", "application/postscript")
+
+
+def test_sniff_documents():
+    assert viewable.sniff(b"%PDF-1.4\r%\xe2\xe3\xcf\xd3\r\n176 0 obj", "application/pdf")
+    assert not viewable.sniff(b"%!PS-Adobe-3.0 EPSF-3.0\r\n", "application/pdf")
+    assert viewable.sniff(b"%!PS-Adobe-3.0 \r\n%%Creator: Adobe Illustrator(TM) 5.0", "application/postscript")
+    # DOS EPS binary wrapper (preview + PostScript behind a 4-byte magic).
+    assert viewable.sniff(b"\xc5\xd0\xd3\xc6\x20\x00\x00\x00", "application/postscript")
+    # Game data squatting on .ai (Eternal Champions' 68k blobs) must not pass.
+    assert not viewable.sniff(b"\x00\x00\x00\x00\x00\x18\x00\x00\x00\x00C\xfa\x02\xae0<", "application/postscript")
+    assert not viewable.sniff(b"%PDF-1.4 pdf bytes under a .ai name", "application/postscript")
+
+
 def test_sniff_text_accepts_legacy_encodings_rejects_binary():
     # Shift-JIS bytes are >= 0x80 — must pass the text heuristic.
     assert viewable.sniff("日本語のテキスト".encode("shift_jis"), "text/plain")

--- a/web/src/app/api/asset/[sha256]/png/route.ts
+++ b/web/src/app/api/asset/[sha256]/png/route.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import type { NextRequest } from "next/server";
 import { assetBlobPath } from "@/lib/assets";
 import { getPool } from "@/lib/db";
+import { gsAvailable, gsRenderable, gsToPng } from "@/lib/gs";
 import { pngConvertible, toPng, WEB_SAFE_IMAGE } from "@/lib/imgpng";
 import { isSha256 } from "@/lib/validate";
 
@@ -9,8 +10,9 @@ export const runtime = "nodejs";
 
 // GET /api/asset/<sha256>/png — the asset converted to PNG, for og:image use
 // on formats unfurlers won't render and inline display of formats browsers
-// won't (today: BMP, TGA, and TIFF). Web-safe formats redirect to the raw
-// asset route; content-addressed, so responses cache hard.
+// won't (today: BMP, TGA, and TIFF in-process, plus EPS/PS and PDF first
+// pages through Ghostscript when the server has it). Web-safe formats
+// redirect to the raw asset route; content-addressed, so responses cache hard.
 
 const CACHE = "public, max-age=31536000, immutable";
 
@@ -32,7 +34,8 @@ export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256
   if (WEB_SAFE_IMAGE.test(meta.mime)) {
     return Response.redirect(new URL(`/api/asset/${sha256}`, _request.url), 308);
   }
-  if (!pngConvertible(meta.mime) || meta.size > MAX_CONVERT_BYTES) {
+  const viaGs = gsRenderable(meta.mime) && (await gsAvailable());
+  if ((!pngConvertible(meta.mime) && !viaGs) || meta.size > MAX_CONVERT_BYTES) {
     return Response.json({ error: `no PNG conversion for ${meta.mime}` }, { status: 415 });
   }
 
@@ -45,7 +48,7 @@ export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256
 
   let png: Buffer;
   try {
-    png = toPng(meta.mime, bytes);
+    png = viaGs ? await gsToPng(meta.mime, bytes) : toPng(meta.mime, bytes);
   } catch {
     return Response.json({ error: "undecodable image" }, { status: 415 });
   }

--- a/web/src/app/api/asset/[sha256]/route.ts
+++ b/web/src/app/api/asset/[sha256]/route.ts
@@ -15,15 +15,22 @@ export const runtime = "nodejs";
 const CACHE = "public, max-age=31536000, immutable";
 
 // Defense against a hostile mime smuggled in through the submissions API: only
-// media types and bare text/plain are ever served inline. text/html (or
+// media types, PDF, and bare text/plain are ever served inline. text/html (or
 // anything else surprising) becomes a plain download instead of a document
 // that could script against this origin. The CSP sandbox below backstops even
 // the inline types (e.g. SVG's script capability when opened as a document).
 function servableMime(mime: string): boolean {
-  return mime === "text/plain" || /^(image|audio|video)\/[\w.+-]+$/.test(mime);
+  return mime === "text/plain" || mime === "application/pdf" || /^(image|audio|video)\/[\w.+-]+$/.test(mime);
 }
 
 const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+
+// PDFs render in the browser's PDF viewer, which `sandbox` blocks (Chrome
+// treats a sandboxed response as plugin-forbidden and downloads instead).
+// Dropping the directive is safe for this type only: with nosniff the
+// response can never be reinterpreted as HTML, and script inside a PDF runs
+// in the viewer's isolated world, not against this origin.
+const PDF_CSP = "default-src 'none'; style-src 'unsafe-inline'";
 
 // Asset metadata is immutable for a given content hash — cache the row lookup
 // so a screenshot gallery's burst of first-loads costs one query, not N.
@@ -85,7 +92,7 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
     "Cache-Control": CACHE,
     ETag: `"${sha256}"`,
     "X-Content-Type-Options": "nosniff",
-    "Content-Security-Policy": CSP,
+    "Content-Security-Policy": meta.mime === "application/pdf" && inline ? PDF_CSP : CSP,
     "Accept-Ranges": "bytes",
   };
 

--- a/web/src/app/builds/[buildId]/AssetGallery.tsx
+++ b/web/src/app/builds/[buildId]/AssetGallery.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 // Grouped preview of a build's viewable assets: image thumbnails, audio embeds
-// with waveforms, small video players, text excerpt cards, hex-preview cards
+// with waveforms, small video players, document cards with server-rasterized
+// previews, text excerpt cards, hex-preview cards
 // for unidentified files' head snippets. The server page passes an
 // already-capped subset plus the full per-kind totals; when a kind is
 // truncated, a "view all" affordance links to <buildHref>/assets.
@@ -18,6 +19,7 @@ const SECTIONS: { kind: string; title: string }[] = [
   { kind: "image", title: "Images" },
   { kind: "audio", title: "Audio" },
   { kind: "video", title: "Video" },
+  { kind: "document", title: "Documents" },
   { kind: "source", title: "Source code" },
   { kind: "text", title: "Text" },
   { kind: "binary", title: "Unidentified" },
@@ -104,6 +106,33 @@ export default function AssetGallery({
                     title={a.path}
                     className="h-36 rounded border border-neutral-200 dark:border-neutral-800"
                   />
+                ))}
+              </div>
+            )}
+
+            {kind === "document" && (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {group.map((a) => (
+                  <button
+                    key={a.path}
+                    onClick={() => open(a)}
+                    title={a.path}
+                    className="flex w-32 flex-col overflow-hidden rounded border border-neutral-200 hover:border-sky-400 dark:border-neutral-800 dark:hover:border-sky-600"
+                  >
+                    {/* Server-rasterized first page/artwork; the card stays
+                        useful without it (no Ghostscript on the server). */}
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={`${assetUrl(a)}/png`}
+                      alt={a.path}
+                      loading="lazy"
+                      className="h-24 w-full bg-white object-contain"
+                      onError={(e) => (e.currentTarget.style.display = "none")}
+                    />
+                    <span className="w-full truncate px-2 py-1 text-left font-mono text-[11px] text-sky-700 dark:text-sky-400">
+                      {baseName(a.path)}
+                    </span>
+                  </button>
                 ))}
               </div>
             )}

--- a/web/src/app/builds/[buildId]/AssetViewer.tsx
+++ b/web/src/app/builds/[buildId]/AssetViewer.tsx
@@ -15,7 +15,7 @@ export interface ViewableAsset {
   sha256: string;
   size: number;
   mime: string;
-  kind: string; // image | audio | video | source | text | binary
+  kind: string; // image | audio | video | document | source | text | binary
 }
 
 export function assetUrl(a: ViewableAsset): string {
@@ -125,6 +125,41 @@ function HexBody({ asset }: { asset: ViewableAsset }) {
   );
 }
 
+// PDFs embed the browser's own viewer; PostScript/EPS goes through the
+// server's Ghostscript rasterization. Either can be unavailable (mobile
+// browsers won't embed PDFs; the server may lack Ghostscript), so both
+// fall back to a download card rather than an error.
+function DocumentBody({ asset }: { asset: ViewableAsset }) {
+  const [failed, setFailed] = useState(false);
+  const url = assetUrl(asset);
+  const name = asset.path.split("/").pop() || asset.path;
+  const fallback = (
+    <div className="flex flex-col items-center gap-3 rounded bg-neutral-900 p-10 text-sm text-neutral-300">
+      <p>No inline preview for this file.</p>
+      <a href={url} download={name} className="rounded bg-neutral-700 px-3 py-1.5 text-neutral-100 hover:bg-neutral-600">
+        Download {name}
+      </a>
+    </div>
+  );
+  if (asset.mime === "application/pdf") {
+    return (
+      <object data={url} type="application/pdf" className="h-[75vh] w-[min(70rem,90vw)] rounded" aria-label={asset.path}>
+        {fallback}
+      </object>
+    );
+  }
+  if (failed) return fallback;
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={`${url}/png`}
+      alt={asset.path}
+      className="max-h-[75vh] max-w-[90vw] rounded object-contain"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
 function Body({ asset }: { asset: ViewableAsset }) {
   const [failed, setFailed] = useState(false);
   const url = assetUrl(asset);
@@ -155,6 +190,8 @@ function Body({ asset }: { asset: ViewableAsset }) {
           onError={() => setFailed(true)}
         />
       );
+    case "document":
+      return <DocumentBody asset={asset} />;
     case "binary":
       return <HexBody asset={asset} />;
     default:

--- a/web/src/app/builds/[buildId]/assets/[[...path]]/page.tsx
+++ b/web/src/app/builds/[buildId]/assets/[[...path]]/page.tsx
@@ -5,6 +5,7 @@ import type { Pool } from "pg";
 import { getPool } from "@/lib/db";
 import { getBuildAssets, resolveBuild, type BuildAsset } from "@/lib/queries";
 import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
+import { gsAvailable, gsRenderable } from "@/lib/gs";
 import { pngConvertible, WEB_SAFE_IMAGE } from "@/lib/imgpng";
 import { humanSize } from "@/lib/meta";
 import { canonicalBuildId, parseBuildParam, safeDecodeSegment } from "@/lib/slug";
@@ -74,14 +75,18 @@ export async function generateMetadata({
       description,
       siteName: "Hidden Palace",
       // Image assets unfurl as themselves — directly when the format is
-      // web-safe, via PNG conversion when it isn't (BMP/TGA/TIFF); everything
-      // else (audio/video/text, ico/svg) gets the build card.
+      // web-safe, via PNG conversion when it isn't (BMP/TGA/TIFF). Documents
+      // unfurl as their rasterized first page/artwork when the server has
+      // Ghostscript; everything else (audio/video/text, ico/svg) gets the
+      // build card.
       images: [
         asset.kind === "image" && WEB_SAFE_IMAGE.test(asset.mime)
           ? `/api/asset/${asset.sha256}`
           : asset.kind === "image" && pngConvertible(asset.mime)
             ? `/api/asset/${asset.sha256}/png`
-            : card,
+            : asset.kind === "document" && gsRenderable(asset.mime) && (await gsAvailable())
+              ? `/api/asset/${asset.sha256}/png`
+              : card,
       ],
     },
     twitter: { card: "summary_large_image" },

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -17,7 +17,7 @@ import AssetViewerHost from "./AssetViewerHost";
 
 // The assets section previews at most this many items per kind; the rest live
 // on /builds/<id>/assets.
-const ASSET_PREVIEW_PER_KIND = { image: 30, audio: 20, video: 10, source: 10, text: 10, binary: 9 };
+const ASSET_PREVIEW_PER_KIND = { image: 30, audio: 20, video: 10, document: 12, source: 10, text: 10, binary: 9 };
 
 export const runtime = "nodejs";
 // The corpus only changes at ingest; render once and serve cached for an hour

--- a/web/src/lib/assets.ts
+++ b/web/src/lib/assets.ts
@@ -24,7 +24,7 @@ export function assetStagingPath(sha256: string): string {
 }
 
 /** Display order for asset kinds on the build pages. */
-export const ASSET_KIND_ORDER = ["image", "audio", "video", "source", "text", "binary"] as const;
+export const ASSET_KIND_ORDER = ["image", "audio", "video", "document", "source", "text", "binary"] as const;
 
 /** Per-kind asset counts. */
 export function assetTotals(assets: { kind: string }[]): Record<string, number> {

--- a/web/src/lib/gs.ts
+++ b/web/src/lib/gs.ts
@@ -1,0 +1,225 @@
+// Ghostscript-backed rasterization: PostScript/EPS (and PDF first pages) to
+// PNG. Unlike the raster formats imgpng.ts decodes in pure JS, PostScript is
+// a programming language — rendering it takes the real interpreter. Ghostscript
+// is a soft dependency: feature-detected at runtime, and every caller degrades
+// (download-only viewer, generated OG card) when it's missing.
+
+import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileP = promisify(execFile);
+
+const GS_BIN = process.env.GHOSTSCRIPT_BIN || "gs";
+
+// Kill a render that runs away — a PostScript file is a program and can loop.
+const GS_TIMEOUT_MS = 15_000;
+
+// Refuse to hand back absurd rasters (a hostile BoundingBox can demand acres).
+const MAX_PNG_BYTES = 32_000_000;
+
+// Target resolution, and the raster-size cap a huge BoundingBox degrades
+// against (the render drops below 150dpi rather than exploding).
+const GS_DPI = 150;
+const MAX_PIXELS = 16_000_000;
+
+/** Mimes gsToPng can rasterize. */
+export function gsRenderable(mime: string): boolean {
+  return mime === "application/pdf" || mime === "application/postscript";
+}
+
+// Feature detection, memoized for the process lifetime. A `gs` on PATH is not
+// proof: on macOS dev machines `gs` is commonly git-spice, so the banner must
+// actually say Ghostscript.
+let available: Promise<boolean> | null = null;
+
+export function gsAvailable(): Promise<boolean> {
+  available ??= execFileP(GS_BIN, ["-h"], { timeout: 5_000 })
+    .then(({ stdout }) => /ghostscript/i.test(stdout))
+    .catch(() => false);
+  return available;
+}
+
+// --- Illustrator EPS with stripped procsets ---------------------------------
+//
+// Illustrator normally embeds its procsets (Adobe_level2_AI5 etc.) in every
+// EPS, and those render in Ghostscript as-is. Some discs strip them to save
+// space (Visual Park ships 335 clipart files whose prologs are gone because
+// the game carries its own AI parser), leaving `%%IncludeResource` references
+// nothing can resolve. For those files we drop the dead setup section and
+// prepend a minimal implementation of the AI3/AI5 operators the art actually
+// uses — paths, fills/strokes, CMYK/gray/spot color, compound paths, layers,
+// guides. Gradient-painted objects (Bb..BB) are dropped rather than mimicked;
+// everything else renders faithfully.
+//
+// The operator set below was chosen from a census of the corpus files; an
+// unknown operator in some future file just errors the render, and callers
+// fall back to the download card.
+const AI_COMPAT_PROLOG = `%%BeginProlog
+/AICompat 80 dict def
+AICompat begin
+/_fk [0 0 0 1] def /_sk [0 0 0 1] def
+/_fg null def /_sg null def
+/k { _fk astore pop /_fg null store } bind def
+/K { _sk astore pop /_sg null store } bind def
+/g { /_fg exch store } bind def
+/G { /_sg exch store } bind def
+/x { pop pop _fk astore pop /_fg null store } bind def
+/X { pop pop _sk astore pop /_sg null store } bind def
+% Inside a gradient block (Bb..BB) fills flatten to light gray — the gradient
+% machinery isn't emulated and its stop colors live in the stripped setup —
+% while strokes keep their real (flat) color.
+/_setf { _gb { 0.75 setgray }
+         { _fg null eq { _fk aload pop setcmykcolor } { _fg setgray } ifelse } ifelse } bind def
+/_sets { _sg null eq { _sk aload pop setcmykcolor } { _sg setgray } ifelse } bind def
+/m { moveto } bind def
+/l { lineto } bind def /L { lineto } bind def
+/c { curveto } bind def /C { curveto } bind def
+/v { currentpoint 6 2 roll curveto } bind def /V /v load def
+/y { 2 copy curveto } bind def /Y /y load def
+/h { closepath } bind def /H { closepath } bind def
+% Compound paths (*u..*U): interior paint ops are deferred so subpaths
+% accumulate and holes keep their winding; the close of the group paints once.
+/_cd 0 def /_cp null def /_gb false def
+/_paint { _cd 0 gt { /_cp exch store } { exec } ifelse } bind def
+/f { { closepath _setf fill } _paint } bind def
+/F { { _setf fill } _paint } bind def
+/s { { closepath _sets stroke } _paint } bind def
+/S { { _sets stroke } _paint } bind def
+/b { { closepath gsave _setf fill grestore _sets stroke } _paint } bind def
+/B { { gsave _setf fill grestore _sets stroke } _paint } bind def
+/n { { newpath } _paint } bind def /N /n load def
+% "/_cp load", never bare "_cp": executing the name would run the stored
+% paint procedure instead of pushing it.
+/*u { /_cd _cd 1 add store } bind def
+/*U { /_cd _cd 1 sub store
+      _cd 0 eq { /_cp load null ne { /_cp load exec /_cp null store } if } if } bind def
+/* { pop newpath } bind def % guide: discard the path
+/w { setlinewidth } bind def
+/j { setlinejoin } bind def /J { setlinecap } bind def
+/M { setmiterlimit } bind def /d { setdash } bind def
+/D { pop } bind def /A { pop } bind def
+/O { pop } bind def /R { pop } bind def
+/Ar { pop } bind def /Ap { pop } bind def
+/u {} def /U {} def
+/q { gsave } bind def /Q { grestore } bind def /W { clip } bind def
+/Lb { clear } bind def /Ln { pop } bind def /LB {} def
+/Bb { /_gb true store } bind def
+/BB { clear newpath /_gb false store } bind def
+/Bg { clear } bind def /Bm { clear } bind def
+/Bc { clear } bind def /Bh { clear } bind def
+/annotatepage {} def
+%%EndProlog
+`;
+
+/** For an Illustrator EPS whose Adobe procsets are referenced but not
+ *  embedded: the file with the compat prolog spliced in, else null. */
+export function patchStrippedIllustrator(bytes: Buffer): Buffer | null {
+  // Only the head matters for detection; procset references sit in the DSC
+  // comments. Skip files that embed their resources — they render natively.
+  const head = bytes.subarray(0, 8192).toString("latin1");
+  if (!/^%%(?:DocumentNeededResources:|IncludeResource:)\s*procset\s+Adobe_/m.test(head)) return null;
+  if (/^%%BeginResource:\s*procset\s+Adobe_/m.test(head)) return null;
+
+  // Classic-Mac \r-only line endings survive in these files; JS multiline
+  // anchors treat \r as a line break, so ^/$ work either way.
+  const text = bytes.toString("latin1");
+  const patched = text
+    // The setup section only initializes the missing procsets and defines
+    // patterns/gradients/palettes our stubs never reference.
+    .replace(/^%%BeginSetup[\s\S]*?^%%EndSetup[^\r\n]*/m, "")
+    .replace(/^Adobe_\S+ \/(?:initialize|terminate) get exec[^\r\n]*$/gm, "")
+    .replace(/^%%EndComments[^\r\n]*/m, (m) => m + "\n" + AI_COMPAT_PROLOG);
+  return Buffer.from(patched, "latin1");
+}
+
+/** The EPS %%BoundingBox (pt), from the DSC header — or the trailer when the
+ *  header defers with "(atend)". Null when absent or degenerate. */
+export function epsBoundingBox(
+  bytes: Buffer
+): { x1: number; y1: number; x2: number; y2: number } | null {
+  const re = /^%%BoundingBox:\s*(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)\s+(-?[\d.]+)/gm;
+  const head = bytes.subarray(0, 8192).toString("latin1");
+  let m = re.exec(head);
+  if (!m && /^%%BoundingBox:\s*\(atend\)/m.test(head)) {
+    const tail = bytes.subarray(-4096).toString("latin1");
+    for (let t; (t = re.exec(tail)); ) m = t; // last one wins per DSC
+  }
+  if (!m) return null;
+  const [x1, y1, x2, y2] = m.slice(1, 5).map(Number);
+  return x2 > x1 && y2 > y1 ? { x1, y1, x2, y2 } : null;
+}
+
+/**
+ * Rasterize a PDF or PostScript asset to a PNG of its first page. Throws when
+ * Ghostscript is missing, times out, errors on the input, or the raster is
+ * outlandish. Input and output go through a private temp dir: PDF needs a
+ * seekable file (stdin won't do), and a `%d` output template keeps a
+ * multi-page PostScript job from concatenating PNGs into one stream.
+ */
+export async function gsToPng(mime: string, bytes: Buffer): Promise<Buffer> {
+  if (!(await gsAvailable())) throw new Error("ghostscript not available");
+
+  // EPS art is cropped to its declared BoundingBox by sizing the device to it
+  // and shifting the origin. Not -dEPSCrop: that needs an `EPSF-3.0` header
+  // marker, which real dumps (Illustrator among them) routinely omit, leaving
+  // small art adrift on a letter-size page.
+  let crop: string[] = [];
+  let translate: string[] = [];
+  if (mime === "application/postscript") {
+    bytes = patchStrippedIllustrator(bytes) ?? bytes;
+    const bb = epsBoundingBox(bytes);
+    if (bb) {
+      const wPt = bb.x2 - bb.x1;
+      const hPt = bb.y2 - bb.y1;
+      let dpi = GS_DPI;
+      if ((wPt / 72) * (hPt / 72) * dpi * dpi > MAX_PIXELS) {
+        dpi = Math.floor(Math.sqrt(MAX_PIXELS / ((wPt / 72) * (hPt / 72))));
+        if (dpi < 1) throw new Error(`EPS BoundingBox out of range: ${wPt}x${hPt}pt`);
+      }
+      const w = Math.ceil((wPt / 72) * dpi);
+      const h = Math.ceil((hPt / 72) * dpi);
+      crop = [`-r${dpi}`, `-g${w}x${h}`, "-dFIXEDMEDIA"];
+      translate = ["-c", `${-bb.x1} ${-bb.y1} translate`, "-f"];
+    }
+  }
+
+  const dir = await mkdtemp(join(tmpdir(), `gs-${randomBytes(4).toString("hex")}-`));
+  try {
+    const input = join(dir, "input");
+    await writeFile(input, bytes);
+    const args = [
+      // -dSAFER is the default since 9.50 but stays explicit; -P- keeps the
+      // interpreter from resolving libraries via the working directory; the
+      // stdout redirect stops PostScript `print` chatter reaching our pipes.
+      "-dSAFER",
+      "-dBATCH",
+      "-dNOPAUSE",
+      "-q",
+      "-P-",
+      "-sstdout=%stderr",
+      // White-background RGB: documents read right on it, and satori (the OG
+      // renderer) has no use for alpha. Alpha bits smooth line art.
+      "-sDEVICE=png16m",
+      `-r${GS_DPI}`,
+      "-dTextAlphaBits=4",
+      "-dGraphicsAlphaBits=4",
+      ...(mime === "application/pdf" ? ["-dFirstPage=1", "-dLastPage=1"] : []),
+      ...crop,
+      "-sOutputFile=" + join(dir, "out-%d.png"),
+      ...translate,
+      input,
+    ];
+    await execFileP(GS_BIN, args, { timeout: GS_TIMEOUT_MS, maxBuffer: 4_000_000 });
+    const png = await readFile(join(dir, "out-1.png"));
+    if (png.length === 0 || png.length > MAX_PNG_BYTES) {
+      throw new Error(`gs raster out of range: ${png.length} bytes`);
+    }
+    return png;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -71,7 +71,7 @@ export interface AssetRef {
   sha256: string;
   size: number;
   mime: string;
-  kind: string; // "image" | "audio" | "video" | "source" | "text" | "binary" (head snippet)
+  kind: string; // "image" | "audio" | "video" | "document" | "source" | "text" | "binary" (head snippet)
 }
 
 export interface MediaFp {

--- a/web/tests/gs.test.ts
+++ b/web/tests/gs.test.ts
@@ -1,0 +1,155 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PNG } from "pngjs";
+import { gsAvailable, gsRenderable, gsToPng, patchStrippedIllustrator } from "../src/lib/gs";
+
+// Rasterization tests need real Ghostscript and skip without it (set
+// GHOSTSCRIPT_BIN when `gs` on PATH is something else, e.g. git-spice).
+
+test("gsRenderable covers exactly the document mimes", () => {
+  assert.equal(gsRenderable("application/pdf"), true);
+  assert.equal(gsRenderable("application/postscript"), true);
+  assert.equal(gsRenderable("image/tiff"), false);
+  assert.equal(gsRenderable("text/plain"), false);
+});
+
+// 8x4pt EPS, solid red — small enough to assert pixels across the raster.
+const EPS = Buffer.from(
+  "%!PS-Adobe-3.0 EPSF-3.0\n%%BoundingBox: 0 0 8 4\n1 0 0 setrgbcolor 0 0 8 4 rectfill\nshowpage\n"
+);
+
+/** Minimal one-page-per-entry PDF, each page an 8x4pt solid-fill rect, with a
+ *  correct xref table (Ghostscript tolerates a broken one; the fixture
+ *  shouldn't lean on that). */
+function tinyPdf(pageColors: string[]): Buffer {
+  const objs: string[] = [];
+  const kids = pageColors.map((_, i) => `${3 + i * 2} 0 R`).join(" ");
+  objs.push(`1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n`);
+  objs.push(`2 0 obj << /Type /Pages /Kids [${kids}] /Count ${pageColors.length} >> endobj\n`);
+  pageColors.forEach((color, i) => {
+    const content = `${color} rg 0 0 8 4 re f`;
+    objs.push(
+      `${3 + i * 2} 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 8 4] /Contents ${4 + i * 2} 0 R >> endobj\n`
+    );
+    objs.push(`${4 + i * 2} 0 obj << /Length ${content.length} >> stream\n${content}\nendstream endobj\n`);
+  });
+  let body = "%PDF-1.4\n";
+  const offsets = objs.map((o) => {
+    const at = body.length;
+    body += o;
+    return at;
+  });
+  const xrefAt = body.length;
+  body += `xref\n0 ${objs.length + 1}\n0000000000 65535 f \n`;
+  for (const at of offsets) body += `${String(at).padStart(10, "0")} 00000 n \n`;
+  body += `trailer << /Size ${objs.length + 1} /Root 1 0 R >>\nstartxref\n${xrefAt}\n%%EOF\n`;
+  return Buffer.from(body, "latin1");
+}
+
+/** The raster's center pixel as [r,g,b,a]. */
+function centerPixel(png: Buffer): number[] {
+  const img = PNG.sync.read(png);
+  const o = ((img.height >> 1) * img.width + (img.width >> 1)) * 4;
+  return [...img.data.subarray(o, o + 4)];
+}
+
+test("gsToPng rasterizes an EPS at its BoundingBox", async (t) => {
+  if (!(await gsAvailable())) return t.skip("ghostscript not installed");
+  const png = PNG.sync.read(await gsToPng("application/postscript", EPS));
+  // 8x4pt at 150dpi ≈ 17x8px — EPSCrop must have sized the page to the art.
+  assert.ok(png.width >= 16 && png.width <= 18, `width ${png.width}`);
+  assert.ok(png.height >= 8 && png.height <= 10, `height ${png.height}`);
+  const o = ((png.height >> 1) * png.width + (png.width >> 1)) * 4;
+  assert.deepEqual([...png.data.subarray(o, o + 4)], [255, 0, 0, 255]);
+});
+
+test("gsToPng renders only a PDF's first page", async (t) => {
+  if (!(await gsAvailable())) return t.skip("ghostscript not installed");
+  const pdf = tinyPdf(["1 0 0", "0 0 1"]); // page 1 red, page 2 blue
+  assert.deepEqual(centerPixel(await gsToPng("application/pdf", pdf)), [255, 0, 0, 255]);
+});
+
+test("gsToPng throws on garbage input", async (t) => {
+  if (!(await gsAvailable())) return t.skip("ghostscript not installed");
+  await assert.rejects(gsToPng("application/postscript", Buffer.from("not postscript at all")));
+});
+
+// Prolog-stripped Illustrator EPS (Visual Park style): procsets referenced but
+// not embedded, art in AI operators. Classic-Mac \r line endings on purpose —
+// the corpus files carry them and the patcher must survive them. Body: a cyan
+// 8x4 rect via a compound path (two subpaths, deferred paint), plus a
+// gradient-block shape that must flatten to gray, not error.
+const STRIPPED_AI = Buffer.from(
+  [
+    "%!PS-Adobe-3.0 ",
+    "%%Creator: Adobe Illustrator(TM) 5.0",
+    "%%BoundingBox: 0 0 8 4",
+    "%%DocumentNeededResources: procset Adobe_level2_AI5 1.2 0",
+    "%%+ procset Adobe_Illustrator_AI5 1.0 0",
+    "%%EndComments",
+    "%%BeginProlog",
+    "%%IncludeResource: procset Adobe_level2_AI5 1.2 0",
+    "%%EndProlog",
+    "%%BeginSetup",
+    "Adobe_level2_AI5 /initialize get exec",
+    "Adobe_Illustrator_AI5 /initialize get exec",
+    "%%EndSetup",
+    "1 1 1 1 0 0 0 79 128 255 Lb",
+    "(Layer 1) Ln",
+    "0 A",
+    "1 0 0 0 k",
+    "*u",
+    "0 0 m",
+    "4 0 L",
+    "4 4 L",
+    "0 4 L",
+    "f",
+    "4 0 m",
+    "8 0 L",
+    "8 4 L",
+    "4 4 L",
+    "f",
+    "*U",
+    "Bb",
+    "2 (Chrome) 0 0 0 0 1 0 0 1 0 0 Bg",
+    "0 0 m",
+    "1 1 L",
+    "f",
+    "0 BB",
+    "LB",
+    "%%PageTrailer",
+    "gsave annotatepage grestore showpage",
+    "%%Trailer",
+    "Adobe_Illustrator_AI5 /terminate get exec",
+    "Adobe_level2_AI5 /terminate get exec",
+    "%%EOF",
+  ].join("\r"),
+  "latin1"
+);
+
+test("patchStrippedIllustrator targets only prolog-stripped files", () => {
+  const patched = patchStrippedIllustrator(STRIPPED_AI);
+  assert.ok(patched, "stripped AI file should be patched");
+  const text = patched.toString("latin1");
+  assert.ok(text.includes("/AICompat"), "compat prolog spliced in");
+  assert.ok(!/Adobe_\S+ \/initialize get exec/.test(text), "initialize calls removed");
+  assert.ok(!/^%%BeginSetup/m.test(text), "setup section removed");
+  // A self-contained EPS is left alone.
+  assert.equal(patchStrippedIllustrator(EPS), null);
+});
+
+test("gsToPng renders prolog-stripped Illustrator art", async (t) => {
+  if (!(await gsAvailable())) return t.skip("ghostscript not installed");
+  const png = PNG.sync.read(await gsToPng("application/postscript", STRIPPED_AI));
+  // The synthesized BoundingBox crop must hold (8x4pt at 150dpi ≈ 17x9px).
+  assert.ok(png.width >= 16 && png.width <= 18, `width ${png.width}`);
+  assert.ok(png.height >= 8 && png.height <= 10, `height ${png.height}`);
+  // Both compound subpaths must have painted cyan (1 0 0 0 cmyk) at 1/4 and
+  // 3/4 width. Exact RGB depends on Ghostscript's CMYK conversion — assert
+  // the hue, not the profile.
+  for (const fx of [0.25, 0.75]) {
+    const o = ((png.height >> 1) * png.width + Math.floor(png.width * fx)) * 4;
+    const [r, g, b] = png.data.subarray(o, o + 3);
+    assert.ok(r < 100 && g > 130 && b > 200, `cyan-ish at ${fx}, got ${r},${g},${b}`);
+  }
+});


### PR DESCRIPTION
PDF and PostScript files (.pdf, .eps, .ps, and classic .ai) now extract as a new document asset kind, byte-sniffed so game data reusing those extensions stays a hex snippet. The web viewer embeds PDFs natively and rasterizes EPS through Ghostscript, a soft server dependency that degrades to a download card when absent. Illustrator files whose Adobe procsets were stripped from the disc get a small compatibility prolog spliced in, verified against all 335 Visual Park clipart files plus the Hermes PDF comic. Rendering is cropped to the declared BoundingBox, gradient fills flatten to gray, and both GUIs group documents and open them with the OS viewer. Deploying this to hpwiki needs the ghostscript package installed and a corpus re-extract under asset profile 5.