### PR TITLE
Add force re-analyze

### DIFF
--- a/crates/curator-cli/src/main.rs
+++ b/crates/curator-cli/src/main.rs
@@ -44,6 +44,10 @@ enum Command {
         /// Write to this file instead of stdout (per-file: appends `.<n>` for multiple).
         #[arg(long, short)]
         out: Option<PathBuf>,
+        /// Ignore the cached record: full re-parse and re-hash, replacing the
+        /// stored record and library row.
+        #[arg(long)]
+        force: bool,
     },
     /// Export the local library as the bulk web-contribute feed.
     ///
@@ -97,15 +101,18 @@ fn main() -> Result<()> {
                 eprintln!("exported {n} builds");
             }
         },
-        Command::Analyze { files, format, out } => {
+        Command::Analyze { files, format, out, force } => {
             let total = files.len() as u64;
             for (i, path) in files.iter().enumerate() {
                 let observer = Arc::new(IndicatifObserver::new());
                 observer.batch(i as u64, total, path);
 
-                let analysis = analyzer
-                    .analyze(path, observer.clone())
-                    .with_context(|| format!("analyzing {path}"))?;
+                let analysis = if force {
+                    analyzer.reanalyze(path, observer.clone())
+                } else {
+                    analyzer.analyze(path, observer.clone())
+                }
+                .with_context(|| format!("analyzing {path}"))?;
                 observer.finish();
 
                 let rendered = match format {

--- a/crates/curator-core/src/lib.rs
+++ b/crates/curator-core/src/lib.rs
@@ -85,6 +85,27 @@ impl Analyzer {
         path: &str,
         observer: Arc<dyn ProgressObserver>,
     ) -> Result<Analysis> {
+        self.analyze_impl(path, observer, false)
+    }
+
+    /// Analyze ignoring any cached record: full re-parse and re-hash, replacing
+    /// the stored record and library row. For builds whose earlier parse is
+    /// known bad (e.g. a since-fixed reader bug) — a plain re-analyze is a
+    /// cache hit that only tops up assets and never re-hashes files.
+    pub fn reanalyze(
+        &self,
+        path: &str,
+        observer: Arc<dyn ProgressObserver>,
+    ) -> Result<Analysis> {
+        self.analyze_impl(path, observer, true)
+    }
+
+    fn analyze_impl(
+        &self,
+        path: &str,
+        observer: Arc<dyn ProgressObserver>,
+        force: bool,
+    ) -> Result<Analysis> {
         // 1. Image identity (single streaming read in Rust).
         let image = fingerprint::hash_image(path, &observer)?;
 
@@ -92,19 +113,21 @@ impl Analyzer {
         // ASSET_PROFILE (or never ran, assets == None) get topped up here —
         // extraction alone, no re-hash — so re-running analyze over an existing
         // collection backfills its asset store.
-        if let Some(mut record) = self.cache.load(&image.sha256)? {
-            observer.on_event(Event::Message(format!("cache hit {}", image.sha256)));
-            if record.assets.is_none() || record.asset_profile < schema::ASSET_PROFILE {
-                if let Some(assets) = self.extract_assets(path, &observer)? {
-                    record.assets = Some(assets);
-                    record.asset_profile = schema::ASSET_PROFILE;
-                    let xml = render::to_dat_xml(&record);
-                    let jp = self.cache.store(&record, &xml)?;
-                    self.db.upsert_build(&record, &jp.to_string_lossy())?;
+        if !force {
+            if let Some(mut record) = self.cache.load(&image.sha256)? {
+                observer.on_event(Event::Message(format!("cache hit {}", image.sha256)));
+                if record.assets.is_none() || record.asset_profile < schema::ASSET_PROFILE {
+                    if let Some(assets) = self.extract_assets(path, &observer)? {
+                        record.assets = Some(assets);
+                        record.asset_profile = schema::ASSET_PROFILE;
+                        let xml = render::to_dat_xml(&record);
+                        let jp = self.cache.store(&record, &xml)?;
+                        self.db.upsert_build(&record, &jp.to_string_lossy())?;
+                    }
                 }
+                let json_path = self.cache.json_path(&image.sha256);
+                return Ok(Analysis { record, from_cache: true, json_path });
             }
-            let json_path = self.cache.json_path(&image.sha256);
-            return Ok(Analysis { record, from_cache: true, json_path });
         }
 
         // 3. Parse + extract via the adapter (Python/ps2exe).

--- a/crates/curator-ffi/src/lib.rs
+++ b/crates/curator-ffi/src/lib.rs
@@ -315,6 +315,21 @@ impl Engine {
         build_summary(&analysis, |sha| analyzer.asset_blob_path(sha))
     }
 
+    /// Analyze ignoring any cached record: full re-parse and re-hash, replacing
+    /// the stored record and library row. For builds whose earlier parse is
+    /// known bad — plain analyze is a cache hit that never re-hashes files.
+    pub fn reanalyze(
+        &self,
+        path: String,
+        listener: Box<dyn ProgressListener>,
+        cancel: Option<Arc<CancelHandle>>,
+    ) -> Result<AnalysisSummary, CuratorError> {
+        let observer = Arc::new(ListenerObserver { listener, cancel });
+        let analyzer = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let analysis = analyzer.reanalyze(&path, observer)?;
+        build_summary(&analysis, |sha| analyzer.asset_blob_path(sha))
+    }
+
     /// Number of builds in the local library.
     pub fn library_size(&self) -> Result<u64, CuratorError> {
         Ok(self.inner.lock().unwrap_or_else(|e| e.into_inner()).library_size()?)

--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -83,6 +83,7 @@ mod app {
     const IDM_BROWSE: usize = 11;
     const IDM_VIEW_ASSETS: usize = 12;
     const IDM_OPEN_DIR_BUILD: usize = 13;
+    const IDM_REANALYZE: usize = 14;
     const IDM_RECENT_BASE: usize = 2000;
     const MAX_RECENT: u32 = 15;
 
@@ -591,6 +592,7 @@ mod app {
         let recent = CreatePopupMenu().unwrap_or_default();
         let _ = AppendMenuW(file, MF_STRING, IDM_OPEN, w!("&Open Image…\tCtrl+O"));
         let _ = AppendMenuW(file, MF_STRING, IDM_OPEN_DIR_BUILD, w!("Open Folder as &Build…"));
+        let _ = AppendMenuW(file, MF_STRING, IDM_REANALYZE, w!("&Re-analyze Image (fresh)…"));
         let _ = AppendMenuW(file, MF_STRING, IDM_OPEN_FOLDER, w!("&Import Folder (recursive)…"));
         let _ = AppendMenuW(file, MF_POPUP, recent.0 as usize, w!("Open &Recent"));
         let _ = AppendMenuW(file, MF_STRING, IDM_BROWSE, w!("&Browse Library…\tCtrl+B"));
@@ -654,6 +656,14 @@ mod app {
             IDM_OPEN => {
                 if let Some(path) = pick_file(hwnd) {
                     start_analysis(hwnd, path);
+                }
+            }
+            IDM_REANALYZE => {
+                // Full re-parse and re-hash, replacing the library record — for
+                // dumps whose earlier parse is known bad (plain re-analyze is a
+                // cache hit that only tops up assets).
+                if let Some(path) = pick_file(hwnd) {
+                    start_analysis_with(hwnd, path, true);
                 }
             }
             IDM_OPEN_DIR_BUILD => {
@@ -766,6 +776,10 @@ mod app {
     }
 
     unsafe fn start_analysis(hwnd: HWND, path: String) {
+        start_analysis_with(hwnd, path, false);
+    }
+
+    unsafe fn start_analysis_with(hwnd: HWND, path: String, force: bool) {
         let Some(st) = state(hwnd) else { return };
         if st.working {
             return;
@@ -794,11 +808,13 @@ mod app {
                 }
                 let obs: Arc<dyn ProgressObserver> =
                     Arc::new(WinObserver { hwnd: hwnd_i, events, cancel });
-                let analysis = guard
-                    .as_ref()
-                    .unwrap()
-                    .analyze(&path, obs)
-                    .map_err(|e| e.to_string())?;
+                let analyzer = guard.as_ref().unwrap();
+                let analysis = if force {
+                    analyzer.reanalyze(&path, obs)
+                } else {
+                    analyzer.analyze(&path, obs)
+                }
+                .map_err(|e| e.to_string())?;
                 let xml = render::to_dat_xml(&analysis.record);
                 let json = render::to_json(&analysis.record).map_err(|e| e.to_string())?;
                 Ok(AnalysisDone { record: analysis.record, xml, json, from_cache: analysis.from_cache })

--- a/macos/Sources/CuratorApp/AppModel.swift
+++ b/macos/Sources/CuratorApp/AppModel.swift
@@ -200,12 +200,12 @@ final class AppModel: ObservableObject {
         }
     }
 
-    func analyze(url: URL) {
+    func analyze(url: URL, force: Bool = false) {
         guard !isWorking else { return }
         isWorking = true
         errorMessage = nil
         counters = []
-        status = "Analyzing \(url.lastPathComponent)…"
+        status = "\(force ? "Re-analyzing" : "Analyzing") \(url.lastPathComponent)…"
         let cancel = CancelHandle()
         cancelHandle = cancel
 
@@ -223,7 +223,9 @@ final class AppModel: ObservableObject {
                 let summary: AnalysisSummary = try await withCheckedThrowingContinuation { continuation in
                     self.analysisQueue.async {
                         do {
-                            let summary = try engine.analyze(path: path, listener: forwarder, cancel: cancel)
+                            let summary = force
+                                ? try engine.reanalyze(path: path, listener: forwarder, cancel: cancel)
+                                : try engine.analyze(path: path, listener: forwarder, cancel: cancel)
                             continuation.resume(returning: summary)
                         } catch {
                             continuation.resume(throwing: error)
@@ -473,6 +475,21 @@ final class AppModel: ObservableObject {
         panel.prompt = "Open"
         if panel.runModal() == .OK, let url = panel.url {
             open(url: url)
+        }
+    }
+
+    /// Full re-parse and re-hash, replacing the library record — for dumps whose
+    /// earlier parse is known bad (plain re-analyze is a cache hit that only tops
+    /// up assets).
+    func reanalyzeDialog() {
+        guard !isWorking else { return }
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Re-analyze"
+        if panel.runModal() == .OK, let url = panel.url {
+            analyze(url: url, force: true)
         }
     }
 

--- a/macos/Sources/CuratorApp/CuratorApp.swift
+++ b/macos/Sources/CuratorApp/CuratorApp.swift
@@ -17,6 +17,8 @@ struct CuratorApp: App {
                     .disabled(model.isWorking)
                 Button("Open Folder as Build…") { model.openFolderAsBuildDialog() }
                     .keyboardShortcut("o", modifiers: [.command, .shift])
+                Button("Re-analyze Image (fresh)…") { model.reanalyzeDialog() }
+                    .keyboardShortcut("r", modifiers: [.command, .shift])
                     .disabled(model.isWorking)
                 Divider()
                 Button("Export Library for Upload…") { model.exportLibrary() }

--- a/macos/Sources/CuratorKit/curator_ffi.swift
+++ b/macos/Sources/CuratorKit/curator_ffi.swift
@@ -743,6 +743,13 @@ public protocol EngineProtocol: AnyObject, Sendable {
     func loadBuild(sha256: String) throws  -> AnalysisSummary?
     
     /**
+     * Analyze ignoring any cached record: full re-parse and re-hash, replacing
+     * the stored record and library row. For builds whose earlier parse is
+     * known bad — plain analyze is a cache hit that never re-hashes files.
+     */
+    func reanalyze(path: String, listener: ProgressListener, cancel: CancelHandle?) throws  -> AnalysisSummary
+    
+    /**
      * The most recently analyzed builds, newest first.
      */
     func recentBuilds(limit: UInt32) throws  -> [LibraryEntry]
@@ -913,6 +920,22 @@ open func loadBuild(sha256: String)throws  -> AnalysisSummary?  {
     uniffi_curator_ffi_fn_method_engine_load_build(
             self.uniffiCloneHandle(),
         FfiConverterString.lower(sha256),$0
+    )
+})
+}
+    
+    /**
+     * Analyze ignoring any cached record: full re-parse and re-hash, replacing
+     * the stored record and library row. For builds whose earlier parse is
+     * known bad — plain analyze is a cache hit that never re-hashes files.
+     */
+open func reanalyze(path: String, listener: ProgressListener, cancel: CancelHandle?)throws  -> AnalysisSummary  {
+    return try  FfiConverterTypeAnalysisSummary_lift(try rustCallWithError(FfiConverterTypeCuratorError_lift) {
+    uniffi_curator_ffi_fn_method_engine_reanalyze(
+            self.uniffiCloneHandle(),
+        FfiConverterString.lower(path),
+        FfiConverterCallbackInterfaceProgressListener_lower(listener),
+        FfiConverterOptionTypeCancelHandle.lower(cancel),$0
     )
 })
 }
@@ -2093,6 +2116,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_curator_ffi_checksum_method_engine_load_build() != 49667) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_curator_ffi_checksum_method_engine_reanalyze() != 14905) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_curator_ffi_checksum_method_engine_recent_builds() != 34130) {

--- a/macos/Sources/curator_ffiFFI/include/curator_ffiFFI.h
+++ b/macos/Sources/curator_ffiFFI/include/curator_ffiFFI.h
@@ -367,6 +367,11 @@ RustBuffer uniffi_curator_ffi_fn_method_engine_list_files(uint64_t ptr, RustBuff
 RustBuffer uniffi_curator_ffi_fn_method_engine_load_build(uint64_t ptr, RustBuffer sha256, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_FN_METHOD_ENGINE_REANALYZE
+#define UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_FN_METHOD_ENGINE_REANALYZE
+RustBuffer uniffi_curator_ffi_fn_method_engine_reanalyze(uint64_t ptr, RustBuffer path, uint64_t listener, RustBuffer cancel, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_FN_METHOD_ENGINE_RECENT_BUILDS
 #define UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_FN_METHOD_ENGINE_RECENT_BUILDS
 RustBuffer uniffi_curator_ffi_fn_method_engine_recent_builds(uint64_t ptr, uint32_t limit, RustCallStatus *_Nonnull out_status
@@ -704,6 +709,12 @@ uint16_t uniffi_curator_ffi_checksum_method_engine_list_files(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_CHECKSUM_METHOD_ENGINE_LOAD_BUILD
 #define UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_CHECKSUM_METHOD_ENGINE_LOAD_BUILD
 uint16_t uniffi_curator_ffi_checksum_method_engine_load_build(void
+
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_CHECKSUM_METHOD_ENGINE_REANALYZE
+#define UNIFFI_FFIDEF_UNIFFI_CURATOR_FFI_CHECKSUM_METHOD_ENGINE_REANALYZE
+uint16_t uniffi_curator_ffi_checksum_method_engine_reanalyze(void
 
 );
 #endif


### PR DESCRIPTION
A plain re-analyze of a known build is a cache hit that only tops up assets and never re-hashes files, so builds parsed under a since-fixed reader bug (like the Mac hybrid fork issue) could only be corrected by hand-deleting the cached record. Core gains reanalyze(), which skips the cache short-circuit, does a full re-parse and re-hash, and replaces the stored record and library row under the same build sha, so a resubmission updates the live wiki page in place. Exposed as analyze --force in the CLI, through the FFI, and as a Re-analyze Image (fresh) menu item in both GUIs. Verified with the Fallout - Jagged Alliance dump: analyze, cached analyze, then forced re-analyze producing the corrected document assets.