### PR TITLE
Add git repo viewer

### DIFF
--- a/web/db/migrations/004-repo.sql
+++ b/web/db/migrations/004-repo.sql
@@ -1,0 +1,21 @@
+-- Source repositories attached to builds (VSS->git conversions, extracted
+-- offline). One row per (build, repo name); the bytes live in the asset store:
+-- every git blob is stored content-addressed by sha256, and manifest_sha256
+-- names a JSON manifest blob describing commits/trees/blobs (see
+-- src/lib/repo-manifest.ts). Rows are created only by scripts/attach-repo.ts —
+-- re-ingest never touches this table (ingestRecord rewrites build_asset from
+-- the record; attached repos must survive).
+-- Idempotent — safe to re-run. Apply to every curator DB:
+--   psql -d <db> -f db/migrations/004-repo.sql
+
+CREATE TABLE IF NOT EXISTS build_repo (
+    build_sha256    TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE,
+    name            TEXT NOT NULL,             -- URL segment; [A-Za-z0-9][A-Za-z0-9._-]{0,63}
+    manifest_sha256 TEXT NOT NULL,             -- manifest blob in the asset store
+    head_oid        TEXT NOT NULL,             -- denormalized for the build page card
+    head_ref        TEXT,                      -- symbolic HEAD name, e.g. "master"
+    commit_count    INT  NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (build_sha256, name)
+);
+CREATE INDEX IF NOT EXISTS idx_build_repo_manifest ON build_repo(manifest_sha256);

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -78,6 +78,24 @@ CREATE TABLE build_asset (
 );
 CREATE INDEX idx_build_asset_sha256 ON build_asset(sha256);
 
+-- ── attached source repositories ──────────────────────────────────────────────
+-- VSS->git conversions attached manually by scripts/attach-repo.ts. The bytes
+-- live in the asset store: every git blob content-addressed by sha256, plus a
+-- JSON manifest blob (commits/trees/blobs — see src/lib/repo-manifest.ts)
+-- named by manifest_sha256. Re-ingest never touches this table (ingestRecord
+-- rewrites build_asset from the record; attached repos must survive).
+CREATE TABLE build_repo (
+    build_sha256    TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE,
+    name            TEXT NOT NULL,             -- URL segment; [A-Za-z0-9][A-Za-z0-9._-]{0,63}
+    manifest_sha256 TEXT NOT NULL,             -- manifest blob in the asset store
+    head_oid        TEXT NOT NULL,             -- denormalized for the build page card
+    head_ref        TEXT,                      -- symbolic HEAD name, e.g. "master"
+    commit_count    INT  NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (build_sha256, name)
+);
+CREATE INDEX idx_build_repo_manifest ON build_repo(manifest_sha256);
+
 -- ── identical-file overlap (set of truncated file-content hashes) ─────
 -- bigint[] of file sha1s truncated to 63 bits; smlar (or intarray &&) for Jaccard.
 CREATE TABLE build_fileset (

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "@types/pngjs": "^6.0.5",
         "bmp-js": "^0.1.0",
         "highlight.js": "^11.11.1",
+        "isomorphic-git": "^1.38.7",
         "next": "16.2.6",
         "pg": "^8.21.0",
         "pngjs": "^7.0.0",
@@ -2774,6 +2775,18 @@
         "win32"
       ]
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3033,11 +3046,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -3074,6 +3092,26 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -3159,11 +3197,34 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3182,7 +3243,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3196,7 +3256,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3256,6 +3315,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clean-git-ref": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3295,6 +3360,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3397,6 +3474,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3453,6 +3545,12 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT"
     },
+    "node_modules/diff3": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+      "license": "MIT"
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -3470,7 +3568,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3628,7 +3725,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4160,6 +4256,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4295,7 +4409,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -4326,7 +4439,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4387,7 +4499,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4412,7 +4523,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4604,7 +4714,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4617,7 +4726,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4633,7 +4741,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4668,11 +4775,30 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4704,6 +4830,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -4818,7 +4950,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5077,7 +5208,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -5139,7 +5269,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -5148,6 +5277,31 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-git": {
+      "version": "1.38.7",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.38.7.tgz",
+      "integrity": "sha512-2J2rCV7gTgcpscEDT7PjU5shbsKKI10E4RqBlPDI3LmMXDjSKsN2w1jTIKiay14v87sPDfXjJkgp/Rrxc0zlSg==",
+      "license": "MIT",
+      "dependencies": {
+        "async-lock": "^1.4.1",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "minimisted": "^2.0.0",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^4.0.0",
+        "sha.js": "^2.4.12",
+        "simple-get": "^4.0.1"
+      },
+      "bin": {
+        "isogit": "cli.cjs"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -5649,7 +5803,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5679,6 +5832,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5696,10 +5861,18 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimisted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
       }
     },
     "node_modules/ms": {
@@ -5982,6 +6155,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onnxruntime-common": {
       "version": "1.24.3",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
@@ -6092,6 +6274,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -6241,6 +6429,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/platform": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
@@ -6260,7 +6457,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6342,6 +6538,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/prop-types": {
@@ -6438,6 +6643,22 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -6599,6 +6820,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6675,7 +6916,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -6718,6 +6958,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sharp": {
@@ -6875,6 +7135,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6918,6 +7223,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -7174,6 +7488,20 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7280,7 +7608,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -7583,7 +7910,6 @@
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
       "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -7610,6 +7936,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -8,13 +8,15 @@
     "start": "next start",
     "lint": "eslint",
     "test": "node --import tsx --test tests/*.test.ts",
-    "ingest": "tsx scripts/ingest.ts"
+    "ingest": "tsx scripts/ingest.ts",
+    "attach-repo": "tsx scripts/attach-repo.ts"
   },
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
     "@types/pngjs": "^6.0.5",
     "bmp-js": "^0.1.0",
     "highlight.js": "^11.11.1",
+    "isomorphic-git": "^1.38.7",
     "next": "16.2.6",
     "pg": "^8.21.0",
     "pngjs": "^7.0.0",

--- a/web/scripts/attach-repo.ts
+++ b/web/scripts/attach-repo.ts
@@ -1,0 +1,308 @@
+// Attach a git repository (typically a VSS->git conversion) to an existing
+// build as a browsable source-repo asset.
+// Usage: npm run attach-repo -- --build <sha256 or 8+ hex prefix> --repo <path>
+//        [--name <name>] [--all-refs] [--force]        (env DATABASE_URL, ASSET_STORE_DIR)
+//
+// Reads the .git repo with isomorphic-git (pure JS — no git binary anywhere in
+// the pipeline), writes every unique git blob's content into the asset store
+// (content-addressed by sha256, so identical file versions dedup for free),
+// emits a manifest blob (see src/lib/repo-manifest.ts), and records the
+// attachment in build_repo. The web app serves the viewer from the manifest +
+// store alone. Re-running is idempotent on blobs; the row needs --force.
+
+import fs from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import git from "isomorphic-git";
+import pg from "pg";
+import { assetBlobPath, assetStoreDir } from "../src/lib/assets";
+import { resolveBuild } from "../src/lib/queries";
+import { buildHref } from "../src/lib/slug";
+import {
+  REPO_MANIFEST_VERSION,
+  REPO_NAME_RE,
+  type RepoBlobInfo,
+  type RepoCommit,
+  type RepoIdent,
+  type RepoManifest,
+  type RepoTreeEntry,
+} from "../src/lib/repo-manifest";
+
+// Guards against pathological commit messages; VSS comments are tiny.
+const MAX_MESSAGE_CHARS = 10_000;
+// Beyond this the manifest still works (the server LRU-caches the parsed
+// form), but a v2 format with interned oids would be worth building.
+const MANIFEST_WARN_BYTES = 50_000_000;
+
+function usage(): never {
+  console.error(
+    "usage: tsx scripts/attach-repo.ts --build <sha256 or 8+ hex prefix> --repo <path> [--name <name>] [--all-refs] [--force]"
+  );
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]) {
+  const opts = { build: "", repo: "", name: "", allRefs: false, force: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--build") opts.build = argv[++i] ?? "";
+    else if (a === "--repo") opts.repo = argv[++i] ?? "";
+    else if (a === "--name") opts.name = argv[++i] ?? "";
+    else if (a === "--all-refs") opts.allRefs = true;
+    else if (a === "--force") opts.force = true;
+    else {
+      console.error(`unknown argument: ${a}`);
+      usage();
+    }
+  }
+  if (!opts.build || !opts.repo) usage();
+  return opts;
+}
+
+/** Resolve a repo path (work tree, bare repo, or .git-file pointer) to the
+ *  actual gitdir isomorphic-git should read. */
+function findGitdir(repoPath: string): string {
+  const dotGit = path.join(repoPath, ".git");
+  let st: fs.Stats | undefined;
+  try {
+    st = fs.statSync(dotGit);
+  } catch {
+    // no .git — maybe bare
+  }
+  if (st?.isDirectory()) return dotGit;
+  if (st?.isFile()) {
+    // Worktree pointer file: "gitdir: <target>"
+    const m = fs.readFileSync(dotGit, "utf8").match(/^gitdir:\s*(.+)\s*$/m);
+    if (m) return path.resolve(repoPath, m[1]);
+  }
+  if (fs.existsSync(path.join(repoPath, "HEAD")) && fs.existsSync(path.join(repoPath, "objects"))) {
+    return repoPath; // bare repo
+  }
+  console.error(`${repoPath} is not a git repository`);
+  process.exit(1);
+}
+
+/** Follow annotated-tag chains down to a commit oid; null when the ref
+ *  ultimately points at something else (e.g. a tagged tree). */
+async function peelToCommit(
+  fsArg: typeof fs,
+  gitdir: string,
+  cache: object,
+  oid: string
+): Promise<string | null> {
+  for (let hops = 0; hops < 10; hops++) {
+    try {
+      const c = await git.readCommit({ fs: fsArg, gitdir, oid, cache });
+      return c.oid;
+    } catch {
+      try {
+        const t = await git.readTag({ fs: fsArg, gitdir, oid, cache });
+        oid = t.tag.object;
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+/** Staged write into the content-addressed store (the ingest.ts idiom): a
+ *  crash can't leave a truncated blob under its final name. */
+function storeBlob(sha256: string, data: Uint8Array): boolean {
+  const dest = assetBlobPath(sha256);
+  if (fs.existsSync(dest)) return false;
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  const tmp = `${dest}.tmp${process.pid}`;
+  fs.writeFileSync(tmp, data);
+  fs.renameSync(tmp, dest);
+  return true;
+}
+
+const ident = (i: { name: string; email: string; timestamp: number; timezoneOffset: number }): RepoIdent => ({
+  name: i.name,
+  email: i.email,
+  time: i.timestamp,
+  tz: i.timezoneOffset,
+});
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  const hex = opts.build.toLowerCase();
+  if (!/^[0-9a-f]{8,64}$/.test(hex)) {
+    console.error("--build must be a sha256 or an 8+ char hex prefix of one");
+    process.exit(1);
+  }
+
+  const repoPath = path.resolve(opts.repo);
+  const gitdir = findGitdir(repoPath);
+  const name = opts.name || path.basename(repoPath).replace(/\.git$/, "");
+  if (!REPO_NAME_RE.test(name)) {
+    console.error(`repo name "${name}" is not URL-safe (${REPO_NAME_RE}); pass --name`);
+    process.exit(1);
+  }
+
+  const pool = new pg.Pool({
+    connectionString: process.env.DATABASE_URL || "postgres:///curator_test",
+  });
+  try {
+    // Fail fast on identity questions before any repo walking.
+    const build = await resolveBuild(pool, hex, null);
+    if (!build) {
+      console.error(`no unique build matches "${hex}"`);
+      process.exit(1);
+    }
+    if (!opts.force) {
+      const existing = await pool.query(
+        "SELECT 1 FROM build_repo WHERE build_sha256=$1 AND name=$2",
+        [build.sha256, name]
+      );
+      if (existing.rows.length) {
+        console.error(`repo "${name}" is already attached to ${build.name} — pass --force to replace`);
+        process.exit(1);
+      }
+    }
+
+    // isomorphic-git's cache memoizes packfile indexes across the thousands of
+    // object reads below — without it every read re-parses the pack.
+    const cache = {};
+
+    let head: string;
+    try {
+      head = await git.resolveRef({ fs, gitdir, ref: "HEAD" });
+    } catch {
+      console.error(`${repoPath} has no commits`);
+      process.exit(1);
+    }
+    const headRef = (await git.currentBranch({ fs, gitdir, fullname: false })) ?? null;
+
+    // Branches then tags, name-sorted; annotated tags peeled to their commits.
+    const refs: { name: string; oid: string }[] = [];
+    const branchNames = (await git.listBranches({ fs, gitdir })).sort();
+    const tagNames = (await git.listTags({ fs, gitdir })).sort();
+    for (const [names, kind] of [
+      [branchNames, "branch"],
+      [tagNames, "tag"],
+    ] as const) {
+      for (const refName of names) {
+        const raw = await git.resolveRef({ fs, gitdir, ref: refName }).catch(() => null);
+        const oid = raw && (await peelToCommit(fs, gitdir, cache, raw));
+        if (oid) refs.push({ name: refName, oid });
+        else console.warn(`skipping unresolvable ${kind} ${refName}`);
+      }
+    }
+
+    // Commit walk: BFS over parents from HEAD (or every ref with --all-refs).
+    const seeds = opts.allRefs ? [head, ...refs.map((r) => r.oid)] : [head];
+    const commitByOid = new Map<string, RepoCommit>();
+    const stack = [...seeds];
+    while (stack.length) {
+      const oid = stack.pop()!;
+      if (commitByOid.has(oid)) continue;
+      const { commit } = await git.readCommit({ fs, gitdir, oid, cache });
+      commitByOid.set(oid, {
+        oid,
+        tree: commit.tree,
+        parents: commit.parent,
+        author: ident(commit.author),
+        committer: ident(commit.committer),
+        message: commit.message.slice(0, MAX_MESSAGE_CHARS),
+      });
+      stack.push(...commit.parent.filter((p) => !commitByOid.has(p)));
+    }
+    // Newest-first, deterministically (same repo -> byte-identical manifest).
+    const commits = [...commitByOid.values()].sort(
+      (a, b) => b.committer.time - a.committer.time || (a.oid < b.oid ? -1 : 1)
+    );
+    // Without --all-refs a ref can point outside the walked history; the
+    // manifest must stay self-contained.
+    const kept = refs.filter((r) => commitByOid.has(r.oid));
+    for (const r of refs) {
+      if (!commitByOid.has(r.oid)) console.warn(`ref ${r.name} not reachable from HEAD — dropped (use --all-refs)`);
+    }
+
+    // Tree walk: consecutive commits share almost all subtrees, so the visited
+    // set is what keeps this linear in the number of *unique* trees.
+    const trees: Record<string, RepoTreeEntry[]> = {};
+    const blobOids = new Set<string>();
+    let gitlinks = 0;
+    const treeStack = commits.map((c) => c.tree);
+    while (treeStack.length) {
+      const oid = treeStack.pop()!;
+      if (trees[oid]) continue;
+      const { tree } = await git.readTree({ fs, gitdir, oid, cache });
+      const entries: RepoTreeEntry[] = [];
+      for (const e of tree) {
+        if (e.type === "commit") {
+          gitlinks++; // submodule pointer — nothing behind it in this repo
+          continue;
+        }
+        entries.push([e.path, e.type, e.oid]);
+        if (e.type === "tree") {
+          if (!trees[e.oid]) treeStack.push(e.oid);
+        } else {
+          blobOids.add(e.oid);
+        }
+      }
+      trees[oid] = entries;
+    }
+    if (gitlinks > 0) console.warn(`dropped ${gitlinks} submodule (gitlink) entries`);
+
+    // Blob pass: content into the store, one blob in memory at a time.
+    const blobs: Record<string, RepoBlobInfo> = {};
+    let written = 0;
+    let done = 0;
+    for (const oid of [...blobOids].sort()) {
+      const { blob } = await git.readBlob({ fs, gitdir, oid, cache });
+      const sha256 = createHash("sha256").update(blob).digest("hex");
+      // Git's own binary heuristic: a NUL byte in the head of the file.
+      const binary = blob.subarray(0, 8000).includes(0) ? 1 : 0;
+      if (storeBlob(sha256, blob)) written++;
+      blobs[oid] = [sha256, blob.length, binary];
+      if (++done % 500 === 0) console.log(`  blobs: ${done}/${blobOids.size}`);
+    }
+
+    const manifest: RepoManifest = {
+      version: REPO_MANIFEST_VERSION,
+      name,
+      head,
+      headRef,
+      refs: kept,
+      commits,
+      trees,
+      blobs,
+    };
+    const manifestBytes = Buffer.from(JSON.stringify(manifest));
+    const manifestSha = createHash("sha256").update(manifestBytes).digest("hex");
+    if (manifestBytes.length > MANIFEST_WARN_BYTES) {
+      console.warn(
+        `manifest is ${(manifestBytes.length / 1e6).toFixed(0)}MB — consider a v2 interned format before attaching many repos this size`
+      );
+    }
+    storeBlob(manifestSha, manifestBytes);
+
+    await pool.query(
+      `INSERT INTO build_repo (build_sha256, name, manifest_sha256, head_oid, head_ref, commit_count)
+       VALUES ($1,$2,$3,$4,$5,$6)
+       ON CONFLICT (build_sha256, name) DO UPDATE
+         SET manifest_sha256=EXCLUDED.manifest_sha256, head_oid=EXCLUDED.head_oid,
+             head_ref=EXCLUDED.head_ref, commit_count=EXCLUDED.commit_count, created_at=now()`,
+      [build.sha256, name, manifestSha, head, headRef, commits.length]
+    );
+
+    console.log(`attached "${name}" to ${build.name} (${build.sha256.slice(0, 10)})`);
+    console.log(
+      `  ${commits.length} commits, ${Object.keys(trees).length} trees, ${blobOids.size} blobs (${written} new in ${assetStoreDir()})`
+    );
+    console.log(`  manifest ${manifestSha} (${(manifestBytes.length / 1024).toFixed(0)}KB)`);
+    console.log(`  ${buildHref(build.sha256, build.name)}/repo/${encodeURIComponent(name)}`);
+    console.log(`  note: the build page card is ISR-cached — allow up to an hour on prod, or restart`);
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/web/src/app/api/repo/[sha256]/blob/[oid]/route.ts
+++ b/web/src/app/api/repo/[sha256]/blob/[oid]/route.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { Readable } from "node:stream";
+import type { NextRequest } from "next/server";
+import { assetBlobPath } from "@/lib/assets";
+import { loadRepo, repoAttached } from "@/lib/repo";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// GET /api/repo/<manifest sha256>/blob/<git blob oid>[?name=<basename hint>]
+// — stream one file version of an attached repo from the blob store. The oid
+// must be referenced by the manifest (which itself must be attached to a
+// build), so this can't serve arbitrary store content. A blob can live at
+// many paths, so the download filename comes from the ?name hint.
+//
+// Headers mirror /api/asset: repo blobs are only ever text/plain (inline) or
+// opaque bytes (attachment), never anything a browser could script with.
+const CACHE = "public, max-age=31536000, immutable";
+const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+
+/** One satisfiable `bytes=start-end` range, else null (serve the whole file). */
+function parseRange(header: string | null, size: number): { start: number; end: number } | null {
+  const m = header?.match(/^bytes=(\d*)-(\d*)$/);
+  if (!m || size === 0) return null;
+  const [, a, b] = m;
+  if (a === "" && b === "") return null;
+  const start = a === "" ? Math.max(0, size - Number(b)) : Number(a);
+  const end = a !== "" && b !== "" ? Math.min(Number(b), size - 1) : size - 1;
+  if (start > end || start >= size) return null;
+  return { start, end };
+}
+
+export async function GET(
+  request: NextRequest,
+  ctx: { params: Promise<{ sha256: string; oid: string }> }
+) {
+  const { sha256, oid } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+  if (!/^[0-9a-f]{40}$/.test(oid)) return Response.json({ error: "invalid oid" }, { status: 400 });
+  if (!(await repoAttached(sha256))) return Response.json({ error: "not found" }, { status: 404 });
+  const idx = await loadRepo(sha256);
+  if (!idx) return Response.json({ error: "repository data not in store" }, { status: 404 });
+
+  const info = idx.blobs.get(oid);
+  if (!info) return Response.json({ error: "not found" }, { status: 404 });
+  const [storeSha, , binary] = info;
+
+  if (request.headers.get("if-none-match") === `"${oid}"`) {
+    return new Response(null, { status: 304, headers: { "Cache-Control": CACHE, ETag: `"${oid}"` } });
+  }
+
+  const blob = assetBlobPath(storeSha);
+  let stat: fs.Stats;
+  try {
+    stat = await fsp.stat(blob);
+  } catch {
+    // Row + manifest landed but this blob hasn't synced to this host yet.
+    return Response.json({ error: "blob bytes not in store" }, { status: 404 });
+  }
+
+  const name = request.nextUrl.searchParams.get("name") || oid;
+  const asciiName = name.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+  const headers: Record<string, string> = {
+    "Content-Type": binary ? "application/octet-stream" : "text/plain; charset=utf-8",
+    "Content-Disposition": `${binary ? "attachment" : "inline"}; filename="${asciiName}"`,
+    "Cache-Control": CACHE,
+    ETag: `"${oid}"`,
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": CSP,
+    "Accept-Ranges": "bytes",
+  };
+
+  const range = parseRange(request.headers.get("range"), stat.size);
+  if (range) {
+    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${stat.size}`;
+    headers["Content-Length"] = String(range.end - range.start + 1);
+    const stream = fs.createReadStream(blob, { start: range.start, end: range.end });
+    return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
+  }
+
+  headers["Content-Length"] = String(stat.size);
+  const stream = fs.createReadStream(blob);
+  return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
+}

--- a/web/src/app/api/repo/[sha256]/commits/route.ts
+++ b/web/src/app/api/repo/[sha256]/commits/route.ts
@@ -1,0 +1,31 @@
+import type { NextRequest } from "next/server";
+import { commitsPage, resolveRev } from "@/lib/repo-manifest";
+import { loadRepo, repoAttached } from "@/lib/repo";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// GET /api/repo/<manifest sha256>/commits?rev=&offset=&limit= — one page of
+// the commit log reachable from a revision, newest-first. Immutable per URL
+// (content-addressed manifest).
+const CACHE = "public, max-age=31536000, immutable";
+
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+  if (!(await repoAttached(sha256))) return Response.json({ error: "not found" }, { status: 404 });
+  const idx = await loadRepo(sha256);
+  if (!idx) return Response.json({ error: "repository data not in store" }, { status: 404 });
+
+  const params = request.nextUrl.searchParams;
+  const rev = resolveRev(idx, params.get("rev") ?? "");
+  if (!rev) return Response.json({ error: "unknown revision" }, { status: 404 });
+  const offset = Math.max(0, Number(params.get("offset")) || 0);
+  const limit = Math.min(200, Math.max(1, Number(params.get("limit")) || 100));
+
+  const page = commitsPage(idx, rev, offset, limit);
+  return Response.json(
+    { rev, total: page.total, offset, commits: page.commits },
+    { headers: { "Cache-Control": CACHE } }
+  );
+}

--- a/web/src/app/api/repo/[sha256]/log/route.ts
+++ b/web/src/app/api/repo/[sha256]/log/route.ts
@@ -1,0 +1,49 @@
+import type { NextRequest } from "next/server";
+import { entryAt, fileLog, resolveRev } from "@/lib/repo-manifest";
+import { loadRepo, repoAttached } from "@/lib/repo";
+import { normalizeAssetPath } from "@/lib/slug";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// GET /api/repo/<manifest sha256>/log?rev=&path=<file> — the revisions of one
+// path walking first parents from a revision, each joined with its commit's
+// identity and message so the history panel needs a single fetch. Immutable
+// per URL (content-addressed manifest).
+const CACHE = "public, max-age=31536000, immutable";
+
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+  if (!(await repoAttached(sha256))) return Response.json({ error: "not found" }, { status: 404 });
+  const idx = await loadRepo(sha256);
+  if (!idx) return Response.json({ error: "repository data not in store" }, { status: 404 });
+
+  const params = request.nextUrl.searchParams;
+  const rev = resolveRev(idx, params.get("rev") ?? "");
+  if (!rev) return Response.json({ error: "unknown revision" }, { status: 404 });
+  const path = normalizeAssetPath(params.get("path") ?? "");
+  if (!path) return Response.json({ error: "path required" }, { status: 400 });
+  // Deleted files log fine (entry is null at rev); directories don't — their
+  // "blob" would be a tree oid the blob route can't serve.
+  if (entryAt(idx, rev, path)?.type === "tree") {
+    return Response.json({ error: "path is a directory" }, { status: 400 });
+  }
+
+  // Entries carry their blob's size/binary flag too: the first entry *is* the
+  // path's version at `rev` (or its deletion), so the file view needs no
+  // second lookup.
+  const entries = fileLog(idx, rev, path).map((e) => {
+    const c = idx.commitByOid.get(e.oid)!;
+    const b = e.blob ? idx.blobs.get(e.blob) : undefined;
+    return {
+      ...e,
+      size: b ? b[1] : null,
+      binary: b ? b[2] === 1 : false,
+      author: c.author,
+      committer: c.committer,
+      message: c.message,
+    };
+  });
+  return Response.json({ rev, path, entries }, { headers: { "Cache-Control": CACHE } });
+}

--- a/web/src/app/api/repo/[sha256]/tree/route.ts
+++ b/web/src/app/api/repo/[sha256]/tree/route.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from "next/server";
+import { buildTree, findByPath, stubChildren } from "@/lib/filetree";
+import { resolveRev, treeNodesAt } from "@/lib/repo-manifest";
+import { loadRepo, repoAttached } from "@/lib/repo";
+import { normalizeAssetPath } from "@/lib/slug";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// GET /api/repo/<manifest sha256>/tree?rev=<rev>&path=<dir> — an attached
+// repo's file tree at a revision: the full tree without `path`, one lazily
+// expanded directory's children with it (same shapes as /api/build/.../tree,
+// so the tree client code is shared thinking).
+//
+// The manifest is content-addressed and refs are frozen inside it, so every
+// response for a given URL is immutable.
+const CACHE = "public, max-age=31536000, immutable";
+
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+  if (!(await repoAttached(sha256))) return Response.json({ error: "not found" }, { status: 404 });
+  const idx = await loadRepo(sha256);
+  if (!idx) return Response.json({ error: "repository data not in store" }, { status: 404 });
+
+  const rev = resolveRev(idx, request.nextUrl.searchParams.get("rev") ?? "");
+  if (!rev) return Response.json({ error: "unknown revision" }, { status: 404 });
+
+  const roots = buildTree(treeNodesAt(idx, rev));
+  const path = request.nextUrl.searchParams.get("path");
+  if (path == null || path === "") {
+    return Response.json({ rev, roots }, { headers: { "Cache-Control": CACHE } });
+  }
+  const node = findByPath(roots, "/" + normalizeAssetPath(path));
+  if (!node || !node.dir) return Response.json({ error: "no such directory" }, { status: 404 });
+  return Response.json({ rev, children: stubChildren(node.children) }, { headers: { "Cache-Control": CACHE } });
+}

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -5,10 +5,11 @@ import { notFound, permanentRedirect } from "next/navigation";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
 import { buildTree, initialExpanded, pruneToExpanded, treeCounts } from "@/lib/filetree";
-import { getBuild, getBuildAssets, getBuildMeta, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, getLotBuilds, listLots, resolveBuild } from "@/lib/queries";
+import { getBuild, getBuildAssets, getBuildMeta, getBuildRepos, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, listLots, resolveBuild } from "@/lib/queries";
+import { shortOid } from "@/lib/repo-manifest";
 import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
 import { buildDescription, displayTitle } from "@/lib/meta";
-import { buildHref, canonicalBuildId, parseBuildParam } from "@/lib/slug";
+import { canonicalBuildId, parseBuildParam } from "@/lib/slug";
 import type { BuildRecord } from "@/lib/types";
 import SimilarBuilds from "./SimilarBuilds";
 import FileTree from "./FileTree";
@@ -138,14 +139,13 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
   const q = deriveQueryFeatures(build.record);
   // Pull a wide candidate set per tier so the fused top-50 is well-populated.
   // Text neighbors use this build's already-stored embedding — no re-embedding per load.
-  const [similar, textNeighbors, assets, lotBuilds, lots] = await Promise.all([
+  const [similar, textNeighbors, assets, lots, repos] = await Promise.all([
     findSimilar(pool, q, 100),
     findByEmbeddingOf(pool, sha256, 100),
     getBuildAssets(pool, sha256),
-    build.lot ? getLotBuilds(pool, build.lot) : Promise.resolve([]),
     listLots(pool),
+    getBuildRepos(pool, sha256),
   ]);
-  const lotMates = lotBuilds.filter((b) => b.sha256 !== sha256);
   const fused = fuseSimilar(similar, textNeighbors);
 
   // A tier only counts when both builds have its data — attach each build's capabilities
@@ -214,27 +214,6 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
         lots={lots}
       />
 
-      {build.lot && lotMates.length > 0 && (
-        <section className="mt-8">
-          <h2 className="text-lg font-medium">
-            Lot: {build.lot}{" "}
-            <span className="text-sm font-normal text-neutral-400">({lotMates.length + 1} builds)</span>
-          </h2>
-          <ul className="mt-3 divide-y divide-neutral-100 dark:divide-neutral-900/60">
-            {lotMates.map((b) => (
-              <li key={b.sha256} className="flex items-center gap-3 py-2 text-sm">
-                <Link href={buildHref(b.sha256, b.name)} className="min-w-0 truncate font-medium hover:underline">
-                  {b.name}
-                </Link>
-                <Chip>{b.system || "unknown"}</Chip>
-                <span className="text-xs text-neutral-500">{b.file_count} files</span>
-                <span className="text-xs text-neutral-500">{humanSize(b.total_size)}</span>
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
-
       {meta.length > 0 && (
         <section className="mt-8">
           <h2 className="text-lg font-medium">Metadata</h2>
@@ -253,6 +232,31 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
               </div>
             ))}
           </div>
+        </section>
+      )}
+
+      {repos.length > 0 && (
+        <section className="mt-8">
+          <h2 className="text-lg font-medium">
+            Source {repos.length === 1 ? "repository" : "repositories"}
+          </h2>
+          <ul className="mt-3 divide-y divide-neutral-100 dark:divide-neutral-900/60">
+            {repos.map((r) => (
+              <li key={r.name} className="flex items-center gap-3 py-2 text-sm">
+                <Link
+                  href={`${href}/repo/${encodeURIComponent(r.name)}`}
+                  className="min-w-0 truncate font-mono font-medium hover:underline"
+                >
+                  {r.name}
+                </Link>
+                <Chip>{r.commit_count} commits</Chip>
+                <Chip>
+                  <span className="font-mono">{r.head_ref ?? shortOid(r.head_oid)}</span>
+                </Chip>
+                <span className="text-xs text-neutral-500">attached {r.created_at.slice(0, 10)}</span>
+              </li>
+            ))}
+          </ul>
         </section>
       )}
 

--- a/web/src/app/builds/[buildId]/repo/[name]/RepoCommitList.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/RepoCommitList.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+// The global commit log reachable from the current revision, newest-first,
+// paginated. The parent remounts this per revision (key={revOid}) and passes
+// the server-rendered first page for the initial one; later revisions fetch
+// their own. Clicking a commit rewinds the whole viewer to that snapshot.
+
+import { useEffect, useState } from "react";
+import { commitSubject, formatCommitDate, shortOid, type RepoCommit } from "@/lib/repo-manifest";
+
+const PAGE = 50;
+
+export default function RepoCommitList({
+  apiBase,
+  revOid,
+  initial,
+  onSelectCommit,
+}: {
+  apiBase: string;
+  revOid: string;
+  initial: { total: number; commits: RepoCommit[] } | null;
+  onSelectCommit: (oid: string) => void;
+}) {
+  const [commits, setCommits] = useState<RepoCommit[]>(initial?.commits ?? []);
+  const [total, setTotal] = useState<number | null>(initial?.total ?? null);
+  // Callers flip busy on before fetching, so no state is ever set
+  // synchronously inside the effect (the initial fetch starts busy).
+  const [busy, setBusy] = useState(initial === null);
+  const [error, setError] = useState(false);
+
+  const loadPage = (offset: number) =>
+    fetch(`${apiBase}/commits?rev=${revOid}&offset=${offset}&limit=${PAGE}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<{ total: number; commits: RepoCommit[] }>;
+      })
+      .then(
+        (data) => {
+          setCommits((prev) => (offset === 0 ? data.commits : [...prev, ...data.commits]));
+          setTotal(data.total);
+          setError(false);
+          setBusy(false);
+        },
+        () => {
+          setError(true);
+          setBusy(false);
+        }
+      );
+
+  // No server-rendered page for this revision — fetch the first one.
+  useEffect(() => {
+    if (initial === null) void loadPage(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div>
+      <h2 className="text-lg font-medium">
+        History{" "}
+        {total !== null && <span className="text-sm font-normal text-neutral-400">({total} commits)</span>}
+      </h2>
+      {error && <p className="mt-3 text-sm text-red-500">Failed to load commits — try again.</p>}
+      <ul className="mt-3 divide-y divide-neutral-100 dark:divide-neutral-900/60">
+        {commits.map((c) => (
+          <li key={c.oid}>
+            <button
+              onClick={() => onSelectCommit(c.oid)}
+              className="flex w-full items-baseline gap-3 py-2 text-left text-sm hover:bg-neutral-50 dark:hover:bg-neutral-900/40"
+              title={`Browse the tree at ${shortOid(c.oid)}`}
+            >
+              <span
+                className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-xs ${
+                  c.oid === revOid
+                    ? "bg-sky-100 text-sky-900 dark:bg-sky-900/40 dark:text-sky-200"
+                    : "bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300"
+                }`}
+              >
+                {shortOid(c.oid)}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate font-medium">{commitSubject(c.message) || "(no message)"}</span>
+                <span className="mt-0.5 block text-xs text-neutral-500">
+                  {c.author.name} · {formatCommitDate(c.author)}
+                  {c.parents.length > 1 && (
+                    <span className="ml-2 rounded bg-neutral-100 px-1 uppercase tracking-wide text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400">
+                      merge
+                    </span>
+                  )}
+                </span>
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      {busy && <p className="mt-3 text-sm text-neutral-400">Loading…</p>}
+      {!busy && total !== null && commits.length < total && (
+        <button
+          onClick={() => {
+            setBusy(true);
+            void loadPage(commits.length);
+          }}
+          className="mt-3 text-sm text-neutral-500 hover:underline"
+        >
+          Load more ({total - commits.length} older)
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/builds/[buildId]/repo/[name]/RepoFileHistory.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/RepoFileHistory.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+// Per-file history panel: the revisions of the open file, walking first
+// parents from the current revision (the log the parent fetched — its head
+// entry is the version on screen). Clicking an entry rewinds the viewer to
+// that commit, so the file shows as of that revision.
+
+import { commitSubject, formatCommitDate, shortOid } from "@/lib/repo-manifest";
+import type { LogState } from "./RepoViewer";
+
+const CHANGE_STYLE: Record<string, string> = {
+  add: "bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200",
+  modify: "bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-300",
+  delete: "bg-red-100 text-red-900 dark:bg-red-900/40 dark:text-red-200",
+};
+
+export default function RepoFileHistory({
+  path,
+  log,
+  revOid,
+  onSelectCommit,
+}: {
+  path: string;
+  log: LogState;
+  revOid: string;
+  onSelectCommit: (oid: string) => void;
+}) {
+  return (
+    <div>
+      <h2 className="text-lg font-medium">
+        File history{" "}
+        {Array.isArray(log) && (
+          <span className="text-sm font-normal text-neutral-400">({log.length})</span>
+        )}
+      </h2>
+      {log === "loading" && <p className="mt-3 text-sm text-neutral-400">Loading…</p>}
+      {log === "error" && <p className="mt-3 text-sm text-red-500">Failed to load history.</p>}
+      {Array.isArray(log) && log.length === 0 && (
+        <p className="mt-3 text-sm text-neutral-500">No history for {path} at this revision.</p>
+      )}
+      {Array.isArray(log) && log.length > 0 && (
+        <ul className="mt-3 divide-y divide-neutral-100 dark:divide-neutral-900/60">
+          {log.map((e, i) => (
+            <li key={e.oid}>
+              <button
+                onClick={() => onSelectCommit(e.oid)}
+                className={`flex w-full items-baseline gap-2 py-2 text-left text-sm hover:bg-neutral-50 dark:hover:bg-neutral-900/40 ${
+                  i === 0 ? "" : "opacity-90"
+                }`}
+                title={`View the file as of ${shortOid(e.oid)}`}
+              >
+                <span
+                  className={`w-14 shrink-0 rounded px-1 text-center text-[10px] uppercase tracking-wide ${CHANGE_STYLE[e.change]}`}
+                >
+                  {e.change}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate">{commitSubject(e.message) || "(no message)"}</span>
+                  <span className="mt-0.5 block font-mono text-xs text-neutral-500">
+                    {e.oid === revOid ? (
+                      <span className="mr-1 rounded bg-sky-100 px-1 text-sky-900 dark:bg-sky-900/40 dark:text-sky-200">
+                        {shortOid(e.oid)}
+                      </span>
+                    ) : (
+                      <span className="mr-1">{shortOid(e.oid)}</span>
+                    )}
+                    {e.author.name} · {formatCommitDate(e.author)}
+                  </span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/builds/[buildId]/repo/[name]/RepoFileTree.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/RepoFileTree.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+// The repo file tree at one revision — FileTree.tsx adapted: rows open files
+// in the repo viewer instead of the asset lightbox, and there's no Modified
+// column (git trees carry no dates). The parent remounts this per revision
+// (key={revOid}) with that snapshot's roots; collapsed stubs lazy-load their
+// children from /api/repo/<sha>/tree.
+
+import { useCallback, useState } from "react";
+import {
+  collectDirPaths,
+  findByPath,
+  fullyLoaded,
+  graftChildren,
+  type TreeNode,
+} from "@/lib/filetree";
+import { normalizeAssetPath } from "@/lib/slug";
+
+function humanSize(bytes?: number): string {
+  if (bytes == null) return "—";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let v = bytes;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return i === 0 ? `${bytes} B` : `${v.toFixed(1)} ${units[i]}`;
+}
+
+// Fixed row height so a folder's sticky `top` can be offset by its depth (the
+// ancestor chain stacks at the top of the scroll container).
+const ROW_H = 28;
+const HEADER_H = 28;
+
+interface Row {
+  node: TreeNode;
+  depth: number;
+}
+
+function visibleRows(nodes: TreeNode[], expanded: Set<string>, depth = 0, out: Row[] = []): Row[] {
+  for (const n of nodes) {
+    out.push({ node: n, depth });
+    if (n.dir && expanded.has(n.path)) visibleRows(n.children, expanded, depth + 1, out);
+  }
+  return out;
+}
+
+export default function RepoFileTree({
+  apiBase,
+  revOid,
+  roots,
+  initiallyExpanded,
+  selectedPath,
+  onOpenFile,
+}: {
+  apiBase: string;
+  revOid: string;
+  roots: TreeNode[];
+  initiallyExpanded: string[];
+  selectedPath: string | null;
+  onOpenFile: (path: string) => void;
+}) {
+  const [tree, setTree] = useState<TreeNode[]>(roots);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set(initiallyExpanded));
+  const [loading, setLoading] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+
+  const rows = visibleRows(tree, expanded);
+
+  const setBusy = (path: string, busy: boolean) =>
+    setLoading((prev) => {
+      const next = new Set(prev);
+      if (busy) next.add(path);
+      else next.delete(path);
+      return next;
+    });
+
+  const toggle = useCallback(
+    async (path: string) => {
+      if (expanded.has(path)) {
+        setExpanded((prev) => {
+          const next = new Set(prev);
+          next.delete(path);
+          return next;
+        });
+        return;
+      }
+      const node = findByPath(tree, path);
+      if (!node || !node.dir) return;
+      if (!node.loaded) {
+        if (loading.has(path)) return;
+        setBusy(path, true);
+        try {
+          const res = await fetch(`${apiBase}/tree?rev=${revOid}&path=${encodeURIComponent(path)}`);
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const data: { children: TreeNode[] } = await res.json();
+          setTree((prev) => graftChildren(prev, path, data.children));
+          setError(null);
+        } catch {
+          setError("Failed to load folder contents — try again.");
+          return;
+        } finally {
+          setBusy(path, false);
+        }
+      }
+      setExpanded((prev) => new Set(prev).add(path));
+    },
+    [expanded, tree, loading, apiBase, revOid]
+  );
+
+  const [expandingAll, setExpandingAll] = useState(false);
+  const expandAll = useCallback(async () => {
+    let full = tree;
+    if (!fullyLoaded(tree)) {
+      setExpandingAll(true);
+      try {
+        const res = await fetch(`${apiBase}/tree?rev=${revOid}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: { roots: TreeNode[] } = await res.json();
+        full = data.roots;
+        setTree(full);
+        setError(null);
+      } catch {
+        setError("Failed to load the full tree — try again.");
+        return;
+      } finally {
+        setExpandingAll(false);
+      }
+    }
+    setExpanded(new Set(collectDirPaths(full)));
+  }, [tree, apiBase, revOid]);
+
+  return (
+    <>
+      <div className="flex gap-3 px-3 pt-2 text-xs text-neutral-500">
+        <button className="hover:underline disabled:opacity-50" onClick={() => void expandAll()} disabled={expandingAll}>
+          {expandingAll ? "Expanding…" : "Expand all"}
+        </button>
+        <button className="hover:underline" onClick={() => setExpanded(new Set())}>
+          Collapse all
+        </button>
+        {error && <span className="text-red-500">{error}</span>}
+      </div>
+      <div className="mt-1">
+        <div
+          className="sticky top-0 z-[70] flex items-center border-b border-neutral-200 bg-white text-xs uppercase tracking-wide text-neutral-500 dark:border-neutral-800 dark:bg-neutral-950"
+          style={{ height: HEADER_H }}
+        >
+          <span className="min-w-0 flex-1 px-3 font-medium">Name</span>
+          <span className="w-24 shrink-0 px-3 text-right font-medium">Size</span>
+        </div>
+        {rows.map(({ node, depth }) => {
+          const open = expanded.has(node.path);
+          const busy = loading.has(node.path);
+          const selected = !node.dir && normalizeAssetPath(node.path) === selectedPath;
+          return (
+            <div
+              key={node.path}
+              className={`flex items-center border-b border-neutral-100 text-sm hover:bg-neutral-50 dark:border-neutral-900 dark:hover:bg-neutral-900/40 ${
+                node.dir ? "bg-white dark:bg-neutral-950" : selected ? "bg-sky-50 dark:bg-sky-950/40" : ""
+              }`}
+              style={
+                node.dir
+                  ? { height: ROW_H, position: "sticky", top: HEADER_H + depth * ROW_H, zIndex: 60 - depth }
+                  : { height: ROW_H }
+              }
+            >
+              <div className="min-w-0 flex-1 font-mono" style={{ paddingLeft: depth * 16 + 12, paddingRight: 12 }}>
+                {node.dir ? (
+                  <button
+                    onClick={() => void toggle(node.path)}
+                    className="flex w-full min-w-0 items-center gap-1 text-left text-neutral-600 hover:text-neutral-900 dark:text-neutral-300 dark:hover:text-neutral-100"
+                  >
+                    <span className="w-3 shrink-0 text-[10px]">{busy ? "⋯" : open ? "▾" : "▸"}</span>
+                    <span className="truncate">{node.name}/</span>
+                    <span className="shrink-0 text-xs text-neutral-400">({node.fileCount})</span>
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => onOpenFile(normalizeAssetPath(node.path))}
+                    title={`View ${node.name}`}
+                    className={`block w-full min-w-0 truncate pl-4 text-left hover:underline ${
+                      selected ? "font-medium text-sky-800 dark:text-sky-300" : "text-sky-700 dark:text-sky-400"
+                    }`}
+                  >
+                    {node.name}
+                  </button>
+                )}
+              </div>
+              <span className="w-24 shrink-0 px-3 text-right tabular-nums text-neutral-500">
+                {humanSize(node.dir ? node.totalSize : node.size)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/web/src/app/builds/[buildId]/repo/[name]/RepoFileView.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/RepoFileView.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+// One file at the current revision. The version to show comes from the log
+// the parent already fetched: its head entry is the path's state at the rev
+// (add/modify = that blob; delete/empty = absent). Text renders through the
+// shared SourceCode highlighter with the asset viewer's display cap; binary
+// files get a download card (repo blobs are whole files, so no hex snippet).
+
+import { useEffect, useState } from "react";
+import SourceCode from "../../SourceCode";
+import type { LogState } from "./RepoViewer";
+
+// Same cap as the asset viewer: a 20MB DOM node makes the tab crawl.
+const TEXT_DISPLAY_CAP = 1_000_000;
+
+function humanSize(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let v = bytes;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return i === 0 ? `${bytes} B` : `${v.toFixed(1)} ${units[i]}`;
+}
+
+function TextBody({ url, path }: { url: string; path: string }) {
+  const [state, setState] = useState<{ text: string; truncated: boolean } | "loading" | "error">("loading");
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const buf = await res.arrayBuffer();
+        const text = new TextDecoder().decode(buf.slice(0, TEXT_DISPLAY_CAP));
+        if (!cancelled) setState({ text, truncated: buf.byteLength > TEXT_DISPLAY_CAP });
+      } catch {
+        if (!cancelled) setState("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (state === "loading") return <p className="p-6 text-sm text-neutral-400">Loading…</p>;
+  if (state === "error") return <p className="p-6 text-sm text-red-500">Failed to load file.</p>;
+  return (
+    <div className="max-h-[75vh] overflow-auto p-4">
+      <pre className="whitespace-pre-wrap break-words font-mono text-xs text-neutral-800 dark:text-neutral-200">
+        <SourceCode path={path} text={state.text} />
+      </pre>
+      {state.truncated && (
+        <p className="mt-3 text-xs text-neutral-400">Preview truncated — download for the full file.</p>
+      )}
+    </div>
+  );
+}
+
+export default function RepoFileView({
+  apiBase,
+  path,
+  log,
+}: {
+  apiBase: string;
+  path: string;
+  log: LogState;
+}) {
+  const name = path.split("/").pop() || path;
+
+  if (log === "loading") return <p className="p-6 text-sm text-neutral-400">Loading…</p>;
+  if (log === "error") return <p className="p-6 text-sm text-red-500">Failed to load file history.</p>;
+
+  const head = log[0];
+  const entry = head && head.change !== "delete" && head.blob ? head : null;
+  const url = entry ? `${apiBase}/blob/${entry.blob}?name=${encodeURIComponent(name)}` : null;
+
+  return (
+    <div className="rounded border border-neutral-200 dark:border-neutral-800">
+      <div className="flex items-center gap-3 border-b border-neutral-200 bg-neutral-50 px-4 py-2 text-sm dark:border-neutral-800 dark:bg-neutral-900/60">
+        <span className="min-w-0 flex-1 truncate font-mono" title={path}>
+          {path}
+        </span>
+        {entry && entry.size !== null && (
+          <span className="shrink-0 text-xs text-neutral-500">{humanSize(entry.size)}</span>
+        )}
+        {url && (
+          <a href={url} download={name} className="shrink-0 text-xs text-neutral-500 hover:underline">
+            Download
+          </a>
+        )}
+      </div>
+      {entry === null ? (
+        <p className="p-6 text-sm text-neutral-500">
+          {log.length === 0
+            ? "This path does not exist at this revision."
+            : "This file was deleted as of this revision."}
+        </p>
+      ) : entry.binary ? (
+        <div className="flex flex-col items-center gap-3 p-10 text-sm text-neutral-500">
+          <p>Binary file — no inline preview.</p>
+          <a
+            href={url!}
+            download={name}
+            className="rounded bg-neutral-100 px-3 py-1.5 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+          >
+            Download {name}
+          </a>
+        </div>
+      ) : (
+        // Remount per blob so load state never bleeds across revisions.
+        <TextBody key={entry.blob} url={url!} path={path} />
+      )}
+    </div>
+  );
+}

--- a/web/src/app/builds/[buildId]/repo/[name]/RepoViewer.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/RepoViewer.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+// State owner of the repo viewer: a file tree at a revision, a main panel
+// showing either the commit log or one file, and a per-file history panel.
+// ?rev= and ?path= mirror the state — every view is deep-linkable, and
+// back/forward replay navigation. pushState/replaceState are shallow (Next
+// keeps the page mounted), the AssetViewerHost pattern adapted to query
+// params. Data comes from /api/repo/<manifest sha>/... whose responses are
+// immutable per URL, so the browser cache makes revisits free.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { initialExpanded, type TreeNode } from "@/lib/filetree";
+import { shortOid, type RepoCommit, type RepoLogEntryDto } from "@/lib/repo-manifest";
+import RepoCommitList from "./RepoCommitList";
+import RepoFileHistory from "./RepoFileHistory";
+import RepoFileTree from "./RepoFileTree";
+import RepoFileView from "./RepoFileView";
+
+interface View {
+  /** The ?rev= form: "" (HEAD), a ref name, or an oid prefix. */
+  rev: string;
+  path: string | null;
+}
+
+export type LogState = RepoLogEntryDto[] | "loading" | "error";
+
+export default function RepoViewer({
+  apiBase,
+  repoHref,
+  head,
+  headRef,
+  refs,
+  initialRev,
+  initialRevOid,
+  initialPath,
+  initialRoots,
+  initialExpandedPaths,
+  initialTotal,
+  initialCommits,
+  initialLog,
+}: {
+  apiBase: string;
+  repoHref: string;
+  head: string;
+  headRef: string | null;
+  refs: { name: string; oid: string }[];
+  initialRev: string;
+  initialRevOid: string;
+  initialPath: string | null;
+  initialRoots: TreeNode[];
+  initialExpandedPaths: string[];
+  initialTotal: number;
+  initialCommits: RepoCommit[];
+  initialLog: RepoLogEntryDto[] | null;
+}) {
+  const [view, setView] = useState<View>({ rev: initialRev, path: initialPath });
+  // The resolved commit oid of view.rev. Known instantly when navigation
+  // originates from a commit row or the ref selector; a deep-linked prefix
+  // resolves through the tree fetch's `rev` echo.
+  const [revOid, setRevOid] = useState(initialRevOid);
+  const [tree, setTree] = useState({ roots: initialRoots, expanded: initialExpandedPaths });
+  const [treeError, setTreeError] = useState(false);
+  const [log, setLog] = useState<LogState>(initialLog ?? "loading");
+
+  const navigate = useCallback(
+    (next: View, oid?: string) => {
+      const qs = new URLSearchParams();
+      if (next.rev) qs.set("rev", next.rev);
+      if (next.path) qs.set("path", next.path);
+      window.history.pushState(null, "", `${repoHref}${qs.size ? `?${qs}` : ""}`);
+      if (oid) setRevOid(oid);
+      setView(next);
+    },
+    [repoHref]
+  );
+
+  // Back/forward: re-derive the view from wherever the URL landed.
+  useEffect(() => {
+    const onPop = () => {
+      const qs = new URLSearchParams(window.location.search);
+      setView({ rev: qs.get("rev") ?? "", path: qs.get("path") });
+    };
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  // Revision changed: fetch that snapshot's full tree (which also resolves a
+  // prefix/ref rev to its oid). The server-rendered rev is already loaded.
+  const loadedTree = useRef(initialRev);
+  useEffect(() => {
+    if (view.rev === loadedTree.current) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${apiBase}/tree?rev=${encodeURIComponent(view.rev)}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: { rev: string; roots: TreeNode[] } = await res.json();
+        if (cancelled) return;
+        loadedTree.current = view.rev;
+        setRevOid(data.rev);
+        setTree({ roots: data.roots, expanded: [...initialExpanded(data.roots)] });
+        setTreeError(false);
+      } catch {
+        if (!cancelled) setTreeError(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [view.rev, apiBase]);
+
+  // File (or revision under it) changed: fetch its history. The head entry is
+  // the file's version at this rev, so this one fetch also drives the viewer.
+  const loadedLog = useRef(initialPath ? `${initialRevOid}\0${initialPath}` : "");
+  useEffect(() => {
+    const path = view.path;
+    if (!path) return;
+    const key = `${revOid}\0${path}`;
+    if (key === loadedLog.current) return;
+    let cancelled = false;
+    setLog("loading");
+    (async () => {
+      try {
+        const res = await fetch(`${apiBase}/log?rev=${revOid}&path=${encodeURIComponent(path)}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: { entries: RepoLogEntryDto[] } = await res.json();
+        if (cancelled) return;
+        loadedLog.current = key;
+        setLog(data.entries);
+      } catch {
+        if (!cancelled) setLog("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [view.path, revOid, apiBase]);
+
+  const openFile = useCallback((path: string) => navigate({ rev: view.rev, path }), [navigate, view.rev]);
+  const closeFile = useCallback(() => navigate({ rev: view.rev, path: null }), [navigate, view.rev]);
+  const selectCommit = useCallback(
+    (oid: string) => navigate({ rev: shortOid(oid), path: view.path }, oid),
+    [navigate, view.path]
+  );
+  const selectRef = useCallback(
+    (name: string) => {
+      const oid = name === "" ? head : refs.find((r) => r.name === name)?.oid;
+      navigate({ rev: name, path: view.path }, oid);
+    },
+    [navigate, view.path, head, refs]
+  );
+
+  return (
+    <div className="mt-6 flex flex-col gap-6 lg:flex-row lg:items-start">
+      <aside className="w-full shrink-0 lg:w-80 xl:w-96">
+        <div className="flex items-center gap-2">
+          <RevSelector refs={refs} headRef={headRef} value={view.rev} revOid={revOid} onSelect={selectRef} />
+          {view.path !== null && (
+            <button onClick={closeFile} className="text-xs text-neutral-500 hover:underline">
+              commit log
+            </button>
+          )}
+        </div>
+        {treeError && <p className="mt-2 text-xs text-red-500">Failed to load this revision.</p>}
+        <div className="mt-3 max-h-[75vh] overflow-auto rounded border border-neutral-200 dark:border-neutral-800">
+          <RepoFileTree
+            key={revOid}
+            apiBase={apiBase}
+            revOid={revOid}
+            roots={tree.roots}
+            initiallyExpanded={tree.expanded}
+            selectedPath={view.path}
+            onOpenFile={openFile}
+          />
+        </div>
+      </aside>
+
+      <section className="min-w-0 flex-1">
+        {view.path !== null ? (
+          <RepoFileView apiBase={apiBase} path={view.path} log={log} />
+        ) : (
+          <RepoCommitList
+            key={revOid}
+            apiBase={apiBase}
+            revOid={revOid}
+            initial={revOid === initialRevOid ? { total: initialTotal, commits: initialCommits } : null}
+            onSelectCommit={selectCommit}
+          />
+        )}
+      </section>
+
+      {view.path !== null && (
+        <aside className="w-full shrink-0 xl:w-96">
+          <RepoFileHistory path={view.path} log={log} revOid={revOid} onSelectCommit={selectCommit} />
+        </aside>
+      )}
+    </div>
+  );
+}
+
+// A plain select over the manifest's frozen refs; an arbitrary oid rev shows
+// as a synthetic (disabled-change) entry so the control always reflects state.
+function RevSelector({
+  refs,
+  headRef,
+  value,
+  revOid,
+  onSelect,
+}: {
+  refs: { name: string; oid: string }[];
+  headRef: string | null;
+  value: string;
+  revOid: string;
+  onSelect: (name: string) => void;
+}) {
+  const OID = "\0oid";
+  const isNamed = value === "" || refs.some((r) => r.name === value);
+  return (
+    <select
+      value={isNamed ? value : OID}
+      onChange={(e) => {
+        if (e.target.value !== OID) onSelect(e.target.value);
+      }}
+      className="rounded border border-neutral-200 bg-white px-2 py-1 font-mono text-xs dark:border-neutral-800 dark:bg-neutral-950"
+      aria-label="Revision"
+    >
+      <option value="">{headRef ? `${headRef} (HEAD)` : "HEAD"}</option>
+      {refs
+        .filter((r) => r.name !== headRef)
+        .map((r) => (
+          <option key={r.name} value={r.name}>
+            {r.name}
+          </option>
+        ))}
+      {!isNamed && <option value={OID}>{shortOid(revOid)}</option>}
+    </select>
+  );
+}

--- a/web/src/app/builds/[buildId]/repo/[name]/page.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/page.tsx
@@ -1,0 +1,188 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, permanentRedirect } from "next/navigation";
+import { getPool } from "@/lib/db";
+import { buildTree, initialExpanded, pruneToExpanded, treeCounts } from "@/lib/filetree";
+import { getBuildRepo, resolveBuild } from "@/lib/queries";
+import { loadRepo } from "@/lib/repo";
+import {
+  commitsPage,
+  entryAt,
+  fileLog,
+  resolveRev,
+  shortOid,
+  treeNodesAt,
+  type RepoLogEntryDto,
+} from "@/lib/repo-manifest";
+import { canonicalBuildId, normalizeAssetPath, parseBuildParam, safeDecodeSegment } from "@/lib/slug";
+import RepoViewer from "./RepoViewer";
+
+export const runtime = "nodejs";
+// Deliberately not the build page's ISR shape: this page reads searchParams
+// (rev/path deep links), so it renders dynamically — cheap, because the
+// manifest is served from a module LRU and the DB work is two row lookups.
+
+const COMMIT_PAGE = 50;
+
+interface Search {
+  rev?: string | string[];
+  path?: string | string[];
+}
+
+const one = (v: string | string[] | undefined): string => (typeof v === "string" ? v : "");
+
+function repoHrefOf(canonical: string, name: string): string {
+  return `/builds/${canonical}/repo/${encodeURIComponent(name)}`;
+}
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ buildId: string; name: string }>;
+  searchParams: Promise<Search>;
+}): Promise<Metadata> {
+  const { buildId, name: rawName } = await params;
+  const sp = await searchParams;
+  const parsed = parseBuildParam(buildId);
+  if (!parsed) return {};
+  const pool = getPool();
+  const resolved = await resolveBuild(pool, parsed.hex, parsed.slug);
+  if (!resolved) return {};
+  const name = safeDecodeSegment(rawName);
+  const repo = await getBuildRepo(pool, resolved.sha256, name);
+  if (!repo) return {};
+
+  const href = repoHrefOf(canonicalBuildId(resolved.sha256, resolved.name), name);
+  const file = normalizeAssetPath(one(sp.path));
+  const title = `${file ? `${file.split("/").pop()} · ` : ""}${name} · ${resolved.name}`;
+  const description = `Source repository · ${repo.commit_count} commits · ${repo.head_ref ?? shortOid(repo.head_oid)}`;
+  // The build's generated card; the file convention doesn't cascade here.
+  const card = `/builds/${canonicalBuildId(resolved.sha256, resolved.name)}/opengraph-image`;
+  return {
+    title,
+    description,
+    alternates: { canonical: href },
+    openGraph: { title, description, url: href, siteName: "Hidden Palace", images: [card] },
+    twitter: { card: "summary_large_image" },
+  };
+}
+
+// /builds/<id>/repo/<name> — browse an attached source repository: file tree,
+// syntax-highlighted files, and revision history (global and per file), all
+// answered from the attach-time manifest (no git at serve time). ?rev= and
+// ?path= deep-link a revision and file; the client keeps them in sync.
+export default async function RepoPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ buildId: string; name: string }>;
+  searchParams: Promise<Search>;
+}) {
+  const { buildId, name: rawName } = await params;
+  const sp = await searchParams;
+  const parsed = parseBuildParam(buildId);
+  if (!parsed) notFound();
+  const pool = getPool();
+  const resolved = await resolveBuild(pool, parsed.hex, parsed.slug);
+  if (!resolved) notFound();
+  const canonical = canonicalBuildId(resolved.sha256, resolved.name);
+  const name = safeDecodeSegment(rawName);
+  if (buildId !== canonical) {
+    const qs = new URLSearchParams();
+    if (one(sp.rev)) qs.set("rev", one(sp.rev));
+    if (one(sp.path)) qs.set("path", one(sp.path));
+    permanentRedirect(`${repoHrefOf(canonical, name)}${qs.size ? `?${qs}` : ""}`);
+  }
+
+  const repo = await getBuildRepo(pool, resolved.sha256, name);
+  if (!repo) notFound();
+  const buildHref = `/builds/${canonical}`;
+  const repoHref = repoHrefOf(canonical, name);
+
+  const idx = await loadRepo(repo.manifest_sha256);
+  if (!idx) {
+    // Rows travel with the DB; blobs sync separately — say so instead of 500ing.
+    return (
+      <main className="mx-auto max-w-none px-4 py-10 sm:px-8">
+        <Link href={buildHref} className="text-sm text-neutral-500 hover:underline">
+          &larr; {resolved.name}
+        </Link>
+        <h1 className="mt-3 text-2xl font-semibold tracking-tight">{name}</h1>
+        <p className="mt-6 text-sm text-neutral-500">
+          Repository data is not in the blob store on this host yet.
+        </p>
+      </main>
+    );
+  }
+
+  const revParam = one(sp.rev);
+  const revOid = resolveRev(idx, revParam);
+  if (!revOid) notFound(); // garbage ?rev= deep links 404, like unknown paths elsewhere
+  let path = normalizeAssetPath(one(sp.path)) || null;
+  // A deep-linked directory just opens the tree; only files get a view.
+  if (path && entryAt(idx, revOid, path)?.type === "tree") path = null;
+
+  // Initial payload, server-rendered: pruned tree (the build page's
+  // RSC-payload discipline), first log page, and — when a file is deep-linked
+  // — its per-file history (whose head entry is the version to display).
+  const tree = buildTree(treeNodesAt(idx, revOid));
+  const expanded = initialExpanded(tree);
+  const counts = treeCounts(tree);
+  const commits = commitsPage(idx, revOid, 0, COMMIT_PAGE);
+
+  let initialLog: RepoLogEntryDto[] | null = null;
+  if (path) {
+    initialLog = fileLog(idx, revOid, path).map((e) => {
+      const c = idx.commitByOid.get(e.oid)!;
+      const b = e.blob ? idx.blobs.get(e.blob) : undefined;
+      return {
+        ...e,
+        size: b ? b[1] : null,
+        binary: b ? b[2] === 1 : false,
+        author: c.author,
+        committer: c.committer,
+        message: c.message,
+      };
+    });
+  }
+
+  return (
+    <main className="mx-auto max-w-none px-4 py-10 sm:px-8">
+      <Link href={buildHref} className="text-sm text-neutral-500 hover:underline">
+        &larr; {resolved.name}
+      </Link>
+
+      <h1 className="mt-3 text-2xl font-semibold tracking-tight">
+        {name} <span className="text-base font-normal text-neutral-400">source repository</span>
+      </h1>
+      <div className="mt-2 flex flex-wrap gap-2 text-xs">
+        <span className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">
+          {repo.commit_count} commits
+        </span>
+        <span className="rounded bg-neutral-100 px-1.5 py-0.5 font-mono dark:bg-neutral-800">
+          {repo.head_ref ?? shortOid(repo.head_oid)}
+        </span>
+        <span className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">
+          {counts.files} files at head
+        </span>
+      </div>
+
+      <RepoViewer
+        apiBase={`/api/repo/${repo.manifest_sha256}`}
+        repoHref={repoHref}
+        head={idx.manifest.head}
+        headRef={idx.manifest.headRef}
+        refs={idx.manifest.refs}
+        initialRev={revParam}
+        initialRevOid={revOid}
+        initialPath={path}
+        initialRoots={pruneToExpanded(tree, expanded)}
+        initialExpandedPaths={[...expanded]}
+        initialTotal={commits.total}
+        initialCommits={commits.commits}
+        initialLog={initialLog}
+      />
+    </main>
+  );
+}

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -557,6 +557,38 @@ export async function getBuildAssets(pool: Pool, sha256: string): Promise<BuildA
   return r.rows as BuildAsset[];
 }
 
+/** One attached source repository of a build (see db build_repo; the bytes —
+ *  manifest + git blobs — live in the asset store). */
+export interface BuildRepoRow {
+  build_sha256: string;
+  name: string;
+  manifest_sha256: string;
+  head_oid: string;
+  head_ref: string | null;
+  commit_count: number;
+  created_at: string;
+}
+
+/// A build's attached repos, for the build page's source-repository cards.
+export async function getBuildRepos(pool: Pool, sha256: string): Promise<BuildRepoRow[]> {
+  const r = await pool.query(
+    `SELECT build_sha256, name, manifest_sha256, head_oid, head_ref, commit_count, created_at::text
+     FROM build_repo WHERE build_sha256=$1 ORDER BY name`,
+    [sha256]
+  );
+  return r.rows as BuildRepoRow[];
+}
+
+/// One attached repo by its URL name.
+export async function getBuildRepo(pool: Pool, sha256: string, name: string): Promise<BuildRepoRow | null> {
+  const r = await pool.query(
+    `SELECT build_sha256, name, manifest_sha256, head_oid, head_ref, commit_count, created_at::text
+     FROM build_repo WHERE build_sha256=$1 AND name=$2`,
+    [sha256, name]
+  );
+  return (r.rows[0] as BuildRepoRow) ?? null;
+}
+
 /// Resolve a /builds/ URL param (hex prefix + optional slug) to a stored build.
 /// A full 64-hex sha resolves exactly; a shorter prefix must match a unique
 /// build — if two builds ever share a prefix, the slug disambiguates.

--- a/web/src/lib/repo-manifest.ts
+++ b/web/src/lib/repo-manifest.ts
@@ -1,0 +1,212 @@
+// Attached source repository manifests (VSS->git conversions). A repo is
+// converted offline by scripts/attach-repo.ts into (a) one asset-store blob
+// per unique git blob and (b) one manifest blob described by these types —
+// commits, deduplicated tree objects, and a git-blob-oid -> store-sha256 map.
+// The web app answers every tree/log/file query from the manifest alone, so
+// serving needs no git implementation at all. Pure data + walks — no DB, no
+// React, no I/O — shared by the attach script, the server loader (repo.ts),
+// the API routes, and the client components.
+
+import type { Node } from "./types";
+
+export const REPO_MANIFEST_VERSION = 1;
+
+/** Repo names become URL segments; the attach script enforces this. */
+export const REPO_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+/** Git identity. time = epoch seconds; tz = minutes from UTC in the
+ *  JS getTimezoneOffset convention (UTC+2 -> -120), as isomorphic-git emits. */
+export interface RepoIdent {
+  name: string;
+  email: string;
+  time: number;
+  tz: number;
+}
+
+export interface RepoCommit {
+  oid: string; // full 40-hex
+  tree: string; // root tree oid
+  parents: string[]; // parents[0] = first parent
+  author: RepoIdent;
+  committer: RepoIdent;
+  message: string; // full message (capped at attach time)
+}
+
+/** [entry name, type, oid]. Gitlinks (submodules) are dropped at attach time;
+ *  symlinks ride along as blobs (their content is the target path). */
+export type RepoTreeEntry = [name: string, type: "blob" | "tree", oid: string];
+
+/** [store sha256, byte size, 1 if binary else 0]. */
+export type RepoBlobInfo = [sha256: string, size: number, binary: 0 | 1];
+
+export interface RepoManifest {
+  version: number;
+  name: string;
+  /** Commit HEAD pointed at when the repo was attached. */
+  head: string;
+  /** Symbolic HEAD name ("master"), null when detached. */
+  headRef: string | null;
+  /** Branches then tags, name-sorted; only refs whose commits were walked. */
+  refs: { name: string; oid: string }[];
+  /** Newest-first: committer.time desc, tie-broken by oid. */
+  commits: RepoCommit[];
+  trees: Record<string, RepoTreeEntry[]>;
+  blobs: Record<string, RepoBlobInfo>;
+}
+
+/** A manifest with lookup maps built once — what everything downstream takes. */
+export interface RepoIndex {
+  manifest: RepoManifest;
+  commitByOid: Map<string, RepoCommit>;
+  trees: Map<string, RepoTreeEntry[]>;
+  blobs: Map<string, RepoBlobInfo>;
+  refByName: Map<string, string>;
+  /** Sorted commit oids, for unique-prefix resolution. */
+  oids: string[];
+}
+
+export function indexManifest(m: RepoManifest): RepoIndex {
+  return {
+    manifest: m,
+    commitByOid: new Map(m.commits.map((c) => [c.oid, c])),
+    trees: new Map(Object.entries(m.trees)),
+    blobs: new Map(Object.entries(m.blobs)),
+    refByName: new Map(m.refs.map((r) => [r.name, r.oid])),
+    oids: m.commits.map((c) => c.oid).sort(),
+  };
+}
+
+export function shortOid(oid: string): string {
+  return oid.slice(0, 10);
+}
+
+/** Resolve "HEAD", a ref name, or a 4-40 char unique oid prefix to a commit
+ *  oid known to the manifest; null when it doesn't resolve. Refs win over
+ *  hex-looking names (a branch called "cafe" beats the oid prefix). */
+export function resolveRev(idx: RepoIndex, rev: string): string | null {
+  if (rev === "" || rev === "HEAD") return idx.manifest.head;
+  const ref = idx.refByName.get(rev);
+  if (ref !== undefined) return idx.commitByOid.has(ref) ? ref : null;
+  if (!/^[0-9a-f]{4,40}$/.test(rev)) return null;
+  if (rev.length === 40) return idx.commitByOid.has(rev) ? rev : null;
+  const hits = idx.oids.filter((o) => o.startsWith(rev));
+  return hits.length === 1 ? hits[0] : null; // ambiguous or unknown
+}
+
+/** The tree entry at `path` in a commit's snapshot, or null when absent.
+ *  Paths are "/"-separated, no leading slash. */
+export function entryAt(
+  idx: RepoIndex,
+  commitOid: string,
+  path: string
+): { type: "blob" | "tree"; oid: string } | null {
+  const commit = idx.commitByOid.get(commitOid);
+  if (!commit) return null;
+  let cur: { type: "blob" | "tree"; oid: string } = { type: "tree", oid: commit.tree };
+  for (const seg of path.split("/").filter(Boolean)) {
+    if (cur.type !== "tree") return null;
+    const entries = idx.trees.get(cur.oid);
+    const hit = entries?.find(([name]) => name === seg);
+    if (!hit) return null;
+    cur = { type: hit[1], oid: hit[2] };
+  }
+  return cur;
+}
+
+/** A commit's whole snapshot as the record-contents Node shape, so the
+ *  existing filetree helpers (buildTree, stubChildren, ...) apply unchanged.
+ *  Git trees carry no dates, so nodes have none. */
+export function treeNodesAt(idx: RepoIndex, commitOid: string): Node[] {
+  const commit = idx.commitByOid.get(commitOid);
+  if (!commit) return [];
+  const walk = (treeOid: string): Node[] =>
+    (idx.trees.get(treeOid) ?? []).map(([name, type, oid]) =>
+      type === "tree"
+        ? { type: "dir", name, children: walk(oid) }
+        : { type: "file", name, size: idx.blobs.get(oid)?.[1] }
+    );
+  return walk(commit.tree);
+}
+
+/** Every commit reachable from `fromOid` (all parents — merges included). */
+export function ancestorSet(idx: RepoIndex, fromOid: string): Set<string> {
+  const seen = new Set<string>();
+  const stack = [fromOid];
+  while (stack.length) {
+    const oid = stack.pop()!;
+    if (seen.has(oid)) continue;
+    const c = idx.commitByOid.get(oid);
+    if (!c) continue;
+    seen.add(oid);
+    stack.push(...c.parents);
+  }
+  return seen;
+}
+
+/** One page of the log reachable from `fromOid`, newest-first (the manifest
+ *  order filtered to the reachable subgraph — an old rev or side ref shows
+ *  exactly its own history). */
+export function commitsPage(
+  idx: RepoIndex,
+  fromOid: string,
+  offset: number,
+  limit: number
+): { total: number; commits: RepoCommit[] } {
+  const reachable = ancestorSet(idx, fromOid);
+  const all = idx.manifest.commits.filter((c) => reachable.has(c.oid));
+  return { total: all.length, commits: all.slice(offset, offset + limit) };
+}
+
+export interface FileLogEntry {
+  oid: string; // the commit
+  change: "add" | "modify" | "delete";
+  /** The path's blob oid as of this commit (null for a delete). */
+  blob: string | null;
+}
+
+/** The revisions of `path`, walking first parents from `fromOid` — the
+ *  `git log --first-parent -- path` story: a change merged in from a side
+ *  branch is attributed to the merge commit. Emits a commit whenever the
+ *  path's entry oid differs from the first parent's; a root commit yields
+ *  "add" for every present path. */
+export function fileLog(idx: RepoIndex, fromOid: string, path: string, limit = 1000): FileLogEntry[] {
+  const out: FileLogEntry[] = [];
+  let cur = idx.commitByOid.get(fromOid);
+  while (cur && out.length < limit) {
+    const parent = cur.parents.length ? idx.commitByOid.get(cur.parents[0]) : undefined;
+    const curEntry = entryAt(idx, cur.oid, path);
+    const prevEntry = parent ? entryAt(idx, parent.oid, path) : null;
+    if ((curEntry?.oid ?? null) !== (prevEntry?.oid ?? null)) {
+      out.push({
+        oid: cur.oid,
+        change: curEntry === null ? "delete" : prevEntry === null ? "add" : "modify",
+        blob: curEntry?.oid ?? null,
+      });
+    }
+    cur = parent;
+  }
+  return out;
+}
+
+/** What /api/repo/.../log serves per entry: a FileLogEntry joined with its
+ *  commit's identity/message and its blob's size/binary flag. The first entry
+ *  is the path's version at the queried rev (or its deletion). */
+export interface RepoLogEntryDto extends FileLogEntry {
+  size: number | null;
+  binary: boolean;
+  author: RepoIdent;
+  committer: RepoIdent;
+  message: string;
+}
+
+/** "YYYY-MM-DD HH:MM" in the identity's own timezone (git log's convention). */
+export function formatCommitDate(ident: RepoIdent): string {
+  const local = new Date((ident.time - ident.tz * 60) * 1000);
+  return local.toISOString().slice(0, 16).replace("T", " ");
+}
+
+/** First line of a commit message. */
+export function commitSubject(message: string): string {
+  const nl = message.indexOf("\n");
+  return (nl === -1 ? message : message.slice(0, nl)).trim();
+}

--- a/web/src/lib/repo.ts
+++ b/web/src/lib/repo.ts
@@ -1,0 +1,55 @@
+// Server-side loader for attached repo manifests (see repo-manifest.ts for
+// the format and scripts/attach-repo.ts for the producer). Manifests are
+// multi-MB and content-addressed, so this is a module-level LRU of the parsed
+// + indexed form, not unstable_cache (which would re-serialize the whole
+// manifest into Next's incremental cache per revalidation window).
+
+import { readFile } from "node:fs/promises";
+import { unstable_cache } from "next/cache";
+import { assetBlobPath } from "./assets";
+import { getPool } from "./db";
+import { indexManifest, REPO_MANIFEST_VERSION, type RepoIndex, type RepoManifest } from "./repo-manifest";
+
+// An indexed manifest runs a few x its JSON size in memory; four bounds the
+// worst case to low hundreds of MB while covering every repo a page or its
+// API burst realistically touches.
+const MAX_CACHED = 4;
+const lru = new Map<string, RepoIndex>(); // insertion order = recency
+
+/** The parsed + indexed manifest blob, or null when it's missing from the
+ *  store on this host or unreadable. Content-addressed, so entries never
+ *  go stale. */
+export async function loadRepo(manifestSha256: string): Promise<RepoIndex | null> {
+  const hit = lru.get(manifestSha256);
+  if (hit) {
+    lru.delete(manifestSha256); // re-insert to refresh recency
+    lru.set(manifestSha256, hit);
+    return hit;
+  }
+  let manifest: RepoManifest;
+  try {
+    manifest = JSON.parse(await readFile(assetBlobPath(manifestSha256), "utf8")) as RepoManifest;
+  } catch {
+    return null; // row landed before the blob synced, or the store is elsewhere
+  }
+  if (manifest.version !== REPO_MANIFEST_VERSION) return null;
+  const idx = indexManifest(manifest);
+  lru.set(manifestSha256, idx);
+  if (lru.size > MAX_CACHED) lru.delete(lru.keys().next().value!);
+  return idx;
+}
+
+// The gate that keeps the /api/repo routes from serving arbitrary store
+// blobs: only a manifest some build_repo row points at resolves, and blob
+// oids are then validated against that manifest's blobs map. Tiny row check,
+// cached like the asset route's meta lookup.
+export const repoAttached = unstable_cache(
+  async (manifestSha256: string): Promise<boolean> => {
+    const r = await getPool().query("SELECT 1 FROM build_repo WHERE manifest_sha256=$1 LIMIT 1", [
+      manifestSha256,
+    ]);
+    return r.rows.length > 0;
+  },
+  ["repo-attached"],
+  { revalidate: 3600 }
+);

--- a/web/tests/repo.test.ts
+++ b/web/tests/repo.test.ts
@@ -1,0 +1,195 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  indexManifest,
+  resolveRev,
+  entryAt,
+  treeNodesAt,
+  ancestorSet,
+  commitsPage,
+  fileLog,
+  formatCommitDate,
+  commitSubject,
+  type RepoManifest,
+  type RepoIdent,
+} from "../src/lib/repo-manifest";
+import { buildTree, findByPath } from "../src/lib/filetree";
+
+// Synthetic five-commit history exercising every transition the viewer cares
+// about: a root commit, a modify, a delete + binary add, a side branch, and a
+// merge that brings the side branch's file in.
+//
+//   c1 (root) ── c2 ── c3 ──── c5 (merge, HEAD, "main")
+//         └───── c4 ──────────┘
+//
+// oids are synthetic 40-hex strings from repeated seeds.
+const O = (seed: string) => seed.repeat(40 / seed.length);
+const C1 = O("1");
+const C2 = O("2");
+const C3 = O("3");
+const C4 = O("4");
+const C5 = "4444" + "5".repeat(36); // shares a 4-char prefix with C4 (ambiguity test)
+
+const ident = (time: number): RepoIdent => ({ name: "dev", email: "dev@example.com", time, tz: 0 });
+const commit = (oid: string, tree: string, parents: string[], time: number, message: string) => ({
+  oid,
+  tree,
+  parents,
+  author: ident(time),
+  committer: ident(time),
+  message,
+});
+
+const MANIFEST: RepoManifest = {
+  version: 1,
+  name: "fixture",
+  head: C5,
+  headRef: "main",
+  refs: [
+    { name: "main", oid: C5 },
+    { name: "v1", oid: C2 },
+  ],
+  // newest-first by committer time: c5(400), c3(300), c4(250), c2(200), c1(100)
+  commits: [
+    commit(C5, O("ee"), [C3, C4], 400, "merge side branch\n\ndetails"),
+    commit(C3, O("dd"), [C2], 300, "drop README, add bin.dat"),
+    commit(C4, O("ff"), [C1], 250, "side: add side.txt"),
+    commit(C2, O("cc"), [C1], 200, "rework main.c, add util.h"),
+    commit(C1, O("aa"), [], 100, "initial import"),
+  ],
+  trees: {
+    [O("aa")]: [
+      ["README", "blob", O("b1")],
+      ["src", "tree", O("ab")],
+    ],
+    [O("ab")]: [["main.c", "blob", O("b2")]],
+    [O("cc")]: [
+      ["README", "blob", O("b1")],
+      ["src", "tree", O("cd")],
+    ],
+    [O("cd")]: [
+      ["main.c", "blob", O("b3")],
+      ["util.h", "blob", O("b4")],
+    ],
+    [O("dd")]: [
+      ["bin.dat", "blob", O("b5")],
+      ["src", "tree", O("cd")],
+    ],
+    [O("ff")]: [
+      ["README", "blob", O("b1")],
+      ["side.txt", "blob", O("b6")],
+      ["src", "tree", O("ab")],
+    ],
+    [O("ee")]: [
+      ["bin.dat", "blob", O("b5")],
+      ["side.txt", "blob", O("b6")],
+      ["src", "tree", O("cd")],
+    ],
+  },
+  blobs: {
+    [O("b1")]: ["f".repeat(64), 12, 0],
+    [O("b2")]: ["e".repeat(64), 100, 0],
+    [O("b3")]: ["d".repeat(64), 140, 0],
+    [O("b4")]: ["c".repeat(64), 40, 0],
+    [O("b5")]: ["b".repeat(64), 2048, 1],
+    [O("b6")]: ["a".repeat(64), 9, 0],
+  },
+};
+
+const idx = indexManifest(MANIFEST);
+
+test("resolveRev handles HEAD, refs, prefixes, and ambiguity", () => {
+  assert.equal(resolveRev(idx, "HEAD"), C5);
+  assert.equal(resolveRev(idx, ""), C5);
+  assert.equal(resolveRev(idx, "main"), C5);
+  assert.equal(resolveRev(idx, "v1"), C2);
+  assert.equal(resolveRev(idx, C3), C3); // full oid
+  assert.equal(resolveRev(idx, "3333"), C3); // unique prefix
+  assert.equal(resolveRev(idx, "4444"), null); // ambiguous: C4 vs C5
+  assert.equal(resolveRev(idx, "44445"), C5); // disambiguated
+  assert.equal(resolveRev(idx, "beef"), null); // unknown
+  assert.equal(resolveRev(idx, "no-such-ref"), null);
+  assert.equal(resolveRev(idx, "123"), null); // too short for a prefix
+});
+
+test("entryAt descends trees and misses cleanly", () => {
+  assert.deepEqual(entryAt(idx, C1, "src/main.c"), { type: "blob", oid: O("b2") });
+  assert.deepEqual(entryAt(idx, C2, "src/main.c"), { type: "blob", oid: O("b3") });
+  assert.deepEqual(entryAt(idx, C2, "src"), { type: "tree", oid: O("cd") });
+  assert.equal(entryAt(idx, C3, "README"), null); // deleted by c3
+  assert.equal(entryAt(idx, C1, "src/main.c/impossible"), null); // descend through a blob
+  assert.equal(entryAt(idx, C1, "nope"), null);
+});
+
+test("treeNodesAt feeds buildTree/findByPath unchanged", () => {
+  // buildTree paths carry a leading "/" (the record-contents convention);
+  // manifest paths don't — routes bridge with normalizeAssetPath.
+  const roots = buildTree(treeNodesAt(idx, C2));
+  const main = findByPath(roots, "/src/main.c");
+  assert.ok(main && !main.dir);
+  assert.equal(main.size, 140); // size joined from the blobs map
+  const src = findByPath(roots, "/src");
+  assert.ok(src && src.dir);
+  assert.equal(src.fileCount, 2);
+  assert.equal(findByPath(roots, "/bin.dat"), null); // not there yet at c2
+});
+
+test("ancestorSet includes merge parents", () => {
+  assert.deepEqual(ancestorSet(idx, C5), new Set([C1, C2, C3, C4, C5]));
+  assert.deepEqual(ancestorSet(idx, C4), new Set([C1, C4]));
+});
+
+test("commitsPage filters to the reachable subgraph, newest-first", () => {
+  const head = commitsPage(idx, C5, 0, 10);
+  assert.equal(head.total, 5);
+  assert.deepEqual(
+    head.commits.map((c) => c.oid),
+    [C5, C3, C4, C2, C1]
+  );
+  const side = commitsPage(idx, C4, 0, 10);
+  assert.equal(side.total, 2);
+  assert.deepEqual(
+    side.commits.map((c) => c.oid),
+    [C4, C1]
+  );
+  const page = commitsPage(idx, C5, 1, 2);
+  assert.deepEqual(
+    page.commits.map((c) => c.oid),
+    [C3, C4]
+  );
+  assert.equal(page.total, 5);
+});
+
+test("fileLog: modify chain down to the root add", () => {
+  assert.deepEqual(fileLog(idx, C5, "src/main.c"), [
+    { oid: C2, change: "modify", blob: O("b3") },
+    { oid: C1, change: "add", blob: O("b2") },
+  ]);
+});
+
+test("fileLog: deletions carry a null blob", () => {
+  assert.deepEqual(fileLog(idx, C5, "README"), [
+    { oid: C3, change: "delete", blob: null },
+    { oid: C1, change: "add", blob: O("b1") },
+  ]);
+});
+
+test("fileLog: side-branch changes attribute to the merge (first-parent)", () => {
+  assert.deepEqual(fileLog(idx, C5, "side.txt"), [{ oid: C5, change: "add", blob: O("b6") }]);
+});
+
+test("fileLog from an old rev sees only its past", () => {
+  assert.deepEqual(fileLog(idx, C2, "src/util.h"), [{ oid: C2, change: "add", blob: O("b4") }]);
+  assert.deepEqual(fileLog(idx, C1, "src/util.h"), []);
+});
+
+test("formatCommitDate renders in the identity's timezone", () => {
+  assert.equal(formatCommitDate({ name: "", email: "", time: 0, tz: 0 }), "1970-01-01 00:00");
+  // tz uses the JS getTimezoneOffset convention: UTC+2 -> -120
+  assert.equal(formatCommitDate({ name: "", email: "", time: 0, tz: -120 }), "1970-01-01 02:00");
+});
+
+test("commitSubject takes the first line", () => {
+  assert.equal(commitSubject("merge side branch\n\ndetails"), "merge side branch");
+  assert.equal(commitSubject("one-liner"), "one-liner");
+});


### PR DESCRIPTION
Adds a browsable source repository viewer for builds with VSS history extracted to git. A repo is built offline by scripts/attach-repo.ts, which reads the .git directory with isomorphic-git, explodes every unique git blob into the asset store, and writes a versioned manifest blob plus a build_repo row. The web app serves the file tree at any revision, the commit log, per file history, and highlighted sources entirely from the manifest, so the server needs no git binary. Views deep link through rev and path query params, a build can carry multiple repos, and the GUIs are out of scope for now.