### PR TITLE
Add commit activity calendar

### DIFF
--- a/web/src/app/builds/[buildId]/repo/[name]/RepoCommitHeatmap.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/RepoCommitHeatmap.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+// GitHub-style commit activity calendar: one grid per year, week columns,
+// one 9px cell per day. Year rows come from the full log so the layout never
+// jumps, while the counts follow the message filter — filter for "sound" and
+// the calendar shows when the sound work happened. Colors are a single blue
+// ramp stepped light-to-dark (flipped to recede toward the dark surface in
+// dark mode); the 2px cell gap is the only separator.
+
+import { useMemo } from "react";
+import {
+  commitYears,
+  dayCounts,
+  DAY_NAMES,
+  levelFor,
+  levelThresholds,
+  yearGrid,
+} from "@/lib/commit-heatmap";
+import type { RepoCommit } from "@/lib/repo-manifest";
+
+const CELL = 9;
+const GAP = 2;
+const PITCH = CELL + GAP;
+const LABEL_H = 14; // month-label band above each grid
+const GRID_H = LABEL_H + 7 * PITCH - GAP;
+
+// Level 0 (no commits) is neutral; 1-4 are one blue ramp, both schemes
+// validated against their surfaces (see lib/commit-heatmap.ts for bucketing).
+const LEVEL_CLASS = [
+  "fill-neutral-200 dark:fill-neutral-800",
+  "fill-[#86b6ef] dark:fill-[#184f95]",
+  "fill-[#3987e5] dark:fill-[#2a78d6]",
+  "fill-[#1c5cab] dark:fill-[#6da7ec]",
+  "fill-[#0d366b] dark:fill-[#b7d3f6]",
+];
+
+export default function RepoCommitHeatmap({
+  commits,
+  shown,
+}: {
+  /** The full log — fixes which year rows exist. */
+  commits: RepoCommit[];
+  /** The filtered log — drives the counts. */
+  shown: RepoCommit[];
+}) {
+  const grids = useMemo(() => commitYears(commits).map(yearGrid), [commits]);
+  const { counts, thresholds } = useMemo(() => {
+    const counts = dayCounts(shown);
+    return { counts, thresholds: levelThresholds(counts) };
+  }, [shown]);
+
+  return (
+    <div className="mt-3 overflow-x-auto">
+      <div className="flex min-w-max flex-col gap-2">
+        {grids.map((g) => (
+          <div key={g.year} className="flex gap-2">
+            <span className="w-8 shrink-0 pt-[15px] text-right font-mono text-[10px] leading-none text-neutral-500">
+              {g.year}
+            </span>
+            <svg width={g.weeks * PITCH - GAP} height={GRID_H} role="img" aria-label={`Commits by day, ${g.year}`}>
+              {g.months.map((m) => (
+                <text key={m.label} x={m.week * PITCH} y={9} className="fill-neutral-400 font-mono text-[9px]">
+                  {m.label}
+                </text>
+              ))}
+              {g.days.map((d) => {
+                const n = counts.get(d.key) ?? 0;
+                return (
+                  // The transparent 2px stroke doubles as hit-area padding;
+                  // on hover it colors in as the lift ring.
+                  <rect
+                    key={d.key}
+                    x={d.week * PITCH}
+                    y={LABEL_H + d.dow * PITCH}
+                    width={CELL}
+                    height={CELL}
+                    rx={2}
+                    strokeWidth={2}
+                    className={`${LEVEL_CLASS[levelFor(n, thresholds)]} stroke-transparent hover:stroke-neutral-400 dark:hover:stroke-neutral-500`}
+                  >
+                    <title>
+                      {`${n === 0 ? "No commits" : n === 1 ? "1 commit" : `${n} commits`} on ${DAY_NAMES[d.dow]} ${d.key}`}
+                    </title>
+                  </rect>
+                );
+              })}
+            </svg>
+          </div>
+        ))}
+        <div className="flex items-center justify-end gap-1 text-[10px] text-neutral-400">
+          <span>Less</span>
+          <svg width={LEVEL_CLASS.length * PITCH - GAP} height={CELL} aria-hidden="true">
+            {LEVEL_CLASS.map((cls, i) => (
+              <rect key={cls} x={i * PITCH} width={CELL} height={CELL} rx={2} className={cls} />
+            ))}
+          </svg>
+          <span>More</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/builds/[buildId]/repo/[name]/RepoCommitList.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/RepoCommitList.tsx
@@ -8,6 +8,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { commitSubject, formatCommitDate, type RepoCommit } from "@/lib/repo-manifest";
+import RepoCommitHeatmap from "./RepoCommitHeatmap";
 
 // One request for everything; far above any real repo (Fallout is 11,432).
 const ALL = 50_000;
@@ -83,6 +84,11 @@ export default function RepoCommitList({
         />
       </div>
       {error && <p className="mt-3 text-xs text-red-500">Failed to load the full history.</p>}
+      {/* Only once the whole log is here — a partial slice would draw a
+          misleadingly sparse calendar. */}
+      {total !== null && commits.length >= total && commits.length > 0 && (
+        <RepoCommitHeatmap commits={commits} shown={shown} />
+      )}
       {query.trim() && shown.length === 0 && !error && (
         <p className="mt-3 text-xs text-neutral-500">No commit messages match.</p>
       )}

--- a/web/src/lib/commit-heatmap.ts
+++ b/web/src/lib/commit-heatmap.ts
@@ -1,0 +1,81 @@
+// Day-grid geometry and count bucketing for the commit activity calendar
+// (RepoCommitHeatmap): one column per week, one cell per day, one grid per
+// year. Pure data — no React — so the shapes are testable and the component
+// stays a straight render.
+
+import { identLocalDate, type RepoCommit } from "./repo-manifest";
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+export const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export interface HeatmapDay {
+  key: string; // "YYYY-MM-DD"
+  week: number; // column, Sunday-started weeks from Jan 1
+  dow: number; // row: 0 = Sunday .. 6 = Saturday
+}
+
+export interface HeatmapYear {
+  year: number;
+  weeks: number; // column count (52-54)
+  months: { week: number; label: string }[]; // first-of-month positions
+  days: HeatmapDay[];
+}
+
+const DAY_MS = 86_400_000;
+
+/** A calendar day in the author's own timezone, matching the dates the
+ *  commit list displays. */
+export function commitDayKey(c: RepoCommit): string {
+  return identLocalDate(c.author).toISOString().slice(0, 10);
+}
+
+/** Every day of `year` laid out GitHub-style: weeks are columns, days rows. */
+export function yearGrid(year: number): HeatmapYear {
+  const startDow = new Date(Date.UTC(year, 0, 1)).getUTCDay();
+  const end = Date.UTC(year, 11, 31);
+  const days: HeatmapDay[] = [];
+  const months: { week: number; label: string }[] = [];
+  let i = 0;
+  // UTC day arithmetic — every step is exactly 24h, no DST anywhere.
+  for (let t = Date.UTC(year, 0, 1); t <= end; t += DAY_MS, i++) {
+    const d = new Date(t);
+    const week = Math.floor((startDow + i) / 7);
+    if (d.getUTCDate() === 1) months.push({ week, label: MONTHS[d.getUTCMonth()] });
+    days.push({ key: d.toISOString().slice(0, 10), week, dow: d.getUTCDay() });
+  }
+  return { year, weeks: Math.floor((startDow + i - 1) / 7) + 1, months, days };
+}
+
+/** The years that have any commits, ascending — gap years (bad clocks put
+ *  strays decades out) get no row at all. */
+export function commitYears(commits: RepoCommit[]): number[] {
+  const years = new Set(commits.map((c) => identLocalDate(c.author).getUTCFullYear()));
+  return [...years].sort((a, b) => a - b);
+}
+
+export function dayCounts(commits: RepoCommit[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const c of commits) {
+    const k = commitDayKey(c);
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** Quartile breakpoints over the active (nonzero) days, so each color level
+ *  covers about a quarter of them and one huge import day doesn't flatten
+ *  the rest of the history to the palest step. */
+export function levelThresholds(counts: Map<string, number>): number[] {
+  const active = [...counts.values()].sort((a, b) => a - b);
+  if (!active.length) return [];
+  const q = (p: number) => active[Math.floor(p * (active.length - 1))];
+  return [q(0.25), q(0.5), q(0.75)];
+}
+
+/** 0 = no commits; 1-4 = which quartile bucket the day's count lands in. */
+export function levelFor(count: number, thresholds: number[]): number {
+  if (count === 0) return 0;
+  let level = 1;
+  for (const t of thresholds) if (count > t) level++;
+  return level;
+}

--- a/web/src/lib/repo-manifest.ts
+++ b/web/src/lib/repo-manifest.ts
@@ -262,10 +262,15 @@ export interface RepoLogEntryDto extends FileLogEntry {
   message: string;
 }
 
-/** "YYYY-MM-DD HH:MM" in the identity's own timezone (git log's convention). */
+/** The identity's wall-clock moment shifted to UTC — read it with the getUTC*
+ *  accessors to see the author's own local calendar (git log's convention). */
+export function identLocalDate(ident: RepoIdent): Date {
+  return new Date((ident.time - ident.tz * 60) * 1000);
+}
+
+/** "YYYY-MM-DD HH:MM" in the identity's own timezone. */
 export function formatCommitDate(ident: RepoIdent): string {
-  const local = new Date((ident.time - ident.tz * 60) * 1000);
-  return local.toISOString().slice(0, 16).replace("T", " ");
+  return identLocalDate(ident).toISOString().slice(0, 16).replace("T", " ");
 }
 
 /** First line of a commit message. */

--- a/web/tests/commit-heatmap.test.ts
+++ b/web/tests/commit-heatmap.test.ts
@@ -1,0 +1,65 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  commitDayKey,
+  commitYears,
+  dayCounts,
+  levelFor,
+  levelThresholds,
+  yearGrid,
+} from "../src/lib/commit-heatmap";
+import type { RepoCommit, RepoIdent } from "../src/lib/repo-manifest";
+
+function commitAt(time: number, tz = 0): RepoCommit {
+  const ident: RepoIdent = { name: "a", email: "a@b", time, tz };
+  return { oid: "0".repeat(40), tree: "1".repeat(40), parents: [], author: ident, committer: ident, message: "m" };
+}
+
+test("yearGrid lays out a leap year starting Monday", () => {
+  const g = yearGrid(1996); // Jan 1 1996 was a Monday
+  assert.equal(g.days.length, 366);
+  assert.equal(g.weeks, 53);
+  assert.deepEqual(g.days[0], { key: "1996-01-01", week: 0, dow: 1 });
+  assert.deepEqual(g.days.at(-1), { key: "1996-12-31", week: 52, dow: 2 });
+  assert.equal(g.months.length, 12);
+  assert.deepEqual(g.months[0], { week: 0, label: "Jan" });
+});
+
+test("yearGrid handles the 54-column case", () => {
+  const g = yearGrid(2000); // leap year starting Saturday
+  assert.equal(g.weeks, 54);
+  assert.deepEqual(g.days[0], { key: "2000-01-01", week: 0, dow: 6 });
+  assert.deepEqual(g.days.at(-1), { key: "2000-12-31", week: 53, dow: 0 });
+});
+
+test("commitDayKey uses the author's own timezone", () => {
+  // 1996-01-01 00:30 UTC, author at UTC-1 (JS convention: tz = +60)
+  const utc = Date.UTC(1996, 0, 1, 0, 30) / 1000;
+  assert.equal(commitDayKey(commitAt(utc, 60)), "1995-12-31");
+  assert.equal(commitDayKey(commitAt(utc, -120)), "1996-01-01"); // UTC+2
+});
+
+test("commitYears is ascending and skips gap years", () => {
+  const commits = [commitAt(Date.UTC(1998, 5, 1) / 1000), commitAt(Date.UTC(1994, 5, 1) / 1000)];
+  assert.deepEqual(commitYears(commits), [1994, 1998]);
+});
+
+test("levels bucket active days into quartiles", () => {
+  const commits = [1, 1, 2, 2, 3, 3, 5, 5].flatMap((n, day) =>
+    Array.from({ length: n }, () => commitAt(Date.UTC(1996, 0, day + 1) / 1000))
+  );
+  const counts = dayCounts(commits);
+  const t = levelThresholds(counts);
+  assert.deepEqual(t, [1, 2, 3]);
+  assert.equal(levelFor(0, t), 0);
+  assert.equal(levelFor(1, t), 1);
+  assert.equal(levelFor(2, t), 2);
+  assert.equal(levelFor(3, t), 3);
+  assert.equal(levelFor(5, t), 4);
+});
+
+test("levelThresholds of nothing is empty and level 1 still applies", () => {
+  const t = levelThresholds(new Map());
+  assert.deepEqual(t, []);
+  assert.equal(levelFor(0, t), 0);
+});


### PR DESCRIPTION
Adds a GitHub style commit calendar above the repo viewer history, one row of week columns per year with a tiny cell per day. Day counts bucket into quartiles of the active days so a single huge import day does not flatten the rest, colored on one blue ramp stepped for light and dark. The calendar follows the message filter so filtering shows when the matching work happened, and the grid math is pure lib code with tests.