### PR TITLE
Add blame view to repo viewer

### DIFF
--- a/web/src/app/api/repo/[sha256]/blame/route.ts
+++ b/web/src/app/api/repo/[sha256]/blame/route.ts
@@ -1,0 +1,72 @@
+import { readFile } from "node:fs/promises";
+import type { NextRequest } from "next/server";
+import { assetBlobPath } from "@/lib/assets";
+import { blameLines, type BlameCommitDto } from "@/lib/blame";
+import { entryAt, fileLog, commitSubject, resolveRev } from "@/lib/repo-manifest";
+import { loadRepo, repoAttached } from "@/lib/repo";
+import { normalizeAssetPath } from "@/lib/slug";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// GET /api/repo/<manifest sha256>/blame?rev=&path=<file> — per-line blame of
+// one path at a revision, replayed from its first-parent history (the same
+// chain the log route serves). Immutable per URL (content-addressed manifest);
+// the client keys the fetch on the head log entry's oid, so revisions that
+// share a file version share the cached response.
+const CACHE = "public, max-age=31536000, immutable";
+
+// The file view caps display at 1MB, so a bigger head has no lines to blame
+// against; the total bound keeps one request from diffing an unbounded chain.
+const HEAD_CAP = 1_000_000;
+const TOTAL_CAP = 32_000_000;
+
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+  if (!(await repoAttached(sha256))) return Response.json({ error: "not found" }, { status: 404 });
+  const idx = await loadRepo(sha256);
+  if (!idx) return Response.json({ error: "repository data not in store" }, { status: 404 });
+
+  const params = request.nextUrl.searchParams;
+  const rev = resolveRev(idx, params.get("rev") ?? "");
+  if (!rev) return Response.json({ error: "unknown revision" }, { status: 404 });
+  const path = normalizeAssetPath(params.get("path") ?? "");
+  if (!path) return Response.json({ error: "path required" }, { status: 400 });
+  if (entryAt(idx, rev, path)?.type === "tree") {
+    return Response.json({ error: "path is a directory" }, { status: 400 });
+  }
+
+  const entries = fileLog(idx, rev, path);
+  const head = entries[0];
+  if (!head || !head.blob) {
+    return Response.json({ error: "no file at this revision" }, { status: 404 });
+  }
+  const headInfo = idx.blobs.get(head.blob)!;
+  if (headInfo[2] === 1) return Response.json({ error: "binary file" }, { status: 400 });
+  if (headInfo[1] > HEAD_CAP) return Response.json({ error: "file too large" }, { status: 400 });
+  let total = 0;
+  for (const e of entries) if (e.blob) total += idx.blobs.get(e.blob)![1];
+  if (total > TOTAL_CAP) return Response.json({ error: "history too large" }, { status: 400 });
+
+  // Oldest first: blameLines replays the chain forward. A delete along the
+  // way is an empty version, so a re-add blames every line on the re-adding
+  // commit — the first-parent story, same as the history panel tells.
+  const chain = [...entries].reverse();
+  let versions: string[];
+  try {
+    versions = await Promise.all(
+      chain.map((e) => (e.blob ? readFile(assetBlobPath(idx.blobs.get(e.blob)![0]), "utf8") : ""))
+    );
+  } catch {
+    // Row + manifest landed but some blob hasn't synced to this host yet.
+    return Response.json({ error: "blob bytes not in store" }, { status: 404 });
+  }
+
+  const commits: BlameCommitDto[] = chain.map((e) => {
+    const c = idx.commitByOid.get(e.oid)!;
+    return { oid: e.oid, author: c.author, subject: commitSubject(c.message) };
+  });
+  const lines = blameLines(versions);
+  return Response.json({ rev, path, commits, lines }, { headers: { "Cache-Control": CACHE } });
+}

--- a/web/src/app/builds/[buildId]/repo/[name]/RepoFileView.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/RepoFileView.tsx
@@ -5,8 +5,14 @@
 // (add/modify = that blob; delete/empty = absent). Text renders through the
 // shared SourceCode highlighter with the asset viewer's display cap; binary
 // files get a download card (repo blobs are whole files, so no hex snippet).
+// A header toggle swaps text files into blame mode: a light gutter of
+// date + author per run of lines from the same commit (the blame route's
+// hunks), clicking through to that change's diff.
 
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
+import { blameHunks, type BlameDto } from "@/lib/blame";
+import { splitLines } from "@/lib/linediff";
+import { formatCommitDate, type RepoLogEntryDto } from "@/lib/repo-manifest";
 import SourceCode from "../../SourceCode";
 import type { LogState } from "./RepoViewer";
 
@@ -58,14 +64,130 @@ function TextBody({ url, path }: { url: string; path: string }) {
   );
 }
 
+function BlameBody({
+  apiBase,
+  path,
+  entry,
+  onSelectDiff,
+}: {
+  apiBase: string;
+  path: string;
+  entry: RepoLogEntryDto;
+  onSelectDiff: (oid: string) => void;
+}) {
+  // Text and blame load independently: blame can 400 (file too large, chain
+  // too long) while the text is fine, and then the plain view still shows.
+  const [text, setText] = useState<{ text: string; truncated: boolean } | "loading" | "error">("loading");
+  const [blame, setBlame] = useState<BlameDto | "loading" | "error">("loading");
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${apiBase}/blob/${entry.blob}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const buf = await res.arrayBuffer();
+        // Blame rejects files over the cap, so truncation only ever shows in
+        // the fallback below — a blamed file is always whole.
+        const decoded = new TextDecoder().decode(buf.slice(0, TEXT_DISPLAY_CAP));
+        if (!cancelled) setText({ text: decoded, truncated: buf.byteLength > TEXT_DISPLAY_CAP });
+      } catch {
+        if (!cancelled) setText("error");
+      }
+    })();
+    (async () => {
+      try {
+        // Keyed on the head log entry's commit, not the viewer's rev: every
+        // rev sharing this file version shares the immutable cached response.
+        const res = await fetch(`${apiBase}/blame?rev=${entry.oid}&path=${encodeURIComponent(path)}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: BlameDto = await res.json();
+        if (!cancelled) setBlame(data);
+      } catch {
+        if (!cancelled) setBlame("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [apiBase, path, entry.oid, entry.blob]);
+
+  if (text === "loading" || blame === "loading")
+    return <p className="p-6 text-sm text-neutral-400">Loading…</p>;
+  if (text === "error") return <p className="p-6 text-sm text-red-500">Failed to load file.</p>;
+
+  const lines = splitLines(text.text);
+  if (blame === "error" || blame.lines.length !== lines.length) {
+    return (
+      <div className="p-4">
+        <p className="mb-3 text-xs text-neutral-400">Blame is unavailable for this file.</p>
+        <pre className="whitespace-pre-wrap break-words font-mono text-xs text-neutral-800 dark:text-neutral-200">
+          <SourceCode path={path} text={text.text} />
+        </pre>
+        {text.truncated && (
+          <p className="mt-3 text-xs text-neutral-400">Preview truncated — download for the full file.</p>
+        )}
+      </div>
+    );
+  }
+  if (lines.length === 0) return <p className="p-6 text-sm text-neutral-500">Empty file.</p>;
+
+  // The gutter cell spans its hunk's rows; number/code cells auto-flow into
+  // the columns beside it. Borders mark hunk starts across the whole row.
+  const sep = "border-t border-neutral-100 dark:border-neutral-900";
+  return (
+    <div className="p-3 text-xs leading-5">
+      <div className="grid grid-cols-[minmax(0,11rem)_2.75rem_minmax(0,1fr)]">
+        {blameHunks(blame.lines).map((h) => {
+          const c = blame.commits[h.commit];
+          return (
+            <Fragment key={h.start}>
+              <button
+                style={{ gridRow: `span ${h.len}` }}
+                onClick={() => onSelectDiff(c.oid)}
+                title={`${c.subject || "(no message)"} · ${c.author.name} · ${formatCommitDate(c.author)}`}
+                className={`flex min-w-0 items-start gap-2 pr-3 text-left hover:bg-neutral-50 dark:hover:bg-neutral-900/40 ${sep}`}
+              >
+                <span className="shrink-0 font-mono text-neutral-500">
+                  {formatCommitDate(c.author).slice(0, 10)}
+                </span>
+                <span className="min-w-0 truncate text-neutral-400">{c.author.name}</span>
+              </button>
+              {lines.slice(h.start, h.start + h.len).map((s, i) => (
+                <Fragment key={h.start + i}>
+                  <span
+                    className={`select-none px-2 text-right font-mono text-neutral-300 dark:text-neutral-600 ${i === 0 ? sep : ""}`}
+                  >
+                    {h.start + i + 1}
+                  </span>
+                  <span
+                    className={`whitespace-pre-wrap break-words font-mono text-neutral-800 dark:text-neutral-200 ${i === 0 ? sep : ""}`}
+                  >
+                    {s}
+                  </span>
+                </Fragment>
+              ))}
+            </Fragment>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export default function RepoFileView({
   apiBase,
   path,
   log,
+  blame,
+  onToggleBlame,
+  onSelectDiff,
 }: {
   apiBase: string;
   path: string;
   log: LogState;
+  blame: boolean;
+  onToggleBlame: () => void;
+  onSelectDiff: (oid: string) => void;
 }) {
   const name = path.split("/").pop() || path;
 
@@ -85,6 +207,16 @@ export default function RepoFileView({
         </span>
         {entry && entry.size !== null && (
           <span className="shrink-0 text-xs text-neutral-500">{humanSize(entry.size)}</span>
+        )}
+        {entry && !entry.binary && (
+          <button
+            onClick={onToggleBlame}
+            className={`shrink-0 text-xs ${
+              blame ? "font-medium text-sky-600 dark:text-sky-400" : "text-neutral-500 hover:underline"
+            }`}
+          >
+            Blame
+          </button>
         )}
         {url && (
           <a href={url} download={name} className="shrink-0 text-xs text-neutral-500 hover:underline">
@@ -109,8 +241,10 @@ export default function RepoFileView({
             Download {name}
           </a>
         </div>
+      ) : blame ? (
+        // Remount per version so load state never bleeds across revisions.
+        <BlameBody key={entry.oid} apiBase={apiBase} path={path} entry={entry} onSelectDiff={onSelectDiff} />
       ) : (
-        // Remount per blob so load state never bleeds across revisions.
         <TextBody key={entry.blob} url={url!} path={path} />
       )}
     </div>

--- a/web/src/app/builds/[buildId]/repo/[name]/RepoViewer.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/RepoViewer.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 // State owner of the repo viewer: a file tree at a revision, a main panel
-// showing the commit log, one file, or one change's side-by-side diff, and a
-// per-file history panel. ?rev=, ?path= and ?diff= mirror the state — every
-// view is deep-linkable, and back/forward replay navigation. pushState /
+// showing the commit log, one file (plain or blame), or one change's
+// side-by-side diff, and a per-file history panel. ?rev=, ?path=, ?diff= and
+// ?blame= mirror the state — every view is deep-linkable, and back/forward
+// replay navigation. pushState /
 // replaceState are shallow (Next keeps the page mounted), the AssetViewerHost
 // pattern adapted to query params. Data comes from /api/repo/<manifest sha>/
 // whose responses are immutable per URL, so the browser cache makes revisits
@@ -29,6 +30,8 @@ interface View {
   path: string | null;
   /** Short oid of the file-history change open as a diff. */
   diff: string | null;
+  /** File view shows the blame gutter. Only meaningful with a path. */
+  blame: boolean;
 }
 
 export type LogState = RepoLogEntryDto[] | "loading" | "error";
@@ -43,6 +46,7 @@ export default function RepoViewer({
   initialRevOid,
   initialPath,
   initialDiff,
+  initialBlame,
   initialRoots,
   initialExpandedPaths,
   initialTotal,
@@ -58,13 +62,19 @@ export default function RepoViewer({
   initialRevOid: string;
   initialPath: string | null;
   initialDiff: string | null;
+  initialBlame: boolean;
   initialRoots: TreeNode[];
   initialExpandedPaths: string[];
   initialTotal: number;
   initialCommits: RepoCommit[];
   initialLog: RepoLogEntryDto[] | null;
 }) {
-  const [view, setView] = useState<View>({ rev: initialRev, path: initialPath, diff: initialDiff });
+  const [view, setView] = useState<View>({
+    rev: initialRev,
+    path: initialPath,
+    diff: initialDiff,
+    blame: initialBlame,
+  });
   // The resolved commit oid of view.rev. Known instantly when navigation
   // originates from a commit row or the ref selector; a deep-linked prefix
   // resolves through the tree fetch's `rev` echo.
@@ -89,6 +99,7 @@ export default function RepoViewer({
       if (next.rev) qs.set("rev", next.rev);
       if (next.path) qs.set("path", next.path);
       if (next.diff) qs.set("diff", next.diff);
+      if (next.path && next.blame) qs.set("blame", "1");
       window.history.pushState(null, "", `${repoHref}${qs.size ? `?${qs}` : ""}`);
       if (oid) setRevOid(oid);
       setView(next);
@@ -100,7 +111,12 @@ export default function RepoViewer({
   useEffect(() => {
     const onPop = () => {
       const qs = new URLSearchParams(window.location.search);
-      setView({ rev: qs.get("rev") ?? "", path: qs.get("path"), diff: qs.get("diff") });
+      setView({
+        rev: qs.get("rev") ?? "",
+        path: qs.get("path"),
+        diff: qs.get("diff"),
+        blame: qs.get("blame") === "1",
+      });
     };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
@@ -159,37 +175,44 @@ export default function RepoViewer({
   }, [view.path, revOid, apiBase]);
 
   const openFile = useCallback(
-    (path: string) => navigate({ rev: view.rev, path, diff: null }),
+    (path: string) => navigate({ rev: view.rev, path, diff: null, blame: false }),
     [navigate, view.rev]
   );
   const closeFile = useCallback(
-    () => navigate({ rev: view.rev, path: null, diff: null }),
+    () => navigate({ rev: view.rev, path: null, diff: null, blame: false }),
     [navigate, view.rev]
   );
   // A commit row opens that commit's change set; "browse tree" inside the
   // overview is what rewinds the whole viewer to the snapshot.
   const selectCommit = useCallback(
-    (oid: string) => navigate({ rev: view.rev, path: null, diff: shortOid(oid) }),
+    (oid: string) => navigate({ rev: view.rev, path: null, diff: shortOid(oid), blame: false }),
     [navigate, view.rev]
   );
   const browseCommit = useCallback(
-    (oid: string) => navigate({ rev: shortOid(oid), path: null, diff: null }, oid),
+    (oid: string) => navigate({ rev: shortOid(oid), path: null, diff: null, blame: false }, oid),
     [navigate]
   );
+  // Rev and diff changes keep blame mode: rewinding a blamed file re-blames
+  // it there, and closing a diff opened from the gutter lands back on blame.
   const selectRef = useCallback(
     (name: string) => {
       const oid = name === "" ? head : refs.find((r) => r.name === name)?.oid;
-      navigate({ rev: name, path: view.path, diff: null }, oid);
+      navigate({ rev: name, path: view.path, diff: null, blame: view.blame }, oid);
     },
-    [navigate, view.path, head, refs]
+    [navigate, view.path, view.blame, head, refs]
   );
   const selectDiff = useCallback(
-    (oid: string) => navigate({ rev: view.rev, path: view.path, diff: shortOid(oid) }),
-    [navigate, view.rev, view.path]
+    (oid: string) =>
+      navigate({ rev: view.rev, path: view.path, diff: shortOid(oid), blame: view.blame }),
+    [navigate, view.rev, view.path, view.blame]
   );
   const closeDiff = useCallback(
-    () => navigate({ rev: view.rev, path: view.path, diff: null }),
-    [navigate, view.rev, view.path]
+    () => navigate({ rev: view.rev, path: view.path, diff: null, blame: view.blame }),
+    [navigate, view.rev, view.path, view.blame]
+  );
+  const toggleBlame = useCallback(
+    () => navigate({ rev: view.rev, path: view.path, diff: null, blame: !view.blame }),
+    [navigate, view.rev, view.path, view.blame]
   );
 
   return (
@@ -226,7 +249,14 @@ export default function RepoViewer({
           view.diff !== null ? (
             <RepoDiffView apiBase={apiBase} path={view.path} log={log} diffOid={view.diff} onClose={closeDiff} />
           ) : (
-            <RepoFileView apiBase={apiBase} path={view.path} log={log} />
+            <RepoFileView
+              apiBase={apiBase}
+              path={view.path}
+              log={log}
+              blame={view.blame}
+              onToggleBlame={toggleBlame}
+              onSelectDiff={selectDiff}
+            />
           )
         ) : view.diff !== null ? (
           <RepoCommitDiff apiBase={apiBase} diffOid={view.diff} onBrowse={browseCommit} onClose={closeDiff} />

--- a/web/src/app/builds/[buildId]/repo/[name]/page.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/page.tsx
@@ -29,6 +29,7 @@ interface Search {
   rev?: string | string[];
   path?: string | string[];
   diff?: string | string[];
+  blame?: string | string[];
 }
 
 const one = (v: string | string[] | undefined): string => (typeof v === "string" ? v : "");
@@ -115,6 +116,7 @@ export default async function RepoPage({
     if (one(sp.rev)) qs.set("rev", one(sp.rev));
     if (one(sp.path)) qs.set("path", one(sp.path));
     if (one(sp.diff)) qs.set("diff", one(sp.diff));
+    if (one(sp.blame)) qs.set("blame", one(sp.blame));
     permanentRedirect(`${repoHrefOf(canonical, name)}${qs.size ? `?${qs}` : ""}`);
   }
 
@@ -214,6 +216,7 @@ export default async function RepoPage({
         initialRevOid={revOid}
         initialPath={path}
         initialDiff={diff}
+        initialBlame={path !== null && one(sp.blame) === "1"}
         initialRoots={pruneToExpanded(tree, expanded)}
         initialExpandedPaths={[...expanded]}
         initialTotal={commits.total}

--- a/web/src/lib/blame.ts
+++ b/web/src/lib/blame.ts
@@ -1,0 +1,62 @@
+// Line blame for the repo viewer, computed by replaying a file's history
+// (the fileLog chain, oldest first): each version diffs against the previous,
+// unchanged lines carry their blame forward, added lines take the version
+// that introduced them. Pure — no React, no I/O — shared by the blame route
+// and its tests; the hunk grouping is what the client renders.
+
+import { diffLines } from "diff";
+import { splitLines } from "./linediff";
+import type { RepoIdent } from "./repo-manifest";
+
+/** `versions` oldest→newest; result[i] = index into `versions` of the version
+ *  that introduced line i of the newest version. */
+export function blameLines(versions: string[]): number[] {
+  let blame: number[] = [];
+  let prev = "";
+  versions.forEach((text, v) => {
+    const next: number[] = [];
+    let li = 0; // line index into prev / blame
+    for (const part of diffLines(prev, text)) {
+      const n = splitLines(part.value).length;
+      if (part.removed) li += n;
+      else if (part.added) for (let i = 0; i < n; i++) next.push(v);
+      else for (let i = 0; i < n; i++) next.push(blame[li++]);
+    }
+    blame = next;
+    prev = text;
+  });
+  return blame;
+}
+
+/** A run of consecutive lines blamed on the same commit — one gutter cell. */
+export interface BlameHunk {
+  commit: number; // index into BlameDto.commits
+  start: number; // 0-based first line
+  len: number;
+}
+
+export function blameHunks(lines: number[]): BlameHunk[] {
+  const out: BlameHunk[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const last = out[out.length - 1];
+    if (last && last.commit === lines[i]) last.len++;
+    else out.push({ commit: lines[i], start: i, len: 1 });
+  }
+  return out;
+}
+
+/** What /api/repo/.../blame serves: per final line an index into `commits`
+ *  (the file's history oldest→newest, subjects only — the log route has the
+ *  full story). */
+export interface BlameCommitDto {
+  oid: string;
+  author: RepoIdent;
+  subject: string;
+}
+
+export interface BlameDto {
+  rev: string;
+  path: string;
+  commits: BlameCommitDto[];
+  lines: number[];
+}

--- a/web/src/lib/linediff.ts
+++ b/web/src/lib/linediff.ts
@@ -16,7 +16,7 @@ export interface DiffRow {
 }
 
 /** value ("a\nb\n") -> ["a","b"]; a trailing newline is not an extra line. */
-function splitLines(value: string): string[] {
+export function splitLines(value: string): string[] {
   const lines = value.split("\n");
   if (lines[lines.length - 1] === "") lines.pop();
   return lines;

--- a/web/tests/blame.test.ts
+++ b/web/tests/blame.test.ts
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { blameHunks, blameLines } from "../src/lib/blame";
+
+test("a single version blames every line on itself", () => {
+  assert.deepEqual(blameLines(["a\nb\nc\n"]), [0, 0, 0]);
+});
+
+test("unchanged lines keep their original blame", () => {
+  assert.deepEqual(blameLines(["a\nb\nc\n", "a\nB\nc\n"]), [0, 1, 0]);
+});
+
+test("an insertion blames only the new lines", () => {
+  assert.deepEqual(blameLines(["a\nc\n", "a\nb\nc\n"]), [0, 1, 0]);
+});
+
+test("a deletion shifts blame without reassigning it", () => {
+  assert.deepEqual(blameLines(["a\nb\nc\n", "a\nc\n"]), [0, 0]);
+});
+
+test("blame survives multiple revisions", () => {
+  // v0 writes a..c, v1 rewrites b, v2 appends d.
+  assert.deepEqual(blameLines(["a\nb\nc\n", "a\nB\nc\n", "a\nB\nc\nd\n"]), [0, 1, 0, 2]);
+});
+
+test("delete then re-add attributes every line to the re-add", () => {
+  assert.deepEqual(blameLines(["x\ny\n", "", "x\ny\n"]), [2, 2]);
+});
+
+test("empty inputs", () => {
+  assert.deepEqual(blameLines([]), []);
+  assert.deepEqual(blameLines([""]), []);
+});
+
+test("a final line without trailing newline still counts", () => {
+  assert.deepEqual(blameLines(["a\nb"]), [0, 0]);
+});
+
+test("blameHunks groups consecutive lines from the same commit", () => {
+  assert.deepEqual(blameHunks([0, 0, 1, 1, 1, 0]), [
+    { commit: 0, start: 0, len: 2 },
+    { commit: 1, start: 2, len: 3 },
+    { commit: 0, start: 5, len: 1 },
+  ]);
+  assert.deepEqual(blameHunks([]), []);
+});


### PR DESCRIPTION
Adds a GitHub-style blame mode to the repo file view: a light gutter with date and author, one rowspanned cell per run of lines from the same commit, hunk click opens that change's diff. Blame is computed server-side by replaying the file's first-parent history from the manifest and diffing consecutive blob versions, served immutable from a new blame route keyed on the head log entry's commit so revisions sharing a file version share the cached response. Binary and over-cap files fall back to the plain view, and the mode deep-links as ?blame=1. Verified against real git blame on CYCLE.C (361/369 lines identical, the rest are ambiguous lone brace alignments).