### PR TITLE
Upload asset blobs in parallel

### DIFF
--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> windows::core::Result<()> {
 mod app {
     use std::collections::{HashMap, VecDeque};
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     use curator_core::adapter::AdapterCommand;
@@ -2150,15 +2150,27 @@ mod app {
         }
         let todo: Vec<&String> = missing.iter().filter(|sha| local.contains_key(*sha)).collect();
         let unavailable = missing.len() - todo.len();
-        let (mut uploaded, mut failed) = (0usize, 0usize);
-        for (i, sha) in todo.iter().enumerate() {
-            post_service_result(hwnd_i, format!("Uploading asset {} of {}…", i + 1, todo.len()));
-            if upload_asset_chunked(&assets_url, sha, &local[*sha]) {
-                uploaded += 1;
-            } else {
-                failed += 1;
+        // Upload a few blobs at once — each is its own resumable PUT (chunks of
+        // one blob never interleave) and http_request builds a fresh WinHTTP
+        // session per call. Workers pull the next index off a shared counter.
+        let total = todo.len();
+        let next = AtomicUsize::new(0);
+        let completed = AtomicUsize::new(0);
+        let ok_count = AtomicUsize::new(0);
+        std::thread::scope(|s| {
+            for _ in 0..PARALLEL_UPLOADS.min(total) {
+                s.spawn(|| loop {
+                    let Some(sha) = todo.get(next.fetch_add(1, Ordering::Relaxed)) else { break };
+                    if upload_asset_chunked(&assets_url, sha, &local[*sha]) {
+                        ok_count.fetch_add(1, Ordering::Relaxed);
+                    }
+                    let n = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                    post_service_result(hwnd_i, format!("Uploading assets {n}/{total}…"));
+                });
             }
-        }
+        });
+        let uploaded = ok_count.into_inner();
+        let failed = total - uploaded;
         let mut note = format!(" Uploaded {uploaded} asset blob{}", if uploaded == 1 { "" } else { "s" });
         if failed > 0 {
             note.push_str(&format!(", {failed} failed"));
@@ -2186,6 +2198,9 @@ mod app {
 
     /// Upload chunk size — small enough to clear typical proxy body-size limits.
     const UPLOAD_CHUNK: usize = 4 * 1024 * 1024;
+
+    /// How many asset blobs to upload at once.
+    const PARALLEL_UPLOADS: usize = 4;
 
     /// PUT one asset blob in resumable chunks: each request appends at `offset`,
     /// a 409 answers with the server's staged offset to resume from, and the

--- a/macos/Sources/CuratorApp/AppModel.swift
+++ b/macos/Sources/CuratorApp/AppModel.swift
@@ -299,9 +299,14 @@ final class AppModel: ObservableObject {
         }
     }
 
-    /// Upload the build's asset blobs that the server lacks and we hold locally.
-    /// Returns a status suffix for the submit message ("" when moot). Upload
-    /// failures degrade to a note — the record submission already succeeded.
+    /// How many asset blobs to upload at once.
+    private static let parallelUploads = 4
+
+    /// Upload the build's asset blobs that the server lacks and we hold locally,
+    /// a few at a time — each is its own resumable PUT, so chunks of one blob
+    /// never interleave. Returns a status suffix for the submit message (""
+    /// when moot). Upload failures degrade to a note — the record submission
+    /// already succeeded.
     private func uploadMissingAssets(for summary: AnalysisSummary) async -> String {
         guard let assets = summary.assets, !assets.isEmpty else { return "" }
         var local: [String: String] = [:] // asset sha256 → blob path
@@ -309,20 +314,51 @@ final class AppModel: ObservableObject {
         do {
             let missing = try await service.missingAssets(buildSha: summary.sha256)
             if missing.isEmpty { return " Assets already on server." }
-            let todo = missing.filter { local[$0] != nil }
+            let todo: [(sha: String, blob: String)] = missing.compactMap { sha in
+                local[sha].map { (sha, $0) }
+            }
+            let buildSha = summary.sha256
+            let service = self.service
             var done = 0
-            for sha in todo {
-                serviceMessage = "Uploading assets \(done + 1)/\(todo.count)…"
-                guard let blob = local[sha] else { continue }
-                try await service.uploadAsset(
-                    buildSha: summary.sha256,
-                    assetSha: sha,
-                    fileURL: URL(fileURLWithPath: blob)
-                )
-                done += 1
+            var failed = 0
+            var firstError: String?
+            await withTaskGroup(of: Result<Void, Error>.self) { group in
+                var next = 0
+                func startNext() {
+                    guard next < todo.count else { return }
+                    let (sha, blob) = todo[next]
+                    next += 1
+                    group.addTask {
+                        do {
+                            try await service.uploadAsset(
+                                buildSha: buildSha,
+                                assetSha: sha,
+                                fileURL: URL(fileURLWithPath: blob)
+                            )
+                            return .success(())
+                        } catch {
+                            return .failure(error)
+                        }
+                    }
+                }
+                for _ in 0..<Self.parallelUploads { startNext() }
+                while let result = await group.next() {
+                    switch result {
+                    case .success:
+                        done += 1
+                    case .failure(let error):
+                        failed += 1
+                        if firstError == nil {
+                            firstError = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+                        }
+                    }
+                    serviceMessage = "Uploading assets \(done + failed)/\(todo.count)…"
+                    startNext()
+                }
             }
             let unavailable = missing.count - todo.count
             var note = " Uploaded \(done) asset blob\(done == 1 ? "" : "s")"
+            if failed > 0 { note += ", \(failed) failed: \(firstError ?? "unknown error")" }
             if unavailable > 0 { note += " (\(unavailable) not in the local store)" }
             return note + "."
         } catch {


### PR DESCRIPTION
Both desktop apps uploaded a submitted build's asset blobs one at a time. They now run up to four uploads at once, on the Mac via a sliding window task group and on Windows via scoped worker threads pulling indexes off a shared atomic counter. Parallelism is across blobs only, each blob remains a single resumable chunked PUT so chunks of one blob never interleave, and the server already stages every asset in its own per-sha file. The status line now counts completions, and a failed upload on the Mac no longer aborts the remaining ones, it is tallied and reported in the final note like on Windows.