### PR TITLE
Retry rate limited asset uploads

### DIFF
--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -2202,6 +2202,9 @@ mod app {
     /// How many asset blobs to upload at once.
     const PARALLEL_UPLOADS: usize = 4;
 
+    /// Give up after this many consecutive rate-limit waits on one chunk.
+    const MAX_THROTTLE_RETRIES: u32 = 30;
+
     /// PUT one asset blob in resumable chunks: each request appends at `offset`,
     /// a 409 answers with the server's staged offset to resume from, and the
     /// final chunk returns `stored` (or `exists`).
@@ -2209,6 +2212,7 @@ mod app {
         let Ok(bytes) = std::fs::read(path) else { return false };
         let mut offset: usize = 0;
         let mut last_staged: Option<usize> = None;
+        let mut throttled = 0u32;
         while offset < bytes.len() {
             let end = (offset + UPLOAD_CHUNK).min(bytes.len());
             let url = format!("{assets_url}/{sha}?offset={offset}");
@@ -2225,8 +2229,23 @@ mod app {
                                 .map(|o| o as usize)
                                 .unwrap_or(end);
                             last_staged = None;
+                            throttled = 0;
                         }
                     }
+                }
+                Ok((429, body)) => {
+                    // Rate limited — wait out the window (the server's retryAfter
+                    // when present) and retry the same offset.
+                    throttled += 1;
+                    if throttled > MAX_THROTTLE_RETRIES {
+                        return false;
+                    }
+                    let secs = serde_json::from_str::<serde_json::Value>(&body)
+                        .ok()
+                        .and_then(|v| v.get("retryAfter").and_then(|r| r.as_f64()))
+                        .unwrap_or(5.0)
+                        .clamp(1.0, 120.0);
+                    std::thread::sleep(std::time::Duration::from_secs_f64(secs));
                 }
                 Ok((409, body)) => {
                     // Resume where the server actually is; the same answer twice

--- a/macos/Sources/CuratorApp/CuratorService.swift
+++ b/macos/Sources/CuratorApp/CuratorService.swift
@@ -157,11 +157,16 @@ struct CuratorService {
     private static let uploadChunkBytes = 4 * 1024 * 1024
 
     /// One chunk response: `partial` carries the next offset; `stored`/`exists`
-    /// end the upload. A 409 body carries only `offset` (the staged size).
+    /// end the upload. A 409 body carries only `offset` (the staged size); a
+    /// 429 body carries `retryAfter` (seconds until the rate window resets).
     private struct ChunkResult: Decodable {
         let status: String?
         let offset: UInt64?
+        let retryAfter: Double?
     }
+
+    /// Give up after this many consecutive rate-limit waits on one chunk.
+    private static let maxThrottleRetries = 30
 
     /// PUT one asset blob under its build in resumable chunks: each request
     /// appends at `offset`, a 409 answers with the server's staged offset to
@@ -171,6 +176,7 @@ struct CuratorService {
         defer { try? fh.close() }
         var offset: UInt64 = 0
         var lastStaged: UInt64?
+        var throttled = 0
         while true {
             try fh.seek(toOffset: offset)
             let chunk = try fh.read(upToCount: Self.uploadChunkBytes) ?? Data()
@@ -188,6 +194,7 @@ struct CuratorService {
                 if r.status == "stored" || r.status == "exists" { return }
                 offset = r.offset ?? offset + UInt64(chunk.count)
                 lastStaged = nil
+                throttled = 0
             } catch let ServiceError.http(code, body) where code == 409 {
                 // Resume where the server actually is; the same answer twice
                 // means we're not making progress — give up.
@@ -195,6 +202,14 @@ struct CuratorService {
                 if lastStaged == staged { throw ServiceError.http(code, body) }
                 lastStaged = staged
                 offset = staged
+            } catch let ServiceError.http(code, body) where code == 429 {
+                // Rate limited — wait out the window (the server's retryAfter
+                // when present) and retry the same offset.
+                throttled += 1
+                if throttled > Self.maxThrottleRetries { throw ServiceError.http(code, body) }
+                let hint = (try? JSONDecoder().decode(ChunkResult.self, from: Data(body.utf8)))?.retryAfter
+                let seconds = min(max(hint ?? 5, 1), 120)
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
             }
         }
     }

--- a/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
@@ -6,7 +6,7 @@ import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
 import { assetBlobPath, assetStagingPath } from "@/lib/assets";
 import { referencedAssets, MAX_BUILD_ASSET_BYTES } from "@/lib/submission-assets";
-import { rateLimit, clientKey } from "@/lib/ratelimit";
+import { rateLimitCheck, clientKey } from "@/lib/ratelimit";
 import { isSha256 } from "@/lib/validate";
 
 export const runtime = "nodejs";
@@ -31,10 +31,16 @@ export async function PUT(
   request: NextRequest,
   ctx: { params: Promise<{ sha256: string; assetSha: string }> }
 ) {
-  // Generous: a bulk desktop upload is many sequential chunk PUTs (a 4096-asset
-  // build is legitimate), and the clients treat 429 as a hard failure.
-  if (!rateLimit(`assets-put:${clientKey(request)}`, 1200, 60_000)) {
-    return Response.json({ error: "rate limit exceeded" }, { status: 429 });
+  // Generous: a bulk desktop upload is many chunk PUTs, a few in parallel (a
+  // 4096-asset build is legitimate). On limit, answer 429 with `retryAfter`
+  // (seconds) so the clients can wait out the window and resume.
+  const rl = rateLimitCheck(`assets-put:${clientKey(request)}`, 6000, 60_000);
+  if (!rl.ok) {
+    const retryAfter = Math.max(1, Math.ceil(rl.retryAfterMs / 1000));
+    return Response.json(
+      { error: "rate limit exceeded", retryAfter },
+      { status: 429, headers: { "Retry-After": String(retryAfter) } }
+    );
   }
   const { sha256, assetSha } = await ctx.params;
   if (!isSha256(sha256) || !isSha256(assetSha)) {

--- a/web/src/lib/ratelimit.ts
+++ b/web/src/lib/ratelimit.ts
@@ -19,16 +19,25 @@ function prune(now: number): void {
 
 /** Returns true if the call for `key` is within `limit` per `windowMs`. */
 export function rateLimit(key: string, limit: number, windowMs: number): boolean {
+  return rateLimitCheck(key, limit, windowMs).ok;
+}
+
+/** `rateLimit` plus, when limited, milliseconds until the window resets. */
+export function rateLimitCheck(
+  key: string,
+  limit: number,
+  windowMs: number
+): { ok: boolean; retryAfterMs: number } {
   const now = Date.now();
   prune(now);
   const w = windows.get(key);
   if (!w || now >= w.resetAt) {
     windows.set(key, { count: 1, resetAt: now + windowMs });
-    return true;
+    return { ok: true, retryAfterMs: 0 };
   }
-  if (w.count >= limit) return false;
+  if (w.count >= limit) return { ok: false, retryAfterMs: w.resetAt - now };
   w.count++;
-  return true;
+  return { ok: true, retryAfterMs: 0 };
 }
 
 // Reverse-proxy hops in front of the app (env TRUSTED_PROXY_HOPS, default 1).


### PR DESCRIPTION
Follow-up to #69. The first parallel field test tripped the asset route's rate limit of 1200 chunk PUTs per minute and both desktop clients treated 429 as a hard failure, which failed most of a 4300 asset upload. The limit is now 6000 per minute, sized for four parallel workers, and a 429 answers with retryAfter seconds plus a Retry-After header computed from the window reset. Both clients now wait out the window and retry the same offset instead of failing the blob, falling back to five second waits against an older server, and give up only after 30 consecutive throttled attempts on one chunk.