### PR TITLE
Add wiki login for moderation

### DIFF
--- a/web/src/app/api/build/[sha256]/route.ts
+++ b/web/src/app/api/build/[sha256]/route.ts
@@ -3,7 +3,7 @@ import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
 import { getBuild, findSimilar, findByEmbeddingOf, getLotBuilds, updateBuildMeta } from "@/lib/queries";
-import { isModerator, moderationToken } from "@/lib/auth";
+import { getModerator, moderationEnabled } from "@/lib/auth";
 import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
 
@@ -37,10 +37,10 @@ export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256
 // PATCH /api/build/<sha256> { name?, lot? } — moderator metadata edit.
 // `name` renames the build; `lot` assigns it to a display group ("" or null clears).
 export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
-  if (!isModerator(request)) {
-    return moderationToken()
+  if (!(await getModerator(request))) {
+    return moderationEnabled()
       ? Response.json({ error: "unauthorized" }, { status: 401 })
-      : Response.json({ error: "moderation disabled (set MODERATION_TOKEN)" }, { status: 403 });
+      : Response.json({ error: "moderation disabled (set MODERATION_TOKEN or WIKI_API_URL)" }, { status: 403 });
   }
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });

--- a/web/src/app/api/submissions/[sha256]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/route.ts
@@ -3,7 +3,7 @@ import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { submissionStatus, setSubmissionStatus } from "@/lib/queries";
 import { ingestRecord, refreshAudioIdf } from "@/lib/ingest";
-import { isModerator, moderationToken } from "@/lib/auth";
+import { getModerator, moderationEnabled } from "@/lib/auth";
 import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
 import type { BuildRecord } from "@/lib/types";
@@ -23,10 +23,10 @@ export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256
 // POST /api/submissions/<sha256> { action: "accept" | "reject" } — moderate.
 // Accept ingests the stored record into the library, then marks it accepted.
 export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
-  if (!isModerator(request)) {
-    return moderationToken()
+  if (!(await getModerator(request))) {
+    return moderationEnabled()
       ? Response.json({ error: "unauthorized" }, { status: 401 })
-      : Response.json({ error: "moderation disabled (set MODERATION_TOKEN)" }, { status: 403 });
+      : Response.json({ error: "moderation disabled (set MODERATION_TOKEN or WIKI_API_URL)" }, { status: 403 });
   }
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });

--- a/web/src/app/api/submissions/route.ts
+++ b/web/src/app/api/submissions/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
 import { enqueueSubmission, listSubmissions } from "@/lib/queries";
-import { isModerator, moderationToken } from "@/lib/auth";
+import { getModerator, moderationEnabled } from "@/lib/auth";
 import { MAX_BODY_BYTES, validateBuildRecord } from "@/lib/validate";
 import { rateLimit, clientKey } from "@/lib/ratelimit";
 import type { BuildRecord } from "@/lib/types";
@@ -9,12 +9,12 @@ import type { BuildRecord } from "@/lib/types";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// GET /api/submissions?status=queued — the moderation queue. Requires a configured token.
+// GET /api/submissions?status=queued — the moderation queue. Requires moderator auth.
 export async function GET(request: NextRequest) {
-  if (!moderationToken()) {
-    return Response.json({ error: "moderation disabled (set MODERATION_TOKEN)" }, { status: 403 });
+  if (!moderationEnabled()) {
+    return Response.json({ error: "moderation disabled (set MODERATION_TOKEN or WIKI_API_URL)" }, { status: 403 });
   }
-  if (!isModerator(request)) {
+  if (!(await getModerator(request))) {
     return Response.json({ error: "unauthorized" }, { status: 401 });
   }
   const status = request.nextUrl.searchParams.get("status") ?? undefined;

--- a/web/src/app/api/whoami/route.ts
+++ b/web/src/app/api/whoami/route.ts
@@ -1,0 +1,22 @@
+import type { NextRequest } from "next/server";
+import { getModerator } from "@/lib/auth";
+import { wikiUserFromCookies } from "@/lib/wiki-auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// GET /api/whoami — the visitor's moderation identity, from the shared token
+// header or the wiki session cookies riding along on this same-origin request.
+// A wiki user outside the moderator groups still gets their name back so the
+// UI can explain why moderation stays hidden.
+export async function GET(request: NextRequest) {
+  const mod = await getModerator(request);
+  if (mod) {
+    return Response.json({ moderator: true, name: mod.name, via: mod.via });
+  }
+  const user = await wikiUserFromCookies(request.headers.get("cookie"));
+  if (user) {
+    return Response.json({ moderator: false, name: user.name, via: "wiki" });
+  }
+  return Response.json({ moderator: false });
+}

--- a/web/src/app/builds/[buildId]/ModeratorTools.tsx
+++ b/web/src/app/builds/[buildId]/ModeratorTools.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 
 // The token never changes while the page is mounted (it's set on /moderate),
@@ -18,19 +18,33 @@ interface Props {
   lots: string[];
 }
 
-// Rename + lot assignment, shown only when a moderation token is saved (the
-// /moderate page keeps it in sessionStorage). Purely cosmetic gating — the
-// PATCH route re-checks the token server-side. The parent keys this component
-// on name+lot, so a router.refresh() after a save remounts it with fresh values.
+// Rename + lot assignment, shown when a moderation token is saved (the
+// /moderate page keeps it in sessionStorage) or the visitor's wiki session
+// belongs to a moderator group. Purely cosmetic gating — the PATCH route
+// re-checks credentials server-side. The parent keys this component on
+// name+lot, so a router.refresh() after a save remounts it with fresh values.
 export default function ModeratorTools({ sha256, name, lot, lots }: Props) {
   const router = useRouter();
   const token = useSyncExternalStore(noSubscribe, clientToken, serverToken);
+  const [wikiModerator, setWikiModerator] = useState(false);
   const [nameInput, setNameInput] = useState(name);
   const [lotInput, setLotInput] = useState(lot ?? "");
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState("");
 
-  if (!token) return null;
+  useEffect(() => {
+    if (token) return;
+    let cancelled = false;
+    fetch("/api/whoami", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((w) => !cancelled && setWikiModerator(!!w.moderator))
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  if (!token && !wikiModerator) return null;
 
   async function save(patch: { name?: string; lot?: string | null }) {
     setBusy(true);
@@ -38,7 +52,10 @@ export default function ModeratorTools({ sha256, name, lot, lots }: Props) {
     try {
       const res = await fetch(`/api/build/${sha256}`, {
         method: "PATCH",
-        headers: { "Content-Type": "application/json", "x-moderation-token": token },
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { "x-moderation-token": token } : {}),
+        },
         body: JSON.stringify(patch),
       });
       const data = await res.json();

--- a/web/src/app/moderate/page.tsx
+++ b/web/src/app/moderate/page.tsx
@@ -17,6 +17,12 @@ interface Submission {
 
 const FILTERS = ["queued", "accepted", "rejected", ""] as const;
 
+interface Whoami {
+  moderator: boolean;
+  name?: string;
+  via?: "token" | "wiki";
+}
+
 export default function Moderate() {
   const [status, setStatus] = useState<string>("queued");
   const [items, setItems] = useState<Submission[]>([]);
@@ -24,6 +30,7 @@ export default function Moderate() {
   const [busy, setBusy] = useState<string | null>(null);
   const [note, setNote] = useState<string>("");
   const [token, setToken] = useState<string>("");
+  const [whoami, setWhoami] = useState<Whoami | null>(null);
 
   // Remember the moderation token locally so it isn't retyped each visit.
   useEffect(() => {
@@ -38,13 +45,26 @@ export default function Moderate() {
     [token],
   );
 
+  // Who does the server think we are? Wiki session cookies ride along
+  // automatically; the token header is attached when one is saved.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/whoami", { headers: authHeaders(), cache: "no-store" })
+      .then((r) => r.json())
+      .then((w: Whoami) => !cancelled && setWhoami(w))
+      .catch(() => !cancelled && setWhoami({ moderator: false }));
+    return () => {
+      cancelled = true;
+    };
+  }, [authHeaders]);
+
   const load = useCallback(async (s: string) => {
     setLoading(true);
     try {
       const res = await fetch(`/api/submissions${s ? `?status=${s}` : ""}`, { headers: authHeaders() });
       if (res.status === 401) {
         setItems([]);
-        setNote("Unauthorized — enter a valid moderation token.");
+        setNote("Unauthorized — log in with your wiki account or enter a moderation token.");
         return;
       }
       const data = await res.json();
@@ -85,17 +105,36 @@ export default function Moderate() {
       </div>
       <p className="mt-1 text-sm text-neutral-500">
         Review contributor submissions. Accepting ingests the build into the library.
-        While a token is saved here, build pages also show moderator tools (rename, lot).
+        While you are signed in, build pages also show moderator tools (rename, lot).
       </p>
 
-      <input
-        type="password"
-        value={token}
-        onChange={(e) => saveToken(e.target.value)}
-        onBlur={() => load(status)}
-        placeholder="moderation token (x-moderation-token)"
-        className="mt-5 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm outline-none focus:border-neutral-500 dark:border-neutral-700 dark:bg-neutral-900"
-      />
+      {whoami?.moderator && whoami.via === "wiki" ? (
+        <p className="mt-5 text-sm text-neutral-600 dark:text-neutral-300">
+          Signed in as <span className="font-medium">{whoami.name}</span> via your wiki account.
+        </p>
+      ) : (
+        <>
+          {whoami && !whoami.moderator && whoami.name && (
+            <p className="mt-5 text-sm text-amber-600">
+              Signed in to the wiki as {whoami.name}, but that account is not in a moderator group.
+            </p>
+          )}
+          {whoami && !whoami.moderator && !whoami.name && (
+            <p className="mt-5 text-sm text-neutral-500">
+              <a href="/wiki/Special:UserLogin" className="underline">Log in with your wiki account</a>
+              {" "}or enter a moderation token below.
+            </p>
+          )}
+          <input
+            type="password"
+            value={token}
+            onChange={(e) => saveToken(e.target.value)}
+            onBlur={() => load(status)}
+            placeholder="moderation token (x-moderation-token)"
+            className="mt-3 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm outline-none focus:border-neutral-500 dark:border-neutral-700 dark:bg-neutral-900"
+          />
+        </>
+      )}
 
       <div className="mt-4 flex gap-2">
         {FILTERS.map((f) => (

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,9 +1,15 @@
 import { timingSafeEqual } from "node:crypto";
 import type { NextRequest } from "next/server";
+import { wikiUserFromCookies, moderatorGroups, wikiApiUrl } from "@/lib/wiki-auth";
 
 /** The configured moderation secret, if any (env MODERATION_TOKEN). */
 export function moderationToken(): string | undefined {
   return process.env.MODERATION_TOKEN || undefined;
+}
+
+/** True when some moderation credential is configured (shared token or wiki login). */
+export function moderationEnabled(): boolean {
+  return !!moderationToken() || !!wikiApiUrl();
 }
 
 /** Constant-time string compare (avoids timingSafeEqual's unequal-length throw). */
@@ -15,8 +21,32 @@ function safeEqual(a: string | null | undefined, b: string): boolean {
   return timingSafeEqual(ab, bb);
 }
 
-/** True when the request carries the matching moderation token. */
-export function isModerator(request: NextRequest): boolean {
+export interface Moderator {
+  /** Wiki username, or "token" for shared-secret auth. */
+  name: string;
+  via: "token" | "wiki";
+}
+
+/**
+ * The moderator identity attached to a request, or null. Two credentials work:
+ *  - the shared x-moderation-token header;
+ *  - a hiddenpalace.org wiki session (same-origin cookies) whose user is in a
+ *    moderator group (MODERATION_WIKI_GROUPS).
+ * Cookies are ambient, so mutating requests authenticated by them must also
+ * prove same-origin via Sec-Fetch-Site. The token header needs no such proof:
+ * cross-site pages cannot attach custom headers.
+ */
+export async function getModerator(request: NextRequest): Promise<Moderator | null> {
   const tok = moderationToken();
-  return !!tok && safeEqual(request.headers.get("x-moderation-token"), tok);
+  if (tok && safeEqual(request.headers.get("x-moderation-token"), tok)) {
+    return { name: "token", via: "token" };
+  }
+  const user = await wikiUserFromCookies(request.headers.get("cookie"));
+  if (!user) return null;
+  if (!moderatorGroups().some((g) => user.groups.includes(g))) return null;
+  const method = request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD" && request.headers.get("sec-fetch-site") !== "same-origin") {
+    return null;
+  }
+  return { name: user.name, via: "wiki" };
 }

--- a/web/src/lib/wiki-auth.ts
+++ b/web/src/lib/wiki-auth.ts
@@ -1,0 +1,103 @@
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { createHash } from "node:crypto";
+
+/** A wiki account resolved from the incoming request's session cookies. */
+export interface WikiUser {
+  id: number;
+  name: string;
+  groups: string[];
+}
+
+/** Base URL of the MediaWiki api.php (env WIKI_API_URL); unset disables wiki login. */
+export function wikiApiUrl(): string | undefined {
+  return process.env.WIKI_API_URL || undefined;
+}
+
+/** Wiki groups whose members may moderate (env MODERATION_WIKI_GROUPS, comma-separated). */
+export function moderatorGroups(): string[] {
+  return (process.env.MODERATION_WIKI_GROUPS ?? "sysop")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function cookiePrefix(): string {
+  return process.env.WIKI_COOKIE_PREFIX ?? "hp_wiki_new";
+}
+
+// The app shares the hiddenpalace.org origin with the wiki, whose session
+// cookies are set with path=/, so they ride along on every request to us.
+// A session is validated by forwarding the cookies to the wiki's own
+// userinfo API; verdicts are cached briefly so page loads don't hammer it.
+const CACHE_TTL_MS = 60_000;
+const cache = new Map<string, { expires: number; user: WikiUser | null }>();
+
+/** Resolve the wiki user behind a Cookie header, or null (anon/invalid/disabled). */
+export async function wikiUserFromCookies(cookieHeader: string | null): Promise<WikiUser | null> {
+  const api = wikiApiUrl();
+  if (!api || !cookieHeader) return null;
+  // Skip the API round-trip unless a wiki session or remember-me cookie is present.
+  const prefix = cookiePrefix();
+  if (!cookieHeader.includes(`${prefix}_session=`) && !cookieHeader.includes(`${prefix}Token=`)) {
+    return null;
+  }
+
+  const key = createHash("sha256").update(cookieHeader).digest("base64");
+  const now = Date.now();
+  const hit = cache.get(key);
+  if (hit && hit.expires > now) return hit.user;
+  if (cache.size > 1000) {
+    for (const [k, v] of cache) if (v.expires <= now) cache.delete(k);
+  }
+
+  const user = await queryUserinfo(api, cookieHeader);
+  cache.set(key, { expires: now + CACHE_TTL_MS, user });
+  return user;
+}
+
+// node:http rather than fetch: undici strips custom Host headers, and
+// WIKI_API_HOST needs one (on the server the wiki is reached by IP without
+// leaving the box, with the vhost picked by Host).
+function queryUserinfo(api: string, cookieHeader: string): Promise<WikiUser | null> {
+  const url = new URL(api);
+  url.search = new URLSearchParams({
+    action: "query",
+    meta: "userinfo",
+    uiprop: "groups",
+    format: "json",
+  }).toString();
+  const request = url.protocol === "https:" ? httpsRequest : httpRequest;
+  return new Promise((resolve) => {
+    const req = request(
+      url,
+      {
+        headers: {
+          Cookie: cookieHeader,
+          ...(process.env.WIKI_API_HOST ? { Host: process.env.WIKI_API_HOST } : {}),
+        },
+        timeout: 4000,
+      },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (c) => (body += c));
+        res.on("end", () => {
+          try {
+            const info = JSON.parse(body)?.query?.userinfo;
+            resolve(
+              info && info.id > 0
+                ? { id: info.id, name: info.name, groups: info.groups ?? [] }
+                : null,
+            );
+          } catch {
+            resolve(null);
+          }
+        });
+      },
+    );
+    req.on("timeout", () => req.destroy(new Error("timeout")));
+    req.on("error", () => resolve(null));
+    req.end();
+  });
+}


### PR DESCRIPTION
Lets moderators sign in with their hiddenpalace.org wiki account. The app shares the wiki's origin, so the server validates the wiki session cookies already present on each request against the wiki's userinfo API and requires a moderator group.

The MODERATION_TOKEN header keeps working as a fallback for scripts. A new /api/whoami endpoint lets the moderation page and build page tools reflect the signed-in user.