### PR TITLE
Add private builds and lots

### DIFF
--- a/web/db/migrations/005-private.sql
+++ b/web/db/migrations/005-private.sql
@@ -1,0 +1,12 @@
+-- Private builds and lots: hidden from the public build list, search, and
+-- similar-builds surfaces, visible to moderators. A build is hidden when its
+-- own flag is set OR its lot is in private_lots (so builds later assigned to
+-- a private lot hide automatically). Direct build URLs stay reachable
+-- (unlisted). Toggled via PATCH /api/build/<sha256> { private, lotPrivate }.
+-- Idempotent — safe to re-run. Apply to every curator DB:
+--   psql -d <db> -f db/migrations/005-private.sql
+
+ALTER TABLE builds ADD COLUMN IF NOT EXISTS private BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE TABLE IF NOT EXISTS private_lots (
+    lot TEXT PRIMARY KEY
+);

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -35,7 +35,8 @@ CREATE TABLE builds (
     record                JSONB NOT NULL,           -- full canonical record
     ingested_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
     build_date            TEXT,                     -- volume creation date, else header release date (sortable copy)
-    lot                   TEXT                      -- moderator-assigned display group, e.g. "Sonic Month 2026"
+    lot                   TEXT,                     -- moderator-assigned display group, e.g. "Sonic Month 2026"
+    private               BOOLEAN NOT NULL DEFAULT FALSE -- hidden from public list/search/similar (direct URL stays reachable)
 );
 CREATE INDEX idx_builds_content      ON builds(content_hash);
 CREATE INDEX idx_builds_filtered     ON builds(filtered_content_hash);
@@ -45,6 +46,11 @@ CREATE INDEX idx_builds_name_trgm    ON builds USING gin (name gin_trgm_ops);
 CREATE INDEX idx_builds_textdoc_fts  ON builds USING gin (to_tsvector('simple', text_doc));
 CREATE INDEX idx_builds_embedding    ON builds USING hnsw (text_embedding vector_cosine_ops);
 CREATE INDEX idx_builds_lot          ON builds(lot) WHERE lot IS NOT NULL;
+
+-- Lots hidden from non-moderators; a build in a listed lot is hidden with it.
+CREATE TABLE private_lots (
+    lot TEXT PRIMARY KEY
+);
 
 -- ── files (per-build) — filename FTS/fuzzy + exact hash lookup ────────────────
 CREATE TABLE files (

--- a/web/src/app/api/build/[sha256]/route.ts
+++ b/web/src/app/api/build/[sha256]/route.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server";
 import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
-import { getBuild, findSimilar, findByEmbeddingOf, getLotBuilds, updateBuildMeta } from "@/lib/queries";
+import { getBuild, findSimilar, findByEmbeddingOf, getLotBuilds, updateBuildMeta, setLotPrivate } from "@/lib/queries";
 import { getModerator, moderationEnabled } from "@/lib/auth";
 import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
@@ -14,8 +14,10 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 // GET /api/build/<sha256> — the stored build plus its similar neighbors
-// (same fusion as /api/similarity, computed from the stored record).
-export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+// (same fusion as /api/similarity, computed from the stored record). The
+// build itself resolves for anyone holding its sha (private = unlisted, not
+// blocked); the neighbor lists hide private builds from non-moderators.
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
   const pool = getPool();
@@ -23,19 +25,22 @@ export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256
   const build = await getBuild(pool, sha256);
   if (!build) return Response.json({ error: "not found" }, { status: 404 });
 
+  const includePrivate = !!(await getModerator(request));
   const q = deriveQueryFeatures(build.record);
-  const similar = await findSimilar(pool, q);
+  const similar = await findSimilar(pool, q, 20, includePrivate);
 
   // Use the build's STORED embedding (pgvector) rather than re-running the
   // transformers model on its text_doc at request time — same neighbors, no
   // model load/inference on the hot path (the GUIs hit this endpoint).
-  const text_neighbors = await findByEmbeddingOf(pool, sha256);
+  const text_neighbors = await findByEmbeddingOf(pool, sha256, 20, includePrivate);
 
   return Response.json({ build, similar: { ...similar, text_neighbors } });
 }
 
-// PATCH /api/build/<sha256> { name?, lot? } — moderator metadata edit.
-// `name` renames the build; `lot` assigns it to a display group ("" or null clears).
+// PATCH /api/build/<sha256> { name?, lot?, private?, lotPrivate? } — moderator
+// metadata edit. `name` renames the build; `lot` assigns it to a display group
+// ("" or null clears); `private` hides the build from public list/search/similar;
+// `lotPrivate` hides/unhides the build's whole lot (current and future members).
 export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
   if (!(await getModerator(request))) {
     return moderationEnabled()
@@ -52,7 +57,7 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
     return Response.json({ error: "invalid JSON body" }, { status: 400 });
   }
 
-  const fields: { name?: string; lot?: string | null } = {};
+  const fields: { name?: string; lot?: string | null; private?: boolean } = {};
   if (body.name !== undefined) {
     if (typeof body.name !== "string" || !body.name.trim()) {
       return Response.json({ error: "name must be a non-empty string" }, { status: 400 });
@@ -71,34 +76,72 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
     }
     fields.lot = (body.lot ?? "").trim() || null;
   }
-  if (fields.name === undefined && fields.lot === undefined) {
-    return Response.json({ error: "nothing to update (name and/or lot required)" }, { status: 400 });
+  if (body.private !== undefined) {
+    if (typeof body.private !== "boolean") {
+      return Response.json({ error: "private must be a boolean" }, { status: 400 });
+    }
+    fields.private = body.private;
+  }
+  const lotPrivate = body.lotPrivate;
+  if (lotPrivate !== undefined && typeof lotPrivate !== "boolean") {
+    return Response.json({ error: "lotPrivate must be a boolean" }, { status: 400 });
+  }
+  const hasFields = fields.name !== undefined || fields.lot !== undefined || fields.private !== undefined;
+  if (!hasFields && lotPrivate === undefined) {
+    return Response.json({ error: "nothing to update (name, lot, private and/or lotPrivate required)" }, { status: 400 });
   }
 
   const pool = getPool();
-  const prev = await updateBuildMeta(pool, sha256, fields);
+  // Validate lotPrivate against the lot the build will be in BEFORE writing
+  // anything, so a rejected request never leaves a partial update behind.
+  const r = await pool.query("SELECT name, lot FROM builds WHERE sha256=$1", [sha256]);
+  const prev = (r.rows[0] as { name: string; lot: string | null }) ?? null;
   if (!prev) return Response.json({ error: "not found" }, { status: 404 });
+  const effectiveLot = fields.lot !== undefined ? fields.lot : prev.lot;
+  if (lotPrivate !== undefined && !effectiveLot) {
+    return Response.json({ error: "lotPrivate requires the build to have a lot" }, { status: 400 });
+  }
+
+  if (hasFields) {
+    const updated = await updateBuildMeta(pool, sha256, fields);
+    if (!updated) return Response.json({ error: "not found" }, { status: 404 });
+  }
+  if (lotPrivate !== undefined && effectiveLot) {
+    await setLotPrivate(pool, effectiveLot, lotPrivate);
+  }
 
   // Build pages are ISR-cached (revalidate = 3600); surface the edit now. A
   // rename changes the canonical slug path, so refresh the old one (it now
   // serves a redirect) and the new one, plus their assets subpages and the
-  // bare-sha redirect. A lot change also alters the lot section on every
-  // sibling page, in the lot the build joined and the one it left.
+  // bare-sha redirect. Lot moves and privacy toggles also alter the lot
+  // section on every sibling page (in the lot joined and the one left), so
+  // refresh those too — including private siblings, whose pages stay
+  // reachable by direct URL.
   revalidatePath("/builds");
   const touched = new Set([
     buildHref(sha256, prev.name),
     buildHref(sha256, fields.name ?? prev.name),
     `/builds/${sha256}`,
   ]);
+  const lotsTouched = new Set<string>();
   if (fields.lot !== undefined && fields.lot !== prev.lot) {
-    const lots = [fields.lot, prev.lot].filter((l): l is string => l != null);
-    for (const lot of lots) {
-      for (const b of await getLotBuilds(pool, lot)) touched.add(buildHref(b.sha256, b.name));
-    }
+    for (const lot of [fields.lot, prev.lot]) if (lot != null) lotsTouched.add(lot);
+  }
+  if ((lotPrivate !== undefined || fields.private !== undefined) && effectiveLot) {
+    lotsTouched.add(effectiveLot);
+  }
+  for (const lot of lotsTouched) {
+    for (const b of await getLotBuilds(pool, lot, true)) touched.add(buildHref(b.sha256, b.name));
   }
   for (const path of touched) {
     revalidatePath(path);
     revalidatePath(`${path}/assets`);
   }
-  return Response.json({ sha256, name: fields.name ?? prev.name, lot: fields.lot !== undefined ? fields.lot : prev.lot });
+  return Response.json({
+    sha256,
+    name: fields.name ?? prev.name,
+    lot: effectiveLot,
+    ...(fields.private !== undefined ? { private: fields.private } : {}),
+    ...(lotPrivate !== undefined ? { lotPrivate } : {}),
+  });
 }

--- a/web/src/app/api/search/route.ts
+++ b/web/src/app/api/search/route.ts
@@ -1,18 +1,21 @@
 import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
 import { search } from "@/lib/queries";
+import { getModerator } from "@/lib/auth";
 import { rateLimit, clientKey } from "@/lib/ratelimit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 // GET /api/search?q=... — filename FTS/fuzzy, or exact hash lookup.
+// Moderators (wiki session or token) also see private builds.
 export async function GET(request: NextRequest) {
   if (!rateLimit(`search:${clientKey(request)}`, 60, 60_000)) {
     return Response.json({ error: "rate limit exceeded" }, { status: 429 });
   }
   const term = (request.nextUrl.searchParams.get("q")?.trim() ?? "").slice(0, 256);
   if (!term) return Response.json({ mode: "text", results: [] });
-  const result = await search(getPool(), term);
+  const mod = await getModerator(request);
+  const result = await search(getPool(), term, 50, !!mod);
   return Response.json(result);
 }

--- a/web/src/app/api/similarity/route.ts
+++ b/web/src/app/api/similarity/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures, semanticDoc } from "@/lib/fingerprint";
 import { findSimilar, findByEmbedding, logCheck } from "@/lib/queries";
+import { getModerator } from "@/lib/auth";
 import { embed, toPgVector } from "@/lib/embed";
 import { MAX_BODY_BYTES, validateBuildRecord } from "@/lib/validate";
 import { rateLimit, clientKey } from "@/lib/ratelimit";
@@ -34,9 +35,10 @@ export async function POST(request: NextRequest) {
 
   try {
     const pool = getPool();
+    const includePrivate = !!(await getModerator(request));
     const q = deriveQueryFeatures(record);
     await logCheck(pool, q.sha256);
-    const result = await findSimilar(pool, q);
+    const result = await findSimilar(pool, q, 20, includePrivate);
 
     // Text: semantic neighbors via the text embedding (build identity, not the
     // filename-heavy text_doc — must match what the ingester embedded).
@@ -44,7 +46,7 @@ export async function POST(request: NextRequest) {
     const sdoc = semanticDoc(record);
     if (sdoc) {
       const vec = toPgVector(await embed(sdoc));
-      text_neighbors = await findByEmbedding(pool, vec, q.sha256 ?? "");
+      text_neighbors = await findByEmbedding(pool, vec, q.sha256 ?? "", 20, includePrivate);
     }
 
     return Response.json({ query: { sha256: q.sha256, name: q.name }, ...result, text_neighbors });

--- a/web/src/app/builds/BuildsBrowser.tsx
+++ b/web/src/app/builds/BuildsBrowser.tsx
@@ -144,6 +144,11 @@ export default function BuildsBrowser({ rows, total, systems, page, perPage, q, 
                         {b.lot}
                       </span>
                     )}
+                    {b.private && (
+                      <span className="ml-2 rounded border border-red-300 px-1.5 py-0.5 text-xs font-normal text-red-600 dark:border-red-800 dark:text-red-400">
+                        private
+                      </span>
+                    )}
                   </RowLink>
                 </td>
                 <td className="h-full p-0">

--- a/web/src/app/builds/[buildId]/ModeratorTools.tsx
+++ b/web/src/app/builds/[buildId]/ModeratorTools.tsx
@@ -16,6 +16,10 @@ interface Props {
   lot: string | null;
   /** Existing lot names, offered as suggestions when assigning. */
   lots: string[];
+  /** The build's own private flag. */
+  privateFlag: boolean;
+  /** Whether the build's lot is private (hides every build in it). */
+  lotPrivate: boolean;
 }
 
 // Rename + lot assignment, shown when a moderation token is saved (the
@@ -23,7 +27,7 @@ interface Props {
 // belongs to a moderator group. Purely cosmetic gating — the PATCH route
 // re-checks credentials server-side. The parent keys this component on
 // name+lot, so a router.refresh() after a save remounts it with fresh values.
-export default function ModeratorTools({ sha256, name, lot, lots }: Props) {
+export default function ModeratorTools({ sha256, name, lot, lots, privateFlag, lotPrivate }: Props) {
   const router = useRouter();
   const token = useSyncExternalStore(noSubscribe, clientToken, serverToken);
   const [wikiModerator, setWikiModerator] = useState(false);
@@ -46,7 +50,7 @@ export default function ModeratorTools({ sha256, name, lot, lots }: Props) {
 
   if (!token && !wikiModerator) return null;
 
-  async function save(patch: { name?: string; lot?: string | null }) {
+  async function save(patch: { name?: string; lot?: string | null; private?: boolean; lotPrivate?: boolean }) {
     setBusy(true);
     setNote("");
     try {
@@ -122,6 +126,31 @@ export default function ModeratorTools({ sha256, name, lot, lots }: Props) {
             </button>
           </div>
         </label>
+        {/* Checkbox state comes straight from props: a successful save triggers
+            router.refresh() and the parent's key remounts this component. */}
+        <div className="flex flex-col gap-1">
+          <span className="text-xs text-neutral-500">Visibility</span>
+          <div className="flex h-9 items-center gap-5">
+            <label className="flex items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={privateFlag}
+                disabled={busy}
+                onChange={(e) => save({ private: e.target.checked })}
+              />
+              Private build
+            </label>
+            <label className={`flex items-center gap-1.5 ${lot ? "" : "opacity-40"}`}>
+              <input
+                type="checkbox"
+                checked={lotPrivate}
+                disabled={busy || !lot}
+                onChange={(e) => save({ lotPrivate: e.target.checked })}
+              />
+              Private lot
+            </label>
+          </div>
+        </div>
       </div>
       {note && <p className="mt-2 text-xs text-neutral-500">{note}</p>}
     </section>

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -5,7 +5,7 @@ import { notFound, permanentRedirect } from "next/navigation";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
 import { buildTree, initialExpanded, pruneToExpanded, treeCounts } from "@/lib/filetree";
-import { getBuild, getBuildAssets, getBuildMeta, getBuildRepos, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, listLots, resolveBuild } from "@/lib/queries";
+import { getBuild, getBuildAssets, getBuildMeta, getBuildRepos, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, listLots, isLotPrivate, resolveBuild } from "@/lib/queries";
 import { shortOid } from "@/lib/repo-manifest";
 import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
 import { buildDescription, displayTitle } from "@/lib/meta";
@@ -139,12 +139,13 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
   const q = deriveQueryFeatures(build.record);
   // Pull a wide candidate set per tier so the fused top-50 is well-populated.
   // Text neighbors use this build's already-stored embedding — no re-embedding per load.
-  const [similar, textNeighbors, assets, lots, repos] = await Promise.all([
+  const [similar, textNeighbors, assets, lots, repos, lotPrivate] = await Promise.all([
     findSimilar(pool, q, 100),
     findByEmbeddingOf(pool, sha256, 100),
     getBuildAssets(pool, sha256),
     listLots(pool),
     getBuildRepos(pool, sha256),
+    build.lot ? isLotPrivate(pool, build.lot) : Promise.resolve(false),
   ]);
   const fused = fuseSimilar(similar, textNeighbors);
 
@@ -207,11 +208,13 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
       </dl>
 
       <ModeratorTools
-        key={`${build.name}\0${build.lot ?? ""}`}
+        key={`${build.name}\0${build.lot ?? ""}\0${build.private}\0${lotPrivate}`}
         sha256={build.sha256}
         name={build.name}
         lot={build.lot}
         lots={lots}
+        privateFlag={build.private}
+        lotPrivate={lotPrivate}
       />
 
       {meta.length > 0 && (

--- a/web/src/app/builds/page.tsx
+++ b/web/src/app/builds/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { headers } from "next/headers";
 import { getPool } from "@/lib/db";
 import { listBuildsPage, type BuildSortKey } from "@/lib/queries";
+import { getModeratorFromHeaders } from "@/lib/auth";
 import BuildsBrowser from "./BuildsBrowser";
 
 export const runtime = "nodejs";
@@ -31,6 +33,9 @@ export default async function BuildsPage({
   const dir = str(sp.dir) === "desc" ? "desc" : "asc";
   const page = Math.max(parseInt(str(sp.page), 10) || 1, 1);
 
+  // This page is already per-request (it reads searchParams), so a viewer
+  // check is free: moderators also see private builds, badged in the list.
+  const moderator = !!(await getModeratorFromHeaders(await headers()));
   const { rows, total, systems } = await listBuildsPage(getPool(), {
     q,
     system,
@@ -39,6 +44,7 @@ export default async function BuildsPage({
     dir,
     offset: (page - 1) * PER_PAGE,
     limit: PER_PAGE,
+    includePrivate: moderator,
   });
 
   return (

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -37,15 +37,21 @@ export interface Moderator {
  * cross-site pages cannot attach custom headers.
  */
 export async function getModerator(request: NextRequest): Promise<Moderator | null> {
+  return getModeratorFromHeaders(request.headers, request.method);
+}
+
+/** Header-based variant for server components (via next/headers), where no
+ *  NextRequest exists. Pages render on GET, so the CSRF gate never bites there. */
+export async function getModeratorFromHeaders(h: Headers, method = "GET"): Promise<Moderator | null> {
   const tok = moderationToken();
-  if (tok && safeEqual(request.headers.get("x-moderation-token"), tok)) {
+  if (tok && safeEqual(h.get("x-moderation-token"), tok)) {
     return { name: "token", via: "token" };
   }
-  const user = await wikiUserFromCookies(request.headers.get("cookie"));
+  const user = await wikiUserFromCookies(h.get("cookie"));
   if (!user) return null;
   if (!moderatorGroups().some((g) => user.groups.includes(g))) return null;
-  const method = request.method.toUpperCase();
-  if (method !== "GET" && method !== "HEAD" && request.headers.get("sec-fetch-site") !== "same-origin") {
+  const m = method.toUpperCase();
+  if (m !== "GET" && m !== "HEAD" && h.get("sec-fetch-site") !== "same-origin") {
     return null;
   }
   return { name: user.name, via: "wiki" };

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -423,12 +423,18 @@ export async function search(
   const t = term.trim();
   if (/^[0-9a-fA-F]{8,}$/.test(t)) {
     const h = t.toLowerCase();
+    // Two UNION arms instead of one OR across the builds×files join: the
+    // joined form made the planner walk the whole files table (15s+ at 9M
+    // rows); separately, each arm is index-served and the union stays in
+    // the low milliseconds. UNION (not ALL) dedups like the old DISTINCT.
+    const vis = includePrivate ? "TRUE" : visibleSql("b");
     const r = await pool.query(
-      `SELECT DISTINCT b.sha256, b.name, b.system
-       FROM builds b LEFT JOIN files f ON f.build_sha256=b.sha256
-       WHERE (b.sha256=$1 OR b.md5=$1 OR b.sha1=$1 OR b.content_hash=$1
-          OR f.md5=$1 OR f.sha1=$1 OR f.sha256=$1)
-         AND ${includePrivate ? "TRUE" : visibleSql("b")}
+      `SELECT b.sha256, b.name, b.system FROM builds b
+       WHERE (b.sha256=$1 OR b.md5=$1 OR b.sha1=$1 OR b.content_hash=$1) AND ${vis}
+       UNION
+       SELECT b.sha256, b.name, b.system FROM builds b
+       WHERE b.sha256 IN (SELECT f.build_sha256 FROM files f WHERE f.md5=$1 OR f.sha1=$1 OR f.sha256=$1)
+         AND ${vis}
        LIMIT $2`,
       [h, limit]
     );

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -14,6 +14,12 @@ import type { FusedBuild, TierKey } from "./tiers";
 const AUDIO_MATCH_THRESHOLD = 0.55;
 const TLSH_MAX_DISTANCE = 120; // below this ≈ similar executable
 
+// Predicate hiding private builds (their own flag or a private lot) from the
+// public list/search/similar surfaces. `alias` names the builds relation in
+// the calling query; pass includePrivate=true (moderators) to skip it.
+const visibleSql = (alias: string) =>
+  `NOT (${alias}.private OR EXISTS (SELECT 1 FROM private_lots _pl WHERE _pl.lot = ${alias}.lot))`;
+
 // A fingerprint present in more than this fraction of the audio corpus is too
 // common to discriminate (idf≈0): it can't push a match over AUDIO_MATCH_THRESHOLD.
 // We restrict both the candidate probe and the scoring to fingerprints with
@@ -29,7 +35,7 @@ const AUDIO_DF_CAP_FRACTION = 0.05;
 // fps (df≤cap=$4); per (query track, candidate track) sum idf over the
 // distinctive intersection/union; a build "matches" a query track when its best
 // candidate track scores ≥ threshold $5. Returns matched_tracks + best per build.
-const AUDIO_SIM_SQL = `
+const audioSimSql = (vis: string) => `
 WITH qf AS (
   SELECT u.qt, u.h, ln(($3::float + 1) / (i.doc_count + 1)) AS w
   FROM unnest($1::int[], $2::bigint[]) AS u(qt, h)
@@ -70,6 +76,7 @@ SELECT pqb.build_sha256 AS sha256, b.name, b.system,
        count(*) FILTER (WHERE pqb.bj >= $5::float) AS matched_tracks,
        max(pqb.bj) AS best
 FROM per_qt_build pqb JOIN builds b ON b.sha256 = pqb.build_sha256
+WHERE ${vis}
 GROUP BY pqb.build_sha256, b.name, b.system
 HAVING count(*) FILTER (WHERE pqb.bj >= $5::float) > 0
 ORDER BY matched_tracks DESC, best DESC
@@ -80,7 +87,8 @@ export async function findAudioSimilar(
   pool: Pool,
   tracks: AudioTrack[],
   exclude: string,
-  limit = 20
+  limit = 20,
+  includePrivate = false
 ) {
   const { rows: nr } = await pool.query(
     "SELECT count(DISTINCT build_sha256)::int AS n FROM audio_fp"
@@ -98,7 +106,7 @@ export async function findAudioSimilar(
     }
   });
   if (!fps.length) return [];
-  const r = await pool.query(AUDIO_SIM_SQL, [
+  const r = await pool.query(audioSimSql(includePrivate ? "TRUE" : visibleSql("b")), [
     arrayLit(qtIdx),
     arrayLit(fps),
     n,
@@ -199,8 +207,14 @@ export async function logCheck(pool: Pool, sha256: string | null): Promise<void>
 
 /** Fuse all-tier neighbors for a query build's derived features. The tiers are
  *  independent queries, so they run concurrently (bounded by the pool size). */
-export async function findSimilar(pool: Pool, q: QueryFeatures, limit = 20): Promise<SimilarityResult> {
+export async function findSimilar(
+  pool: Pool,
+  q: QueryFeatures,
+  limit = 20,
+  includePrivate = false
+): Promise<SimilarityResult> {
   const exclude = q.sha256 || "";
+  const vis = includePrivate ? "TRUE" : visibleSql("b");
   const out: SimilarityResult = {
     identical_content: [], shared_files: [], similar_chunks: [], resemblance: [], exe_imports: [], exe_similar: [], audio_neighbors: [],
   };
@@ -208,7 +222,8 @@ export async function findSimilar(pool: Pool, q: QueryFeatures, limit = 20): Pro
 
   if (q.content_hash) {
     tiers.push(pool.query(
-      "SELECT sha256, name, system FROM builds WHERE content_hash=$1 AND sha256<>$2",
+      `SELECT b.sha256, b.name, b.system FROM builds b
+       WHERE b.content_hash=$1 AND b.sha256<>$2 AND ${vis}`,
       [q.content_hash, exclude]
     ).then((r) => { out.identical_content = r.rows; }));
   }
@@ -234,6 +249,7 @@ export async function findSimilar(pool: Pool, q: QueryFeatures, limit = 20): Pro
        CROSS JOIN qn
        JOIN build_fileset f ON f.build_sha256 = i.build_sha256
        JOIN builds b ON b.sha256 = i.build_sha256
+       WHERE ${vis}
        ORDER BY jaccard DESC LIMIT $3`,
       [arrayLit(q.fileset), exclude, limit]
     ).then((r) => {
@@ -246,7 +262,7 @@ export async function findSimilar(pool: Pool, q: QueryFeatures, limit = 20): Pro
     tiers.push(pool.query(
       `SELECT s.build_sha256 AS sha256, b.name, b.system, s.minhash
        FROM build_chunk_signature s JOIN builds b ON b.sha256=s.build_sha256
-       WHERE s.build_sha256<>$2 AND s.lsh_bands && $1::bigint[]`,
+       WHERE s.build_sha256<>$2 AND s.lsh_bands && $1::bigint[] AND ${vis}`,
       [arrayLit(q.bands), exclude]
     ).then((cand) => {
       out.similar_chunks = cand.rows
@@ -269,7 +285,7 @@ export async function findSimilar(pool: Pool, q: QueryFeatures, limit = 20): Pro
     tiers.push(pool.query(
       `SELECT s.build_sha256 AS sha256, b.name, b.system, s.minhash
        FROM build_resemblance s JOIN builds b ON b.sha256=s.build_sha256
-       WHERE s.build_sha256<>$2 AND s.lsh_bands && $1::bigint[]`,
+       WHERE s.build_sha256<>$2 AND s.lsh_bands && $1::bigint[] AND ${vis}`,
       [arrayLit(q.resemblanceBands), exclude]
     ).then((cand) => {
       out.resemblance = cand.rows
@@ -290,7 +306,7 @@ export async function findSimilar(pool: Pool, q: QueryFeatures, limit = 20): Pro
     tiers.push(pool.query(
       `SELECT e.build_sha256 AS sha256, b.name, b.system
        FROM exe_fp e JOIN builds b ON b.sha256=e.build_sha256
-       WHERE e.imphash=$1 AND e.build_sha256<>$2`,
+       WHERE e.imphash=$1 AND e.build_sha256<>$2 AND ${vis}`,
       [q.imphash, exclude]
     ).then((r) => { out.exe_imports = r.rows; }));
   }
@@ -302,7 +318,7 @@ export async function findSimilar(pool: Pool, q: QueryFeatures, limit = 20): Pro
       // Cap the linear TLSH scan to bound work on large corpora.
       `SELECT e.build_sha256 AS sha256, b.name, b.system, e.tlsh
        FROM exe_fp e JOIN builds b ON b.sha256=e.build_sha256
-       WHERE e.tlsh IS NOT NULL AND e.build_sha256<>$1
+       WHERE e.tlsh IS NOT NULL AND e.build_sha256<>$1 AND ${vis}
        LIMIT 5000`,
       [exclude]
     ).then((r) => {
@@ -315,7 +331,7 @@ export async function findSimilar(pool: Pool, q: QueryFeatures, limit = 20): Pro
   }
 
   if (q.audioTracks.length) {
-    tiers.push(findAudioSimilar(pool, q.audioTracks, exclude, limit).then((r) => {
+    tiers.push(findAudioSimilar(pool, q.audioTracks, exclude, limit, includePrivate).then((r) => {
       out.audio_neighbors = r;
     }));
   }
@@ -340,14 +356,19 @@ export interface EmbeddingHit {
  * (`ORDER BY b.emb <=> me.emb`) forces a full seq scan + sort over every
  * embedding in the corpus (~1.9s at 16k builds vs ~40ms indexed).
  */
-export async function findByEmbeddingOf(pool: Pool, sha256: string, limit = 20): Promise<EmbeddingHit[]> {
+export async function findByEmbeddingOf(
+  pool: Pool,
+  sha256: string,
+  limit = 20,
+  includePrivate = false
+): Promise<EmbeddingHit[]> {
   const r = await pool.query(
     "SELECT text_embedding::text AS v FROM builds WHERE sha256=$1 AND text_embedding IS NOT NULL",
     [sha256]
   );
   const v = r.rows[0]?.v as string | undefined;
   if (!v) return [];
-  return findByEmbedding(pool, v, sha256, limit);
+  return findByEmbedding(pool, v, sha256, limit, includePrivate);
 }
 
 /** Text: nearest builds by text-embedding cosine (pgvector). For a query vector
@@ -356,7 +377,8 @@ export async function findByEmbedding(
   pool: Pool,
   vectorLiteral: string,
   exclude: string,
-  limit = 20
+  limit = 20,
+  includePrivate = false
 ): Promise<EmbeddingHit[]> {
   const c = await pool.connect();
   try {
@@ -371,6 +393,7 @@ export async function findByEmbedding(
       `SELECT sha256, name, system, 1 - (text_embedding <=> $1::vector) AS cosine
        FROM builds
        WHERE sha256<>$2 AND text_embedding IS NOT NULL
+         AND ${includePrivate ? "TRUE" : visibleSql("builds")}
        ORDER BY text_embedding <=> $1::vector
        LIMIT $3`,
       [vectorLiteral, exclude, limit]
@@ -391,15 +414,21 @@ export interface SearchResult {
 }
 
 /** Filename FTS/fuzzy search, or exact hash lookup when the term looks like a hash. */
-export async function search(pool: Pool, term: string, limit = 50): Promise<SearchResult> {
+export async function search(
+  pool: Pool,
+  term: string,
+  limit = 50,
+  includePrivate = false
+): Promise<SearchResult> {
   const t = term.trim();
   if (/^[0-9a-fA-F]{8,}$/.test(t)) {
     const h = t.toLowerCase();
     const r = await pool.query(
       `SELECT DISTINCT b.sha256, b.name, b.system
        FROM builds b LEFT JOIN files f ON f.build_sha256=b.sha256
-       WHERE b.sha256=$1 OR b.md5=$1 OR b.sha1=$1 OR b.content_hash=$1
-          OR f.md5=$1 OR f.sha1=$1 OR f.sha256=$1
+       WHERE (b.sha256=$1 OR b.md5=$1 OR b.sha1=$1 OR b.content_hash=$1
+          OR f.md5=$1 OR f.sha1=$1 OR f.sha256=$1)
+         AND ${includePrivate ? "TRUE" : visibleSql("b")}
        LIMIT $2`,
       [h, limit]
     );
@@ -408,7 +437,8 @@ export async function search(pool: Pool, term: string, limit = 50): Promise<Sear
   const r = await pool.query(
     `SELECT sha256, name, system, similarity(name,$1) AS sim
      FROM builds
-     WHERE name % $1 OR to_tsvector('simple', text_doc) @@ plainto_tsquery('simple',$1)
+     WHERE (name % $1 OR to_tsvector('simple', text_doc) @@ plainto_tsquery('simple',$1))
+       AND ${includePrivate ? "TRUE" : visibleSql("builds")}
      ORDER BY sim DESC NULLS LAST LIMIT $2`,
     [t, limit]
   );
@@ -444,6 +474,9 @@ export interface BuildRow {
   record: BuildRecord;
   /** Moderator-assigned display group, e.g. "Sonic Month 2026". */
   lot: string | null;
+  /** Hidden from public list/search/similar (the build's own flag; a private
+   *  lot hides its builds without setting this). */
+  private: boolean;
 }
 
 export interface BuildListItem {
@@ -457,6 +490,9 @@ export interface BuildListItem {
   build_date: string | null;
   /** Moderator-assigned display group, e.g. "Sonic Month 2026". */
   lot: string | null;
+  /** Hidden from non-moderators (own flag or private lot). Only meaningful
+   *  when the list was fetched with includePrivate. */
+  private?: boolean;
 }
 
 export type BuildSortKey = "name" | "system" | "build_date" | "file_count" | "total_size";
@@ -469,6 +505,8 @@ export interface BuildsPageOpts {
   dir?: "asc" | "desc";
   offset?: number;
   limit?: number;
+  /** Moderator view: include private builds (marked via the `private` field). */
+  includePrivate?: boolean;
 }
 
 export interface BuildsPageResult {
@@ -508,6 +546,7 @@ export async function listBuildsPage(pool: Pool, opts: BuildsPageOpts = {}): Pro
     params.push(opts.lot);
     conds.push(`lot = $${params.length}`);
   }
+  if (!opts.includePrivate) conds.push(visibleSql("builds"));
   const where = conds.length ? `WHERE ${conds.join(" AND ")}` : "";
 
   const key = opts.sort && BUILD_SORT[opts.sort] ? opts.sort : "name";
@@ -523,13 +562,17 @@ export async function listBuildsPage(pool: Pool, opts: BuildsPageOpts = {}): Pro
 
   const [rows, count, systems] = await Promise.all([
     pool.query(
-      `SELECT sha256, name, system, file_count, total_size, ingested_at, build_date, lot
+      `SELECT sha256, name, system, file_count, total_size, ingested_at, build_date, lot,
+              (private OR EXISTS (SELECT 1 FROM private_lots _pl WHERE _pl.lot = builds.lot)) AS private
        FROM builds ${where} ORDER BY ${order}
        LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
       [...params, limit, offset]
     ),
     pool.query(`SELECT count(*)::int AS n FROM builds ${where}`, params),
-    pool.query("SELECT DISTINCT system FROM builds ORDER BY system"),
+    pool.query(
+      `SELECT DISTINCT system FROM builds
+       ${opts.includePrivate ? "" : `WHERE ${visibleSql("builds")}`} ORDER BY system`
+    ),
   ]);
   return {
     rows: rows.rows as BuildListItem[],
@@ -643,20 +686,21 @@ export async function getBuildMeta(pool: Pool, sha256: string): Promise<BuildMet
 export async function getBuild(pool: Pool, sha256: string): Promise<BuildRow | null> {
   const r = await pool.query(
     `SELECT sha256, name, system, size, md5, sha1, content_hash, file_count,
-            total_size, fingerprint_profile, ingested_at, record, lot
+            total_size, fingerprint_profile, ingested_at, record, lot, private
      FROM builds WHERE sha256=$1`,
     [sha256]
   );
   return (r.rows[0] as BuildRow) ?? null;
 }
 
-/// Moderator metadata edit: rename and/or move between lots. Omitted fields are
-/// untouched; lot=null clears it. Returns the previous name/lot (so the caller
-/// can revalidate pages of the lot the build left), or null when not found.
+/// Moderator metadata edit: rename, move between lots, and/or toggle privacy.
+/// Omitted fields are untouched; lot=null clears it. Returns the previous
+/// name/lot (so the caller can revalidate pages of the lot the build left),
+/// or null when not found.
 export async function updateBuildMeta(
   pool: Pool,
   sha256: string,
-  fields: { name?: string; lot?: string | null }
+  fields: { name?: string; lot?: string | null; private?: boolean }
 ): Promise<{ name: string; lot: string | null } | null> {
   const sets: string[] = [];
   const params: unknown[] = [sha256];
@@ -667,6 +711,10 @@ export async function updateBuildMeta(
   if (fields.lot !== undefined) {
     params.push(fields.lot);
     sets.push(`lot=$${params.length}`);
+  }
+  if (fields.private !== undefined) {
+    params.push(fields.private);
+    sets.push(`private=$${params.length}`);
   }
   if (!sets.length) throw new Error("updateBuildMeta: no fields to update");
   const r = await pool.query(
@@ -680,19 +728,42 @@ export async function updateBuildMeta(
 }
 
 /// All builds in a lot, for the build page's lot section and revalidation.
-export async function getLotBuilds(pool: Pool, lot: string): Promise<BuildListItem[]> {
+/// The lot section is ISR-cached (one copy for every viewer), so it must stay
+/// public-only; revalidation passes includePrivate to reach every sibling page.
+export async function getLotBuilds(pool: Pool, lot: string, includePrivate = false): Promise<BuildListItem[]> {
   const r = await pool.query(
     `SELECT sha256, name, system, file_count, total_size, ingested_at, build_date, lot
-     FROM builds WHERE lot=$1 ORDER BY lower(name)`,
+     FROM builds WHERE lot=$1 AND ${includePrivate ? "TRUE" : visibleSql("builds")}
+     ORDER BY lower(name)`,
     [lot]
   );
   return r.rows as BuildListItem[];
 }
 
-/** Distinct lot names, for the moderator edit box's suggestions. */
+/** Distinct lot names, for the moderator edit box's suggestions. Private lots
+ *  are excluded — the list is embedded in ISR-cached build pages. */
 export async function listLots(pool: Pool): Promise<string[]> {
-  const r = await pool.query("SELECT DISTINCT lot FROM builds WHERE lot IS NOT NULL ORDER BY lot");
+  const r = await pool.query(
+    `SELECT DISTINCT lot FROM builds
+     WHERE lot IS NOT NULL AND NOT EXISTS (SELECT 1 FROM private_lots _pl WHERE _pl.lot = builds.lot)
+     ORDER BY lot`
+  );
   return r.rows.map((row) => row.lot as string);
+}
+
+/** Whether a lot is hidden from non-moderators. */
+export async function isLotPrivate(pool: Pool, lot: string): Promise<boolean> {
+  const r = await pool.query("SELECT 1 FROM private_lots WHERE lot=$1", [lot]);
+  return r.rows.length > 0;
+}
+
+/** Hide/unhide a whole lot (every build in it, now and later). */
+export async function setLotPrivate(pool: Pool, lot: string, priv: boolean): Promise<void> {
+  if (priv) {
+    await pool.query("INSERT INTO private_lots (lot) VALUES ($1) ON CONFLICT DO NOTHING", [lot]);
+  } else {
+    await pool.query("DELETE FROM private_lots WHERE lot=$1", [lot]);
+  }
 }
 
 export async function submissionStatus(pool: Pool, sha256: string) {


### PR DESCRIPTION
Moderators can mark a build or a whole lot as private. Private builds disappear from the build list, search, similar builds and lot sections for everyone else, while their direct URLs stay reachable (unlisted).

A private lot hides all its builds, including ones assigned later. Toggles live in the build page moderator tools, moderators see badged private rows in /builds, and db/migrations/005-private.sql must be applied to each deployed DB.