### PR TITLE
Add MPEG video support to asset viewer

### DIFF
--- a/ps2exe-adapter/curator_adapter/viewable.py
+++ b/ps2exe-adapter/curator_adapter/viewable.py
@@ -46,6 +46,14 @@ _VIDEO = {
     "mp4": "video/mp4",
     "m4v": "video/mp4",
     "webm": "video/webm",
+    # MPEG-1/2 program streams (and bare video elementary streams). No browser
+    # plays these natively. The web viewer streams them through a server-side
+    # MP4 transcode and degrades to a download card without it.
+    "mpg": "video/mpeg",
+    "mpeg": "video/mpeg",
+    "m1v": "video/mpeg",
+    "m2v": "video/mpeg",
+    "vob": "video/mpeg",
 }
 
 # Print-format documents. Browsers render PDF natively; PostScript (.eps, .ps,
@@ -152,6 +160,9 @@ _MAGIC = {
     "audio/mp4": lambda h: h[4:8] == b"ftyp",
     "video/mp4": lambda h: h[4:8] == b"ftyp",
     "video/webm": lambda h: h.startswith(b"\x1aE\xdf\xa3"),
+    # Program streams (.mpg, DVD .vob) open on a pack start code, elementary
+    # video streams (.m1v/.m2v) on a sequence header.
+    "video/mpeg": lambda h: h.startswith((b"\x00\x00\x01\xba", b"\x00\x00\x01\xb3")),
     "application/pdf": lambda h: h.startswith(b"%PDF-"),
     # ASCII PostScript/EPS, or the DOS EPS binary wrapper around one.
     "application/postscript": lambda h: h.startswith((b"%!PS", b"\xc5\xd0\xd3\xc6")),

--- a/ps2exe-adapter/tests/test_viewable.py
+++ b/ps2exe-adapter/tests/test_viewable.py
@@ -69,6 +69,23 @@ def test_sniff_tiff_magic_and_case_insensitive_extension():
     assert not viewable.sniff(b"Not a TIFF at all, honest.", "image/tiff")
 
 
+def test_classify_mpeg_video():
+    assert viewable.classify("/MOVIE/OPENING.MPG") == ("video", "video/mpeg")
+    assert viewable.classify("/movie/intro.mpeg") == ("video", "video/mpeg")
+    assert viewable.classify("/VIDEO_TS/VTS_01_1.VOB") == ("video", "video/mpeg")
+    assert viewable.classify("/FMV/DEMO.M2V") == ("video", "video/mpeg")
+
+
+def test_sniff_mpeg_video():
+    # Program stream pack header (.mpg, DVD .vob), MPEG-2 flavor bits vary.
+    assert viewable.sniff(b"\x00\x00\x01\xba\x44\x00\x04\x00", "video/mpeg")
+    # Elementary video stream sequence header (.m1v/.m2v).
+    assert viewable.sniff(b"\x00\x00\x01\xb3\x16\x00\xf0\xc4", "video/mpeg")
+    # Renamed junk must not ship as video.
+    assert not viewable.sniff(b"RIFF\x24\x08\x00\x00CDXA", "video/mpeg")
+    assert not viewable.sniff(b"MZ\x90\x00", "video/mpeg")
+
+
 def test_classify_documents():
     assert viewable.classify("/COMIC/BOOK.PDF") == ("document", "application/pdf")
     assert viewable.classify("/ART/LOGO.EPS") == ("document", "application/postscript")

--- a/web/src/app/api/asset/[sha256]/mp4/route.ts
+++ b/web/src/app/api/asset/[sha256]/mp4/route.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { Readable } from "node:stream";
+import type { NextRequest } from "next/server";
+import { getPool } from "@/lib/db";
+import { ensureMp4, ffmpegAvailable, mp4Transcodable } from "@/lib/ffmpeg";
+import { parseRange } from "@/lib/range";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// GET /api/asset/<sha256>/mp4 — the asset transcoded to H.264/AAC MP4, for
+// video formats browsers won't play natively (today: MPEG-1/2 program streams,
+// i.e. .mpg and DVD .vob, via ffmpeg when the server has it). Native formats
+// redirect to the raw asset route. The transcode is produced once, cached on
+// disk, and streamed with Range support so the player can seek. The URL is
+// content-addressed, so responses cache hard.
+
+const CACHE = "public, max-age=31536000, immutable";
+const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const r = await getPool().query(
+    "SELECT path, mime FROM build_asset WHERE sha256=$1 LIMIT 1",
+    [sha256]
+  );
+  const meta = r.rows[0] as { path: string; mime: string } | undefined;
+  if (!meta) return Response.json({ error: "not found" }, { status: 404 });
+
+  if (meta.mime === "video/mp4" || meta.mime === "video/webm") {
+    return Response.redirect(new URL(`/api/asset/${sha256}`, request.url), 308);
+  }
+  if (!mp4Transcodable(meta.mime) || !(await ffmpegAvailable())) {
+    return Response.json({ error: `no MP4 transcode for ${meta.mime}` }, { status: 415 });
+  }
+
+  // The browser already holds an immutable copy: never re-send the bytes.
+  if (request.headers.get("if-none-match") === `"${sha256}-mp4"`) {
+    return new Response(null, {
+      status: 304,
+      headers: { "Cache-Control": CACHE, ETag: `"${sha256}-mp4"` },
+    });
+  }
+
+  let mp4: string;
+  try {
+    mp4 = await ensureMp4(sha256);
+  } catch {
+    // Blob missing from the store, or ffmpeg rejected/timed out on the input.
+    return Response.json({ error: "untranscodable video" }, { status: 415 });
+  }
+  const stat = await fsp.stat(mp4);
+
+  const base = (meta.path.split("/").pop() || sha256).replace(/\.[^.]*$/, "");
+  const asciiName = base.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+  const headers: Record<string, string> = {
+    "Content-Type": "video/mp4",
+    "Content-Disposition": `inline; filename="${asciiName}.mp4"`,
+    "Cache-Control": CACHE,
+    ETag: `"${sha256}-mp4"`,
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": CSP,
+    "Accept-Ranges": "bytes",
+  };
+
+  // Single-range support so <video> can seek.
+  const range = parseRange(request.headers.get("range"), stat.size);
+  if (range) {
+    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${stat.size}`;
+    headers["Content-Length"] = String(range.end - range.start + 1);
+    const stream = fs.createReadStream(mp4, { start: range.start, end: range.end });
+    return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
+  }
+
+  headers["Content-Length"] = String(stat.size);
+  const stream = fs.createReadStream(mp4);
+  return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
+}

--- a/web/src/app/api/asset/[sha256]/route.ts
+++ b/web/src/app/api/asset/[sha256]/route.ts
@@ -5,6 +5,7 @@ import type { NextRequest } from "next/server";
 import { unstable_cache } from "next/cache";
 import { assetBlobPath } from "@/lib/assets";
 import { getPool } from "@/lib/db";
+import { parseRange } from "@/lib/range";
 import { isSha256 } from "@/lib/validate";
 
 export const runtime = "nodejs";
@@ -45,18 +46,6 @@ const getMeta = unstable_cache(
   ["asset-meta"],
   { revalidate: 3600 }
 );
-
-/** One satisfiable `bytes=start-end` range, else null (serve the whole file). */
-function parseRange(header: string | null, size: number): { start: number; end: number } | null {
-  const m = header?.match(/^bytes=(\d*)-(\d*)$/);
-  if (!m || size === 0) return null;
-  const [, a, b] = m;
-  if (a === "" && b === "") return null;
-  const start = a === "" ? Math.max(0, size - Number(b)) : Number(a);
-  const end = a !== "" && b !== "" ? Math.min(Number(b), size - 1) : size - 1;
-  if (start > end || start >= size) return null;
-  return { start, end };
-}
 
 export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
   const { sha256 } = await ctx.params;

--- a/web/src/app/api/asset/[sha256]/video/route.ts
+++ b/web/src/app/api/asset/[sha256]/video/route.ts
@@ -3,18 +3,19 @@ import fsp from "node:fs/promises";
 import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
-import { ensureMp4, ffmpegAvailable, mp4Transcodable } from "@/lib/ffmpeg";
+import { ensureTranscode, transcodable } from "@/lib/ffmpeg";
 import { parseRange } from "@/lib/range";
 import { isSha256 } from "@/lib/validate";
 
 export const runtime = "nodejs";
 
-// GET /api/asset/<sha256>/mp4 — the asset transcoded to H.264/AAC MP4, for
-// video formats browsers won't play natively (today: MPEG-1/2 program streams,
-// i.e. .mpg and DVD .vob, via ffmpeg when the server has it). Native formats
-// redirect to the raw asset route. The transcode is produced once, cached on
-// disk, and streamed with Range support so the player can seek. The URL is
-// content-addressed, so responses cache hard.
+// GET /api/asset/<sha256>/video — the asset transcoded to a browser-playable
+// format (H.264/AAC MP4, or VP9/Opus WebM when the server's ffmpeg lacks
+// libx264), for video formats browsers won't play natively: today MPEG-1/2
+// program streams, i.e. .mpg and DVD .vob. Native formats redirect to the raw
+// asset route. The transcode is produced once, cached on disk, and streamed
+// with Range support so the player can seek. The URL is content-addressed, so
+// responses cache hard.
 
 const CACHE = "public, max-age=31536000, immutable";
 const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
@@ -33,34 +34,36 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   if (meta.mime === "video/mp4" || meta.mime === "video/webm") {
     return Response.redirect(new URL(`/api/asset/${sha256}`, request.url), 308);
   }
-  if (!mp4Transcodable(meta.mime) || !(await ffmpegAvailable())) {
-    return Response.json({ error: `no MP4 transcode for ${meta.mime}` }, { status: 415 });
+  if (!transcodable(meta.mime)) {
+    return Response.json({ error: `no video transcode for ${meta.mime}` }, { status: 415 });
   }
 
   // The browser already holds an immutable copy: never re-send the bytes.
-  if (request.headers.get("if-none-match") === `"${sha256}-mp4"`) {
+  if (request.headers.get("if-none-match") === `"${sha256}-video"`) {
     return new Response(null, {
       status: 304,
-      headers: { "Cache-Control": CACHE, ETag: `"${sha256}-mp4"` },
+      headers: { "Cache-Control": CACHE, ETag: `"${sha256}-video"` },
     });
   }
 
-  let mp4: string;
+  let video: { path: string; mime: string };
   try {
-    mp4 = await ensureMp4(sha256);
+    video = await ensureTranscode(sha256);
   } catch {
-    // Blob missing from the store, or ffmpeg rejected/timed out on the input.
+    // No usable ffmpeg, blob missing from the store, or ffmpeg rejected or
+    // timed out on the input.
     return Response.json({ error: "untranscodable video" }, { status: 415 });
   }
-  const stat = await fsp.stat(mp4);
+  const stat = await fsp.stat(video.path);
 
   const base = (meta.path.split("/").pop() || sha256).replace(/\.[^.]*$/, "");
   const asciiName = base.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+  const ext = video.mime === "video/webm" ? "webm" : "mp4";
   const headers: Record<string, string> = {
-    "Content-Type": "video/mp4",
-    "Content-Disposition": `inline; filename="${asciiName}.mp4"`,
+    "Content-Type": video.mime,
+    "Content-Disposition": `inline; filename="${asciiName}.${ext}"`,
     "Cache-Control": CACHE,
-    ETag: `"${sha256}-mp4"`,
+    ETag: `"${sha256}-video"`,
     "X-Content-Type-Options": "nosniff",
     "Content-Security-Policy": CSP,
     "Accept-Ranges": "bytes",
@@ -71,11 +74,11 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   if (range) {
     headers["Content-Range"] = `bytes ${range.start}-${range.end}/${stat.size}`;
     headers["Content-Length"] = String(range.end - range.start + 1);
-    const stream = fs.createReadStream(mp4, { start: range.start, end: range.end });
+    const stream = fs.createReadStream(video.path, { start: range.start, end: range.end });
     return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
   }
 
   headers["Content-Length"] = String(stat.size);
-  const stream = fs.createReadStream(mp4);
+  const stream = fs.createReadStream(video.path);
   return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
 }

--- a/web/src/app/builds/[buildId]/AssetGallery.tsx
+++ b/web/src/app/builds/[buildId]/AssetGallery.tsx
@@ -10,7 +10,7 @@
 // file tree), which also deep-links the asset in the URL.
 
 import Link from "next/link";
-import { assetUrl, humanSize, imageSrc, type ViewableAsset } from "./AssetViewer";
+import { assetUrl, humanSize, imageSrc, videoSrc, type ViewableAsset } from "./AssetViewer";
 import { useOpenAsset } from "./AssetViewerHost";
 import AudioEmbed from "./AudioEmbed";
 import SourceCode from "./SourceCode";
@@ -102,7 +102,7 @@ export default function AssetGallery({
                     key={a.path}
                     controls
                     preload="none"
-                    src={assetUrl(a)}
+                    src={videoSrc(a)}
                     title={a.path}
                     className="h-36 rounded border border-neutral-200 dark:border-neutral-800"
                   />

--- a/web/src/app/builds/[buildId]/AssetViewer.tsx
+++ b/web/src/app/builds/[buildId]/AssetViewer.tsx
@@ -30,6 +30,12 @@ export function imageSrc(a: ViewableAsset): string {
   return a.mime === "image/x-tga" || a.mime === "image/tiff" ? `${assetUrl(a)}/png` : assetUrl(a);
 }
 
+/** Where <video> should point: MP4/WebM play natively, while MPEG-1/2 program
+ *  streams (.mpg, DVD .vob) go through the server's MP4 transcode. */
+export function videoSrc(a: ViewableAsset): string {
+  return a.mime === "video/mpeg" ? `${assetUrl(a)}/mp4` : assetUrl(a);
+}
+
 export function humanSize(bytes: number): string {
   const units = ["B", "KB", "MB", "GB", "TB"];
   let v = bytes;
@@ -125,6 +131,40 @@ function HexBody({ asset }: { asset: ViewableAsset }) {
   );
 }
 
+// The "can't show this inline" downgrade shared by the bodies whose rendering
+// depends on an optional server-side converter.
+function DownloadCard({ asset }: { asset: ViewableAsset }) {
+  const name = asset.path.split("/").pop() || asset.path;
+  return (
+    <div className="flex flex-col items-center gap-3 rounded bg-neutral-900 p-10 text-sm text-neutral-300">
+      <p>No inline preview for this file.</p>
+      <a
+        href={assetUrl(asset)}
+        download={name}
+        className="rounded bg-neutral-700 px-3 py-1.5 text-neutral-100 hover:bg-neutral-600"
+      >
+        Download {name}
+      </a>
+    </div>
+  );
+}
+
+// MP4/WebM play natively. MPEG program streams go through the server's ffmpeg
+// transcode, which can be unavailable (no ffmpeg on the server) or fail on a
+// damaged stream, so fall back to a download card rather than an error.
+function VideoBody({ asset }: { asset: ViewableAsset }) {
+  const [failed, setFailed] = useState(false);
+  if (failed) return <DownloadCard asset={asset} />;
+  return (
+    <video
+      controls
+      src={videoSrc(asset)}
+      className="max-h-[75vh] max-w-[90vw] rounded"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
 // PDFs embed the browser's own viewer; PostScript/EPS goes through the
 // server's Ghostscript rasterization. Either can be unavailable (mobile
 // browsers won't embed PDFs; the server may lack Ghostscript), so both
@@ -132,15 +172,7 @@ function HexBody({ asset }: { asset: ViewableAsset }) {
 function DocumentBody({ asset }: { asset: ViewableAsset }) {
   const [failed, setFailed] = useState(false);
   const url = assetUrl(asset);
-  const name = asset.path.split("/").pop() || asset.path;
-  const fallback = (
-    <div className="flex flex-col items-center gap-3 rounded bg-neutral-900 p-10 text-sm text-neutral-300">
-      <p>No inline preview for this file.</p>
-      <a href={url} download={name} className="rounded bg-neutral-700 px-3 py-1.5 text-neutral-100 hover:bg-neutral-600">
-        Download {name}
-      </a>
-    </div>
-  );
+  const fallback = <DownloadCard asset={asset} />;
   if (asset.mime === "application/pdf") {
     return (
       <object data={url} type="application/pdf" className="h-[75vh] w-[min(70rem,90vw)] rounded" aria-label={asset.path}>
@@ -182,14 +214,7 @@ function Body({ asset }: { asset: ViewableAsset }) {
     case "audio":
       return <audio controls src={url} className="w-[min(40rem,85vw)]" onError={() => setFailed(true)} />;
     case "video":
-      return (
-        <video
-          controls
-          src={url}
-          className="max-h-[75vh] max-w-[90vw] rounded"
-          onError={() => setFailed(true)}
-        />
-      );
+      return <VideoBody asset={asset} />;
     case "document":
       return <DocumentBody asset={asset} />;
     case "binary":

--- a/web/src/app/builds/[buildId]/AssetViewer.tsx
+++ b/web/src/app/builds/[buildId]/AssetViewer.tsx
@@ -31,9 +31,9 @@ export function imageSrc(a: ViewableAsset): string {
 }
 
 /** Where <video> should point: MP4/WebM play natively, while MPEG-1/2 program
- *  streams (.mpg, DVD .vob) go through the server's MP4 transcode. */
+ *  streams (.mpg, DVD .vob) go through the server's transcode. */
 export function videoSrc(a: ViewableAsset): string {
-  return a.mime === "video/mpeg" ? `${assetUrl(a)}/mp4` : assetUrl(a);
+  return a.mime === "video/mpeg" ? `${assetUrl(a)}/video` : assetUrl(a);
 }
 
 export function humanSize(bytes: number): string {

--- a/web/src/lib/ffmpeg.ts
+++ b/web/src/lib/ffmpeg.ts
@@ -1,0 +1,123 @@
+// ffmpeg-backed transcoding: MPEG-1/2 program streams (.mpg, DVD .vob) and
+// bare MPEG video elementary streams to H.264/AAC MP4, the one video format
+// every browser plays. Like Ghostscript in gs.ts, ffmpeg is a soft dependency:
+// feature-detected at runtime, and callers degrade (download-only viewer)
+// when it's missing.
+//
+// Unlike the PNG conversions, a transcode is too slow to redo per request, so
+// results are cached in the blob store under .transcode/ (which can't collide
+// with the two-hex-char blob dirs) and streamed from disk with Range support.
+
+import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdir, rename, rm, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { assetBlobPath, assetStoreDir } from "./assets";
+
+const execFileP = promisify(execFile);
+
+const FFMPEG_BIN = process.env.FFMPEG_BIN || "ffmpeg";
+
+// Inputs are capped by the analyzer (viewable.py MAX_ASSET_SIZE, 20MB), so a
+// transcode is bounded work, but MPEG-2 decode plus x264 on a modest server
+// can still take tens of seconds. Kill anything that runs away.
+const FFMPEG_TIMEOUT_MS = 120_000;
+
+/** Mimes ensureMp4 can transcode. */
+export function mp4Transcodable(mime: string): boolean {
+  return mime === "video/mpeg";
+}
+
+// Feature detection, memoized for the process lifetime.
+let available: Promise<boolean> | null = null;
+
+export function ffmpegAvailable(): Promise<boolean> {
+  available ??= execFileP(FFMPEG_BIN, ["-version"], { timeout: 5_000 })
+    .then(({ stdout }) => /^ffmpeg version/i.test(stdout))
+    .catch(() => false);
+  return available;
+}
+
+/** Where a blob's cached MP4 transcode lives. Caller must have validated `sha256`. */
+export function transcodePath(sha256: string): string {
+  return join(assetStoreDir(), ".transcode", `${sha256}.mp4`);
+}
+
+// One transcode per blob at a time: a gallery of players can fire several
+// requests for the same asset before the first transcode finishes.
+const inFlight = new Map<string, Promise<string>>();
+
+/**
+ * Path of the cached MP4 transcode for this blob, producing it on first use.
+ * Throws when ffmpeg is missing, errors on the input, or times out.
+ */
+export async function ensureMp4(sha256: string): Promise<string> {
+  const out = transcodePath(sha256);
+  try {
+    if ((await stat(out)).size > 0) return out;
+  } catch {
+    // Not cached yet.
+  }
+  let job = inFlight.get(sha256);
+  if (!job) {
+    job = transcode(sha256, out).finally(() => inFlight.delete(sha256));
+    inFlight.set(sha256, job);
+  }
+  return job;
+}
+
+async function transcode(sha256: string, out: string): Promise<string> {
+  if (!(await ffmpegAvailable())) throw new Error("ffmpeg not available");
+  await mkdir(dirname(out), { recursive: true });
+  // Private temp name in the final dir, atomically renamed on success, so a
+  // concurrent request in another process never streams a partial file.
+  const tmp = `${out}.${randomBytes(4).toString("hex")}.part`;
+  const args = [
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-y",
+    "-i",
+    assetBlobPath(sha256),
+    // First video + first audio track only: DVD VOBs carry alternate audio
+    // tracks and subpicture/nav streams a browser player has no UI for.
+    "-map",
+    "0:v:0",
+    "-map",
+    "0:a:0?",
+    "-dn",
+    "-sn",
+    // Deinterlace frames flagged interlaced (DVD content usually is), and
+    // keep dimensions even (4:2:0 H.264 rejects odd sizes).
+    "-vf",
+    "yadif=deint=interlaced,scale=trunc(iw/2)*2:trunc(ih/2)*2",
+    "-c:v",
+    "libx264",
+    "-preset",
+    "veryfast",
+    "-crf",
+    "23",
+    "-pix_fmt",
+    "yuv420p",
+    "-c:a",
+    "aac",
+    "-b:a",
+    "160k",
+    // moov atom up front so playback starts before the download completes.
+    "-movflags",
+    "+faststart",
+    "-f",
+    "mp4",
+    tmp,
+  ];
+  try {
+    await execFileP(FFMPEG_BIN, args, { timeout: FFMPEG_TIMEOUT_MS, maxBuffer: 4_000_000 });
+    if ((await stat(tmp)).size === 0) throw new Error("empty transcode");
+    await rename(tmp, out);
+    return out;
+  } catch (err) {
+    await rm(tmp, { force: true });
+    throw err;
+  }
+}

--- a/web/src/lib/ffmpeg.ts
+++ b/web/src/lib/ffmpeg.ts
@@ -1,8 +1,11 @@
 // ffmpeg-backed transcoding: MPEG-1/2 program streams (.mpg, DVD .vob) and
-// bare MPEG video elementary streams to H.264/AAC MP4, the one video format
-// every browser plays. Like Ghostscript in gs.ts, ffmpeg is a soft dependency:
-// feature-detected at runtime, and callers degrade (download-only viewer)
-// when it's missing.
+// bare MPEG video elementary streams to a format browsers actually play.
+// Like Ghostscript in gs.ts, ffmpeg is a soft dependency: feature-detected at
+// runtime, and callers degrade (download-only viewer) when it's missing.
+//
+// The output format follows what the ffmpeg build can encode: H.264/AAC MP4
+// (universal) when libx264 is present, else VP9/Opus WebM (all modern
+// browsers) for the distro builds that omit GPL components.
 //
 // Unlike the PNG conversions, a transcode is too slow to redo per request, so
 // results are cached in the blob store under .transcode/ (which can't collide
@@ -20,55 +23,99 @@ const execFileP = promisify(execFile);
 const FFMPEG_BIN = process.env.FFMPEG_BIN || "ffmpeg";
 
 // Inputs are capped by the analyzer (viewable.py MAX_ASSET_SIZE, 20MB), so a
-// transcode is bounded work, but MPEG-2 decode plus x264 on a modest server
-// can still take tens of seconds. Kill anything that runs away.
+// transcode is bounded work, but MPEG-2 decode plus encoding on a modest
+// server can still take tens of seconds. Kill anything that runs away.
 const FFMPEG_TIMEOUT_MS = 120_000;
 
-/** Mimes ensureMp4 can transcode. */
-export function mp4Transcodable(mime: string): boolean {
+/** Mimes ensureTranscode can convert. */
+export function transcodable(mime: string): boolean {
   return mime === "video/mpeg";
 }
 
-// Feature detection, memoized for the process lifetime.
-let available: Promise<boolean> | null = null;
-
-export function ffmpegAvailable(): Promise<boolean> {
-  available ??= execFileP(FFMPEG_BIN, ["-version"], { timeout: 5_000 })
-    .then(({ stdout }) => /^ffmpeg version/i.test(stdout))
-    .catch(() => false);
-  return available;
+export interface TranscodeProfile {
+  mime: "video/mp4" | "video/webm";
+  ext: ".mp4" | ".webm";
+  args: string[];
 }
 
-/** Where a blob's cached MP4 transcode lives. Caller must have validated `sha256`. */
-export function transcodePath(sha256: string): string {
-  return join(assetStoreDir(), ".transcode", `${sha256}.mp4`);
+const MP4_PROFILE: TranscodeProfile = {
+  mime: "video/mp4",
+  ext: ".mp4",
+  args: [
+    "-c:v", "libx264", "-preset", "veryfast", "-crf", "23", "-pix_fmt", "yuv420p",
+    "-c:a", "aac", "-b:a", "160k",
+    // moov atom up front so playback starts before the download completes.
+    "-movflags", "+faststart",
+    "-f", "mp4",
+  ],
+};
+
+const WEBM_PROFILE: TranscodeProfile = {
+  mime: "video/webm",
+  ext: ".webm",
+  args: [
+    "-c:v", "libvpx-vp9", "-crf", "34", "-b:v", "0", "-deadline", "good",
+    "-cpu-used", "4", "-row-mt", "1", "-pix_fmt", "yuv420p",
+    "-c:a", "libopus", "-b:a", "128k",
+    "-f", "webm",
+  ],
+};
+
+/** The output profile this `ffmpeg -encoders` listing supports, else null. */
+export function detectProfile(encoders: string): TranscodeProfile | null {
+  if (/^\s*V\S*\s+libx264\s/m.test(encoders)) return MP4_PROFILE;
+  if (/^\s*V\S*\s+libvpx-vp9\s/m.test(encoders) && /^\s*A\S*\s+libopus\s/m.test(encoders)) {
+    return WEBM_PROFILE;
+  }
+  return null;
+}
+
+// Feature detection, memoized for the process lifetime. A missing binary and
+// a binary without a usable encoder pair degrade the same way.
+let profile: Promise<TranscodeProfile | null> | null = null;
+
+export function transcodeProfile(): Promise<TranscodeProfile | null> {
+  profile ??= execFileP(FFMPEG_BIN, ["-hide_banner", "-encoders"], { timeout: 5_000 })
+    .then(({ stdout }) => detectProfile(stdout))
+    .catch(() => null);
+  return profile;
+}
+
+/** Where a blob's cached transcode lives. Caller must have validated `sha256`. */
+export function transcodePath(sha256: string, ext: string): string {
+  return join(assetStoreDir(), ".transcode", `${sha256}${ext}`);
 }
 
 // One transcode per blob at a time: a gallery of players can fire several
 // requests for the same asset before the first transcode finishes.
-const inFlight = new Map<string, Promise<string>>();
+const inFlight = new Map<string, Promise<{ path: string; mime: string }>>();
 
 /**
- * Path of the cached MP4 transcode for this blob, producing it on first use.
+ * The cached browser-playable transcode for this blob, produced on first use.
  * Throws when ffmpeg is missing, errors on the input, or times out.
  */
-export async function ensureMp4(sha256: string): Promise<string> {
-  const out = transcodePath(sha256);
+export async function ensureTranscode(sha256: string): Promise<{ path: string; mime: string }> {
+  const p = await transcodeProfile();
+  if (!p) throw new Error("ffmpeg not available");
+  const out = transcodePath(sha256, p.ext);
   try {
-    if ((await stat(out)).size > 0) return out;
+    if ((await stat(out)).size > 0) return { path: out, mime: p.mime };
   } catch {
     // Not cached yet.
   }
   let job = inFlight.get(sha256);
   if (!job) {
-    job = transcode(sha256, out).finally(() => inFlight.delete(sha256));
+    job = transcode(sha256, out, p).finally(() => inFlight.delete(sha256));
     inFlight.set(sha256, job);
   }
   return job;
 }
 
-async function transcode(sha256: string, out: string): Promise<string> {
-  if (!(await ffmpegAvailable())) throw new Error("ffmpeg not available");
+async function transcode(
+  sha256: string,
+  out: string,
+  p: TranscodeProfile
+): Promise<{ path: string; mime: string }> {
   await mkdir(dirname(out), { recursive: true });
   // Private temp name in the final dir, atomically renamed on success, so a
   // concurrent request in another process never streams a partial file.
@@ -89,33 +136,17 @@ async function transcode(sha256: string, out: string): Promise<string> {
     "-dn",
     "-sn",
     // Deinterlace frames flagged interlaced (DVD content usually is), and
-    // keep dimensions even (4:2:0 H.264 rejects odd sizes).
+    // keep dimensions even (4:2:0 encoders reject odd sizes).
     "-vf",
     "yadif=deint=interlaced,scale=trunc(iw/2)*2:trunc(ih/2)*2",
-    "-c:v",
-    "libx264",
-    "-preset",
-    "veryfast",
-    "-crf",
-    "23",
-    "-pix_fmt",
-    "yuv420p",
-    "-c:a",
-    "aac",
-    "-b:a",
-    "160k",
-    // moov atom up front so playback starts before the download completes.
-    "-movflags",
-    "+faststart",
-    "-f",
-    "mp4",
+    ...p.args,
     tmp,
   ];
   try {
     await execFileP(FFMPEG_BIN, args, { timeout: FFMPEG_TIMEOUT_MS, maxBuffer: 4_000_000 });
     if ((await stat(tmp)).size === 0) throw new Error("empty transcode");
     await rename(tmp, out);
-    return out;
+    return { path: out, mime: p.mime };
   } catch (err) {
     await rm(tmp, { force: true });
     throw err;

--- a/web/src/lib/range.ts
+++ b/web/src/lib/range.ts
@@ -1,0 +1,14 @@
+// HTTP Range parsing shared by the routes that stream media off disk
+// (the raw asset route and the MP4 transcode route).
+
+/** One satisfiable `bytes=start-end` range, else null (serve the whole file). */
+export function parseRange(header: string | null, size: number): { start: number; end: number } | null {
+  const m = header?.match(/^bytes=(\d*)-(\d*)$/);
+  if (!m || size === 0) return null;
+  const [, a, b] = m;
+  if (a === "" && b === "") return null;
+  const start = a === "" ? Math.max(0, size - Number(b)) : Number(a);
+  const end = a !== "" && b !== "" ? Math.min(Number(b), size - 1) : size - 1;
+  if (start > end || start >= size) return null;
+  return { start, end };
+}

--- a/web/tests/ffmpeg.test.ts
+++ b/web/tests/ffmpeg.test.ts
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { assetBlobPath } from "../src/lib/assets";
+import { ensureMp4, ffmpegAvailable, mp4Transcodable, transcodePath } from "../src/lib/ffmpeg";
+
+const execFileP = promisify(execFile);
+
+// Transcode tests need real ffmpeg and skip without it (set FFMPEG_BIN when
+// `ffmpeg` isn't on PATH).
+
+test("mp4Transcodable covers exactly the MPEG program-stream mime", () => {
+  assert.equal(mp4Transcodable("video/mpeg"), true);
+  assert.equal(mp4Transcodable("video/mp4"), false);
+  assert.equal(mp4Transcodable("video/webm"), false);
+  assert.equal(mp4Transcodable("audio/mpeg"), false);
+});
+
+// The store dir is read per call, so pointing the env at a temp dir scopes
+// every blob/transcode path in this file to it.
+async function tempStore(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "ffmpeg-test-"));
+  process.env.ASSET_STORE_DIR = dir;
+  return dir;
+}
+
+/** Drop `bytes` into the store as blob `sha` (any 64-hex name will do). */
+async function putBlob(sha: string, bytes: Buffer): Promise<void> {
+  const blob = assetBlobPath(sha);
+  await mkdir(dirname(blob), { recursive: true });
+  await writeFile(blob, bytes);
+}
+
+/** A 1s 64x48 MPEG-2 program stream with MP2 audio, VOB-shaped content. */
+async function mpegFixture(dir: string): Promise<Buffer> {
+  const out = join(dir, "fixture.mpg");
+  await execFileP(process.env.FFMPEG_BIN || "ffmpeg", [
+    "-hide_banner", "-loglevel", "error", "-y",
+    "-f", "lavfi", "-i", "testsrc=duration=1:size=64x48:rate=10",
+    "-f", "lavfi", "-i", "sine=frequency=440:duration=1",
+    "-c:v", "mpeg2video", "-c:a", "mp2", "-f", "mpeg",
+    out,
+  ]);
+  return readFile(out);
+}
+
+test("ensureMp4 transcodes an MPEG-PS blob and caches the result", async (t) => {
+  if (!(await ffmpegAvailable())) return t.skip("ffmpeg not installed");
+  const dir = await tempStore();
+  try {
+    const sha = "aa".repeat(32);
+    const mpeg = await mpegFixture(dir);
+    // The fixture must open on the pack start code viewable.py sniffs for.
+    assert.deepEqual([...mpeg.subarray(0, 4)], [0x00, 0x00, 0x01, 0xba]);
+    await putBlob(sha, mpeg);
+
+    const out = await ensureMp4(sha);
+    assert.equal(out, transcodePath(sha));
+    const mp4 = await readFile(out);
+    assert.equal(mp4.subarray(4, 8).toString("latin1"), "ftyp");
+    // faststart must have moved the moov atom ahead of the media data.
+    assert.ok(mp4.indexOf("moov") < mp4.indexOf("mdat"), "moov after mdat");
+
+    // Second call serves the cache, so the file must not be rewritten.
+    const before = (await stat(out)).mtimeMs;
+    assert.equal(await ensureMp4(sha), out);
+    assert.equal((await stat(out)).mtimeMs, before);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureMp4 rejects junk that is not a video stream", async (t) => {
+  if (!(await ffmpegAvailable())) return t.skip("ffmpeg not installed");
+  const dir = await tempStore();
+  try {
+    const sha = "bb".repeat(32);
+    await putBlob(sha, Buffer.from("\x00\x00\x01\xbanot really mpeg data", "latin1"));
+    await assert.rejects(ensureMp4(sha));
+    // A failed transcode must leave no cached output (or stray .part files).
+    await assert.rejects(stat(transcodePath(sha)));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureMp4 rejects a blob missing from the store", async (t) => {
+  if (!(await ffmpegAvailable())) return t.skip("ffmpeg not installed");
+  const dir = await tempStore();
+  try {
+    await assert.rejects(ensureMp4("cc".repeat(32)));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/web/tests/ffmpeg.test.ts
+++ b/web/tests/ffmpeg.test.ts
@@ -6,18 +6,41 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { assetBlobPath } from "../src/lib/assets";
-import { ensureMp4, ffmpegAvailable, mp4Transcodable, transcodePath } from "../src/lib/ffmpeg";
+import {
+  detectProfile,
+  ensureTranscode,
+  transcodable,
+  transcodePath,
+  transcodeProfile,
+} from "../src/lib/ffmpeg";
 
 const execFileP = promisify(execFile);
 
 // Transcode tests need real ffmpeg and skip without it (set FFMPEG_BIN when
 // `ffmpeg` isn't on PATH).
 
-test("mp4Transcodable covers exactly the MPEG program-stream mime", () => {
-  assert.equal(mp4Transcodable("video/mpeg"), true);
-  assert.equal(mp4Transcodable("video/mp4"), false);
-  assert.equal(mp4Transcodable("video/webm"), false);
-  assert.equal(mp4Transcodable("audio/mpeg"), false);
+test("transcodable covers exactly the MPEG program-stream mime", () => {
+  assert.equal(transcodable("video/mpeg"), true);
+  assert.equal(transcodable("video/mp4"), false);
+  assert.equal(transcodable("video/webm"), false);
+  assert.equal(transcodable("audio/mpeg"), false);
+});
+
+// Encoder listings in `ffmpeg -encoders` format: flags column, name, blurb.
+const X264_LINE = " V....D libx264              libx264 H.264 / AVC (codec h264)\n";
+const VP9_LINE = " V....D libvpx-vp9           libvpx VP9 (codec vp9)\n";
+const OPUS_LINE = " A....D libopus              libopus Opus (codec opus)\n";
+const AAC_LINE = " A....D aac                  AAC (Advanced Audio Coding)\n";
+
+test("detectProfile prefers H.264 MP4 and falls back to VP9 WebM", () => {
+  assert.equal(detectProfile(X264_LINE + VP9_LINE + OPUS_LINE + AAC_LINE)?.mime, "video/mp4");
+  // A GPL-less distro build: no libx264, but libvpx + libopus present.
+  assert.equal(detectProfile(VP9_LINE + OPUS_LINE + AAC_LINE)?.mime, "video/webm");
+  // No usable encoder pair at all.
+  assert.equal(detectProfile(AAC_LINE), null);
+  assert.equal(detectProfile(VP9_LINE + AAC_LINE), null);
+  // The name must match whole, not as a prefix of something else.
+  assert.equal(detectProfile(" V....D libx264rgb           libx264 RGB (codec h264)\n"), null);
 });
 
 // The store dir is read per call, so pointing the env at a temp dir scopes
@@ -48,8 +71,9 @@ async function mpegFixture(dir: string): Promise<Buffer> {
   return readFile(out);
 }
 
-test("ensureMp4 transcodes an MPEG-PS blob and caches the result", async (t) => {
-  if (!(await ffmpegAvailable())) return t.skip("ffmpeg not installed");
+test("ensureTranscode converts an MPEG-PS blob and caches the result", async (t) => {
+  const profile = await transcodeProfile();
+  if (!profile) return t.skip("ffmpeg not installed");
   const dir = await tempStore();
   try {
     const sha = "aa".repeat(32);
@@ -58,41 +82,48 @@ test("ensureMp4 transcodes an MPEG-PS blob and caches the result", async (t) => 
     assert.deepEqual([...mpeg.subarray(0, 4)], [0x00, 0x00, 0x01, 0xba]);
     await putBlob(sha, mpeg);
 
-    const out = await ensureMp4(sha);
-    assert.equal(out, transcodePath(sha));
-    const mp4 = await readFile(out);
-    assert.equal(mp4.subarray(4, 8).toString("latin1"), "ftyp");
-    // faststart must have moved the moov atom ahead of the media data.
-    assert.ok(mp4.indexOf("moov") < mp4.indexOf("mdat"), "moov after mdat");
+    const video = await ensureTranscode(sha);
+    assert.equal(video.path, transcodePath(sha, profile.ext));
+    assert.equal(video.mime, profile.mime);
+    const bytes = await readFile(video.path);
+    if (profile.mime === "video/mp4") {
+      assert.equal(bytes.subarray(4, 8).toString("latin1"), "ftyp");
+      // faststart must have moved the moov atom ahead of the media data.
+      assert.ok(bytes.indexOf("moov") < bytes.indexOf("mdat"), "moov after mdat");
+    } else {
+      // EBML header opens every WebM file.
+      assert.deepEqual([...bytes.subarray(0, 4)], [0x1a, 0x45, 0xdf, 0xa3]);
+    }
 
     // Second call serves the cache, so the file must not be rewritten.
-    const before = (await stat(out)).mtimeMs;
-    assert.equal(await ensureMp4(sha), out);
-    assert.equal((await stat(out)).mtimeMs, before);
+    const before = (await stat(video.path)).mtimeMs;
+    assert.equal((await ensureTranscode(sha)).path, video.path);
+    assert.equal((await stat(video.path)).mtimeMs, before);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
 });
 
-test("ensureMp4 rejects junk that is not a video stream", async (t) => {
-  if (!(await ffmpegAvailable())) return t.skip("ffmpeg not installed");
+test("ensureTranscode rejects junk that is not a video stream", async (t) => {
+  const profile = await transcodeProfile();
+  if (!profile) return t.skip("ffmpeg not installed");
   const dir = await tempStore();
   try {
     const sha = "bb".repeat(32);
     await putBlob(sha, Buffer.from("\x00\x00\x01\xbanot really mpeg data", "latin1"));
-    await assert.rejects(ensureMp4(sha));
+    await assert.rejects(ensureTranscode(sha));
     // A failed transcode must leave no cached output (or stray .part files).
-    await assert.rejects(stat(transcodePath(sha)));
+    await assert.rejects(stat(transcodePath(sha, profile.ext)));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
 });
 
-test("ensureMp4 rejects a blob missing from the store", async (t) => {
-  if (!(await ffmpegAvailable())) return t.skip("ffmpeg not installed");
+test("ensureTranscode rejects a blob missing from the store", async (t) => {
+  if (!(await transcodeProfile())) return t.skip("ffmpeg not installed");
   const dir = await tempStore();
   try {
-    await assert.rejects(ensureMp4("cc".repeat(32)));
+    await assert.rejects(ensureTranscode("cc".repeat(32)));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Classifies .mpg, .mpeg, .m1v, .m2v, and .vob files as video assets and plays them in the web viewer. Browsers can't play MPEG program streams natively, so a new /api/asset/<sha>/mp4 route transcodes them to H.264/AAC MP4 with ffmpeg, cached on disk and served with Range support.

Like Ghostscript, ffmpeg is a soft dependency (FFMPEG_BIN, feature-detected) and the viewer degrades to a download card without it. hpwiki needs an ffmpeg install before transcoding works in production, and existing collections need re-analysis to pick up the new extensions.