### PR TITLE
Link gallery media names to viewer

### DIFF
--- a/web/src/app/builds/[buildId]/AssetGallery.tsx
+++ b/web/src/app/builds/[buildId]/AssetGallery.tsx
@@ -6,8 +6,9 @@
 // for unidentified files' head snippets. The server page passes an
 // already-capped subset plus the full per-kind totals; when a kind is
 // truncated, a "view all" affordance links to <buildHref>/assets.
-// Images and text open the page's AssetViewerHost lightbox (shared with the
-// file tree), which also deep-links the asset in the URL.
+// Cards open the page's AssetViewerHost lightbox (shared with the file tree),
+// which deep-links the asset in the URL; audio and video play inline, so for
+// those it's the filename that opens the viewer.
 
 import Link from "next/link";
 import { assetUrl, humanSize, imageSrc, videoSrc, type ViewableAsset } from "./AssetViewer";
@@ -98,14 +99,21 @@ export default function AssetGallery({
             {kind === "video" && (
               <div className="mt-2 flex flex-wrap gap-2">
                 {group.map((a) => (
-                  <video
+                  <div
                     key={a.path}
-                    controls
-                    preload="none"
-                    src={videoSrc(a)}
-                    title={a.path}
-                    className="h-36 rounded border border-neutral-200 dark:border-neutral-800"
-                  />
+                    className="flex flex-col overflow-hidden rounded border border-neutral-200 dark:border-neutral-800"
+                  >
+                    <video controls preload="none" src={videoSrc(a)} title={a.path} className="h-36" />
+                    {/* w-0 min-w-full: the caption follows the player's width
+                        instead of stretching the card to the filename's. */}
+                    <button
+                      onClick={() => open(a)}
+                      title={a.path}
+                      className="w-0 min-w-full truncate px-2 py-1 text-left font-mono text-[11px] text-sky-700 hover:underline dark:text-sky-400"
+                    >
+                      {baseName(a.path)}
+                    </button>
+                  </div>
                 ))}
               </div>
             )}

--- a/web/src/app/builds/[buildId]/AudioEmbed.tsx
+++ b/web/src/app/builds/[buildId]/AudioEmbed.tsx
@@ -10,6 +10,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { assetUrl, humanSize, type ViewableAsset } from "./AssetViewer";
+import { useOpenAsset } from "./AssetViewerHost";
 
 const BARS = 160;
 // Auto-decode on scroll-into-view only below this size, so a page of embeds
@@ -51,6 +52,7 @@ function fmtTime(s: number): string {
 
 export default function AudioEmbed({ asset }: { asset: ViewableAsset }) {
   const url = assetUrl(asset);
+  const openAsset = useOpenAsset();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -209,9 +211,15 @@ export default function AudioEmbed({ asset }: { asset: ViewableAsset }) {
       </button>
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline justify-between gap-2 text-[11px]">
-          <span className="truncate font-mono text-neutral-600 dark:text-neutral-300" title={asset.path}>
+          {/* The name deep-links the asset in the viewer; the embed itself
+              stays play/seek only. */}
+          <button
+            onClick={() => openAsset(asset.path)}
+            title={asset.path}
+            className="truncate font-mono text-neutral-600 hover:text-sky-700 hover:underline dark:text-neutral-300 dark:hover:text-sky-400"
+          >
             {name}
-          </span>
+          </button>
           <span className="shrink-0 tabular-nums text-neutral-400">
             {failed
               ? "playback failed"


### PR DESCRIPTION
Audio and video embeds in the build gallery had no way into the asset viewer, they only play inline. Clicking the filename now opens the lightbox at the asset's own /builds/id/assets/path URL, matching how images and documents already behave.

Video embeds gain a caption bar under the player and the audio embed's name gets link hover styling. The players themselves are unchanged and still play inline.