### PR TITLE
Large video assets and poster thumbnails

### DIFF
--- a/crates/curator-core/src/schema.rs
+++ b/crates/curator-core/src/schema.rs
@@ -15,9 +15,11 @@ pub const FINGERPRINT_PROFILE: &str = "v1";
 /// records that predate the field, which deserialize to 0); 2 = also head
 /// snippets (`kind: "binary"`) for every file that isn't viewable; 3 = TGA
 /// classified as an image (previously a head snippet); 4 = TIFF likewise;
-/// 5 = PDF and PostScript (.eps/.ps/.ai) as `kind: "document"`. A record
-/// below the current value gets its assets re-extracted on the next analyze.
-pub const ASSET_PROFILE: u32 = 5;
+/// 5 = PDF and PostScript (.eps/.ps/.ai) as `kind: "document"`; 6 = videos
+/// ship whole up to DVD-VOB scale (previously capped with everything else at
+/// 20MB). A record below the current value gets its assets re-extracted on
+/// the next analyze.
+pub const ASSET_PROFILE: u32 = 6;
 
 /// A fully analyzed disc image / container — image-independent and self-describing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,9 +46,10 @@ pub struct BuildRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resemblance: Option<Signature>,
     /// Files extracted into the asset store: browser-viewable ones whole
-    /// (images, audio, text ≤ 20MB), everything else as a raw head snippet for
-    /// the hex view. `None` = extraction never ran (pre-assets record — analyze
-    /// tops it up on the next cache hit); `Some(vec![])` = ran, nothing kept.
+    /// (images, audio, text ≤ 20MB; videos up to DVD-VOB scale), everything
+    /// else as a raw head snippet for the hex view. `None` = extraction never
+    /// ran (pre-assets record — analyze tops it up on the next cache hit);
+    /// `Some(vec![])` = ran, nothing kept.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assets: Option<Vec<AssetRef>>,
     /// [`ASSET_PROFILE`] the assets were extracted under; analyze re-extracts

--- a/ps2exe-adapter/curator_adapter/cli.py
+++ b/ps2exe-adapter/curator_adapter/cli.py
@@ -744,27 +744,41 @@ def _extract_assets(reader, out_dir, manager):
         if size == 0:
             continue
         classified = viewable.classify(path)
-        if classified is not None and size is not None and size > viewable.MAX_ASSET_SIZE:
+        if classified is not None and size is not None and size > viewable.max_size(classified[0]):
             classified = None  # too big to serve whole — keep the head snippet only
-        entries.append((f, path, classified))
+        entries.append((f, path, size, classified))
 
     out = []
     with manager.counter(total=len(entries), desc="Extracting assets", unit="files") as pbar:
-        for f, path, classified in entries:
+        for f, path, size, classified in entries:
             if classified is None:
                 head = _read_head(reader, f, viewable.SNIPPET_BYTES)
                 asset = (head, viewable.SNIPPET_MIME, viewable.SNIPPET_KIND) if head else None
             else:
                 kind, mime = classified
-                data = _read_capped(reader, f, viewable.MAX_ASSET_SIZE)
-                if data and viewable.sniff(data[: viewable.SNIFF_BYTES], mime):
-                    asset = (data, mime, kind)
-                elif data:
-                    # Extension claimed a viewable type but the bytes disagree —
-                    # keep the head snippet, same as any unidentified file.
-                    asset = (data[: viewable.SNIPPET_BYTES], viewable.SNIPPET_MIME, viewable.SNIPPET_KIND)
+                if size is not None and size > viewable.MAX_ASSET_SIZE:
+                    # Too big to buffer (a large video — max_size() demoted every
+                    # other kind above): stream it into the store while hashing.
+                    streamed = _stream_to_store(reader, f, out_dir, mime, viewable.max_size(kind))
+                    if streamed is not None and streamed[0] == "stored":
+                        _, sha, n = streamed
+                        out.append({"path": path, "sha256": sha, "size": n, "mime": mime, "kind": kind})
+                        pbar.update()
+                        continue
+                    if streamed is not None:  # ("mismatch", head)
+                        asset = (streamed[1][: viewable.SNIPPET_BYTES], viewable.SNIPPET_MIME, viewable.SNIPPET_KIND)
+                    else:
+                        asset = None
                 else:
-                    asset = None
+                    data = _read_capped(reader, f, viewable.MAX_ASSET_SIZE)
+                    if data and viewable.sniff(data[: viewable.SNIFF_BYTES], mime):
+                        asset = (data, mime, kind)
+                    elif data:
+                        # Extension claimed a viewable type but the bytes disagree —
+                        # keep the head snippet, same as any unidentified file.
+                        asset = (data[: viewable.SNIPPET_BYTES], viewable.SNIPPET_MIME, viewable.SNIPPET_KIND)
+                    else:
+                        asset = None
             pbar.update()
             if asset is None:
                 continue
@@ -796,6 +810,56 @@ def _read_capped(reader, f, cap):
         logging.getLogger("curator-adapter").debug("asset read failed: %s", e)
         return None
     return bytes(buf)
+
+
+def _stream_to_store(reader, f, out_dir, mime, cap):
+    """Stream a large classified file into the store without buffering it:
+    sniff the head, then hash while spooling to a temp file renamed into its
+    content address. Returns ("stored", sha256, size); ("mismatch", head) when
+    the leading bytes disagree with the claimed mime; or None when the file is
+    unreadable or overruns `cap` (a size the directory record understated must
+    not smuggle an oversized asset in)."""
+    from . import viewable
+
+    tmp = os.path.join(out_dir, f".stream{os.getpid()}.part")
+    digest = hashlib.sha256()
+    size = 0
+    try:
+        fh = reader.open_file(f)
+        is_ctx = hasattr(fh, "__enter__")
+        if is_ctx:
+            fh.__enter__()
+        try:
+            head = fh.read(viewable.SNIFF_BYTES)
+            if not head:
+                return None
+            if not viewable.sniff(head, mime):
+                return ("mismatch", head)
+            os.makedirs(out_dir, exist_ok=True)
+            with open(tmp, "wb") as spool:
+                chunk = head
+                while chunk:
+                    size += len(chunk)
+                    if size > cap:
+                        return None
+                    digest.update(chunk)
+                    spool.write(chunk)
+                    chunk = fh.read(1 << 20)
+        finally:
+            with contextlib.suppress(Exception):
+                fh.__exit__(None, None, None) if is_ctx else fh.close()
+        sha = digest.hexdigest()
+        final = os.path.join(out_dir, sha[:2], sha)
+        if not os.path.exists(final):
+            os.makedirs(os.path.dirname(final), exist_ok=True)
+            os.replace(tmp, final)
+        return ("stored", sha, size)
+    except Exception as e:  # noqa: BLE001
+        logging.getLogger("curator-adapter").debug("asset stream failed: %s", e)
+        return None
+    finally:
+        with contextlib.suppress(OSError):
+            os.remove(tmp)
 
 
 def _read_head(reader, f, n):

--- a/ps2exe-adapter/curator_adapter/viewable.py
+++ b/ps2exe-adapter/curator_adapter/viewable.py
@@ -9,6 +9,17 @@ can't script against the web origin.
 # Hard cap on extracted asset size. Files past this fall back to a head snippet.
 MAX_ASSET_SIZE = 20 * 1024 * 1024
 
+# Videos get a larger allowance: DVD-Video discs split a title into .VOB files
+# of up to 1 GiB each, and demoting those to head snippets would drop the only
+# viewable content such a disc carries. Files above MAX_ASSET_SIZE are streamed
+# into the store (see cli._stream_to_store), never buffered whole.
+MAX_VIDEO_SIZE = 1280 * 1024 * 1024
+
+
+def max_size(kind):
+    """Per-kind cap on shipping a file whole into the asset store."""
+    return MAX_VIDEO_SIZE if kind == "video" else MAX_ASSET_SIZE
+
 # How many leading bytes sniffing needs (SVG tag scan is the long pole).
 SNIFF_BYTES = 4096
 

--- a/ps2exe-adapter/tests/test_assets.py
+++ b/ps2exe-adapter/tests/test_assets.py
@@ -118,5 +118,54 @@ def test_oversized_viewable_demoted_to_snippet(tmp_path, monkeypatch):
     assert blob(tmp_path, a["sha256"]) == png[: viewable.SNIPPET_BYTES]
 
 
+# MPEG program-stream pack start code — what viewable.py sniffs video/mpeg by.
+MPEG_PS = b"\x00\x00\x01\xba" + bytes(range(256)) * 40  # ~10KB
+
+
+def test_video_above_buffer_cap_streams_whole(tmp_path, monkeypatch):
+    # Past MAX_ASSET_SIZE a video takes the streaming path; it must still land
+    # in the store whole, under its full-content hash, with no temp left over.
+    monkeypatch.setattr(viewable, "MAX_ASSET_SIZE", 1024)
+    assets = extract({"/VIDEO_TS/VTS_01_1.VOB": MPEG_PS}, tmp_path)
+    a = assets["/VIDEO_TS/VTS_01_1.VOB"]
+    assert (a["kind"], a["mime"], a["size"]) == ("video", "video/mpeg", len(MPEG_PS))
+    assert a["sha256"] == hashlib.sha256(MPEG_PS).hexdigest()
+    assert blob(tmp_path, a["sha256"]) == MPEG_PS
+    assert not list(tmp_path.glob("*.part"))
+
+
+def test_video_above_video_cap_demoted_to_snippet(tmp_path, monkeypatch):
+    monkeypatch.setattr(viewable, "MAX_VIDEO_SIZE", 1024)
+    assets = extract({"/VIDEO_TS/VTS_01_1.VOB": MPEG_PS}, tmp_path)
+    a = assets["/VIDEO_TS/VTS_01_1.VOB"]
+    assert a["kind"] == viewable.SNIPPET_KIND
+    assert blob(tmp_path, a["sha256"]) == MPEG_PS[: viewable.SNIPPET_BYTES]
+
+
+def test_streamed_sniff_mismatch_falls_back_to_snippet(tmp_path, monkeypatch):
+    monkeypatch.setattr(viewable, "MAX_ASSET_SIZE", 1024)
+    fake = b"not a program stream" * 600  # > MAX_ASSET_SIZE, wrong leading bytes
+    assets = extract({"/MOVIE.VOB": fake}, tmp_path)
+    a = assets["/MOVIE.VOB"]
+    assert a["kind"] == viewable.SNIPPET_KIND
+    assert blob(tmp_path, a["sha256"]) == fake[: viewable.SNIPPET_BYTES]
+    assert not list(tmp_path.glob("*.part"))
+
+
+def test_streamed_size_lie_is_dropped(tmp_path, monkeypatch):
+    # The directory record understates the size; the stream overruns the cap
+    # and the file must be dropped entirely, leaving no temp file behind.
+    monkeypatch.setattr(viewable, "MAX_ASSET_SIZE", 1024)
+    monkeypatch.setattr(viewable, "MAX_VIDEO_SIZE", 4096)
+
+    class LyingReader(FakeReader):
+        def get_file_size(self, f):
+            return 2048  # over MAX_ASSET_SIZE (streams), under MAX_VIDEO_SIZE
+
+    out = _extract_assets(LyingReader({"/MOVIE.VOB": MPEG_PS}), str(tmp_path), ProgressManager())
+    assert out == []
+    assert not list(tmp_path.glob("*.part"))
+
+
 def test_empty_files_are_skipped(tmp_path):
     assert extract({"/EMPTY.BIN": b""}, tmp_path) == {}

--- a/web/src/app/api/asset/[sha256]/thumb/route.ts
+++ b/web/src/app/api/asset/[sha256]/thumb/route.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { Readable } from "node:stream";
+import type { NextRequest } from "next/server";
+import { getPool } from "@/lib/db";
+import { ensureThumb } from "@/lib/ffmpeg";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// GET /api/asset/<sha256>/thumb — a poster still (JPEG) pulled out of a video
+// asset, for gallery cards and <video poster>. Produced by ffmpeg on first
+// use and cached in the store under .thumb/. The URL is content-addressed, so
+// responses cache hard; clients treat a failure (no ffmpeg on the server, or
+// a stream with no decodable frame) as "no poster" and degrade.
+
+const CACHE = "public, max-age=31536000, immutable";
+const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const r = await getPool().query(
+    "SELECT mime FROM build_asset WHERE sha256=$1 LIMIT 1",
+    [sha256]
+  );
+  const meta = r.rows[0] as { mime: string } | undefined;
+  if (!meta) return Response.json({ error: "not found" }, { status: 404 });
+  if (!meta.mime.startsWith("video/")) {
+    return Response.json({ error: `no thumbnail for ${meta.mime}` }, { status: 415 });
+  }
+
+  // The browser already holds an immutable copy: never re-send the bytes.
+  if (request.headers.get("if-none-match") === `"${sha256}-thumb"`) {
+    return new Response(null, {
+      status: 304,
+      headers: { "Cache-Control": CACHE, ETag: `"${sha256}-thumb"` },
+    });
+  }
+
+  let thumb: string;
+  try {
+    thumb = await ensureThumb(sha256);
+  } catch {
+    // No usable ffmpeg, blob missing from the store, or no decodable frame.
+    return Response.json({ error: "no thumbnail" }, { status: 415 });
+  }
+  const stat = await fsp.stat(thumb);
+  const stream = fs.createReadStream(thumb);
+  return new Response(Readable.toWeb(stream) as ReadableStream, {
+    status: 200,
+    headers: {
+      "Content-Type": "image/jpeg",
+      "Content-Length": String(stat.size),
+      "Cache-Control": CACHE,
+      ETag: `"${sha256}-thumb"`,
+      "X-Content-Type-Options": "nosniff",
+      "Content-Security-Policy": CSP,
+    },
+  });
+}

--- a/web/src/app/api/asset/[sha256]/video/route.ts
+++ b/web/src/app/api/asset/[sha256]/video/route.ts
@@ -16,9 +16,17 @@ export const runtime = "nodejs";
 // asset route. The transcode is produced once, cached on disk, and streamed
 // with Range support so the player can seek. The URL is content-addressed, so
 // responses cache hard.
+//
+// Small inputs finish within the soft wait and stream from this same request.
+// A DVD-sized input keeps transcoding in the background while this request
+// answers 202 — the client polls ./video/status and comes back when ready.
 
 const CACHE = "public, max-age=31536000, immutable";
 const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+
+// How long one request holds on for a transcode before handing off to the
+// status-poll flow. Long enough for the short clips that dominate the corpus.
+const SOFT_WAIT_MS = 25_000;
 
 export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
   const { sha256 } = await ctx.params;
@@ -48,7 +56,21 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
 
   let video: { path: string; mime: string };
   try {
-    video = await ensureTranscode(sha256);
+    const job = ensureTranscode(sha256);
+    const soft = await Promise.race([
+      job,
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), SOFT_WAIT_MS).unref?.()),
+    ]);
+    if (soft === null) {
+      // Still transcoding — it finishes in the background (the eventual
+      // rejection, if any, surfaces through the status probe, not here).
+      job.catch(() => {});
+      return Response.json(
+        { state: "transcoding" },
+        { status: 202, headers: { "Cache-Control": "no-store" } }
+      );
+    }
+    video = soft;
   } catch {
     // No usable ffmpeg, blob missing from the store, or ffmpeg rejected or
     // timed out on the input.

--- a/web/src/app/api/asset/[sha256]/video/status/route.ts
+++ b/web/src/app/api/asset/[sha256]/video/status/route.ts
@@ -1,0 +1,42 @@
+import { getPool } from "@/lib/db";
+import { ensureTranscode, transcodable, transcodeStatus } from "@/lib/ffmpeg";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// GET /api/asset/<sha256>/video/status — where this asset's transcode stands:
+// {state: "ready" | "transcoding" | "failed"}, with a best-effort integer
+// `percent` while transcoding. The player polls this after ../video answers
+// 202 (or after a server restart orphaned its wait). When nothing is running
+// or cached, this kicks the transcode off — the poll loop stays a plain
+// repeat-until-ready on one URL.
+
+export async function GET(_request: Request, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const r = await getPool().query("SELECT mime FROM build_asset WHERE sha256=$1 LIMIT 1", [sha256]);
+  const meta = r.rows[0] as { mime: string } | undefined;
+  if (!meta) return Response.json({ error: "not found" }, { status: 404 });
+
+  const headers = { "Cache-Control": "no-store" };
+  // Natively playable formats have no transcode; the raw asset is the stream.
+  if (meta.mime === "video/mp4" || meta.mime === "video/webm") {
+    return Response.json({ state: "ready" }, { headers });
+  }
+  if (!transcodable(meta.mime)) {
+    return Response.json({ error: `no video transcode for ${meta.mime}` }, { status: 415 });
+  }
+
+  const status = await transcodeStatus(sha256);
+  if (status.state === "ready") return Response.json({ state: "ready" }, { headers });
+  if (status.state === "transcoding") {
+    return Response.json({ state: "transcoding", percent: status.percent }, { headers });
+  }
+  if (status.state === "failed") return Response.json({ state: "failed" }, { headers });
+
+  // Nothing cached, running, or failed — start it (a restart may have lost an
+  // in-flight job) and report the fresh run. Errors surface on later polls.
+  ensureTranscode(sha256).catch(() => {});
+  return Response.json({ state: "transcoding", percent: null }, { headers });
+}

--- a/web/src/app/builds/[buildId]/AssetGallery.tsx
+++ b/web/src/app/builds/[buildId]/AssetGallery.tsx
@@ -11,7 +11,7 @@
 // those it's the filename that opens the viewer.
 
 import Link from "next/link";
-import { assetUrl, humanSize, imageSrc, videoSrc, type ViewableAsset } from "./AssetViewer";
+import { assetUrl, humanSize, imageSrc, VideoPlayer, type ViewableAsset } from "./AssetViewer";
 import { useOpenAsset } from "./AssetViewerHost";
 import AudioEmbed from "./AudioEmbed";
 import SourceCode from "./SourceCode";
@@ -103,7 +103,7 @@ export default function AssetGallery({
                     key={a.path}
                     className="flex flex-col overflow-hidden rounded border border-neutral-200 dark:border-neutral-800"
                   >
-                    <video controls preload="none" src={videoSrc(a)} title={a.path} className="h-36" />
+                    <VideoPlayer asset={a} className="h-36" />
                     {/* w-0 min-w-full: the caption follows the player's width
                         instead of stretching the card to the filename's. */}
                     <button

--- a/web/src/app/builds/[buildId]/AssetViewer.tsx
+++ b/web/src/app/builds/[buildId]/AssetViewer.tsx
@@ -36,6 +36,11 @@ export function videoSrc(a: ViewableAsset): string {
   return a.mime === "video/mpeg" ? `${assetUrl(a)}/video` : assetUrl(a);
 }
 
+/** Poster still for a video asset (server-side ffmpeg frame grab). */
+export function videoThumbSrc(a: ViewableAsset): string {
+  return `${assetUrl(a)}/thumb`;
+}
+
 export function humanSize(bytes: number): string {
   const units = ["B", "KB", "MB", "GB", "TB"];
   let v = bytes;
@@ -149,18 +154,126 @@ function DownloadCard({ asset }: { asset: ViewableAsset }) {
   );
 }
 
-// MP4/WebM play natively. MPEG program streams go through the server's ffmpeg
-// transcode, which can be unavailable (no ffmpeg on the server) or fail on a
-// damaged stream, so fall back to a download card rather than an error.
-function VideoBody({ asset }: { asset: ViewableAsset }) {
-  const [failed, setFailed] = useState(false);
-  if (failed) return <DownloadCard asset={asset} />;
+// How often the player re-asks the server about an in-flight transcode.
+const TRANSCODE_POLL_MS = 4_000;
+
+/**
+ * Video player over an extracted asset, shared by the viewer body and the
+ * gallery cards. MP4/WebM play natively; MPEG program streams (.mpg, DVD
+ * .vob) go through the server's ffmpeg transcode, which for DVD-sized inputs
+ * may still be running when playback is first attempted — the player then
+ * polls ./video/status, showing progress over the poster still, and starts
+ * playback when the stream is ready. A transcode that is unavailable (no
+ * ffmpeg on the server) or fails renders `fallback` (a download affordance).
+ */
+export function VideoPlayer({
+  asset,
+  className,
+  fallback,
+}: {
+  asset: ViewableAsset;
+  className?: string;
+  fallback?: React.ReactNode;
+}) {
+  const [phase, setPhase] = useState<"player" | "preparing" | "failed">("player");
+  // Bumped when a finished transcode re-mounts the <video>, so play resumes
+  // by itself (the user already hit play once). Also the retry limiter: a
+  // second error after a "ready" means the stream really doesn't play here.
+  const [readyAt, setReadyAt] = useState(0);
+  const [percent, setPercent] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (phase !== "preparing") return;
+    let cancelled = false;
+    let timer: number | undefined;
+    const poll = async () => {
+      let state = "failed";
+      let pct: number | null = null;
+      try {
+        const res = await fetch(`${assetUrl(asset)}/video/status`, { cache: "no-store" });
+        if (res.ok) {
+          const s = (await res.json()) as { state: string; percent?: number | null };
+          state = s.state;
+          pct = typeof s.percent === "number" ? s.percent : null;
+        }
+      } catch {
+        // Network blip — poll again rather than giving up on a live transcode.
+        state = "transcoding";
+      }
+      if (cancelled) return;
+      if (state === "ready") {
+        setPhase("player");
+        setReadyAt((n) => n + 1);
+      } else if (state === "transcoding") {
+        setPercent(pct);
+        timer = window.setTimeout(poll, TRANSCODE_POLL_MS);
+      } else {
+        setPhase("failed");
+      }
+    };
+    poll();
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [phase, asset]);
+
+  if (phase === "failed") {
+    const name = asset.path.split("/").pop() || asset.path;
+    return (
+      fallback ?? (
+        <a
+          href={assetUrl(asset)}
+          download={name}
+          className={`flex min-w-[12rem] items-center justify-center bg-neutral-950 px-6 text-xs text-neutral-300 hover:text-white hover:underline ${className ?? ""}`}
+        >
+          No preview — download {name}
+        </a>
+      )
+    );
+  }
+  if (phase === "preparing") {
+    return (
+      <div className={`relative min-w-[16rem] overflow-hidden bg-neutral-950 ${className ?? ""}`}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={videoThumbSrc(asset)}
+          alt=""
+          className="h-full w-full object-contain opacity-40"
+          onError={(e) => (e.currentTarget.style.visibility = "hidden")}
+        />
+        <span className="absolute inset-0 flex animate-pulse items-center justify-center px-4 text-center text-xs text-neutral-200">
+          Preparing video…{percent != null ? ` ${percent}%` : ""}
+        </span>
+      </div>
+    );
+  }
   return (
     <video
+      key={readyAt}
       controls
+      preload="none"
+      autoPlay={readyAt > 0}
+      poster={videoThumbSrc(asset)}
       src={videoSrc(asset)}
+      title={asset.path}
+      className={className}
+      onError={() => {
+        if (asset.mime === "video/mpeg" && readyAt === 0) setPhase("preparing");
+        else setPhase("failed");
+      }}
+    />
+  );
+}
+
+// The lightbox body wrapping the shared player: failures fall back to a
+// download card rather than an error.
+function VideoBody({ asset }: { asset: ViewableAsset }) {
+  return (
+    <VideoPlayer
+      asset={asset}
       className="max-h-[75vh] max-w-[90vw] rounded"
-      onError={() => setFailed(true)}
+      fallback={<DownloadCard asset={asset} />}
     />
   );
 }

--- a/web/src/lib/ffmpeg.ts
+++ b/web/src/lib/ffmpeg.ts
@@ -5,15 +5,19 @@
 //
 // The output format follows what the ffmpeg build can encode: H.264/AAC MP4
 // (universal) when libx264 is present, else VP9/Opus WebM (all modern
-// browsers) for the distro builds that omit GPL components.
+// browsers) for the distro builds that omit GPL components. The cache lookup
+// accepts either extension regardless of the local profile, so a transcode
+// produced on a better-equipped machine and dropped into the store serves
+// as-is.
 //
 // Unlike the PNG conversions, a transcode is too slow to redo per request, so
 // results are cached in the blob store under .transcode/ (which can't collide
 // with the two-hex-char blob dirs) and streamed from disk with Range support.
+// Poster stills live under .thumb/ the same way.
 
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { mkdir, rename, rm, stat } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { assetBlobPath, assetStoreDir } from "./assets";
@@ -21,11 +25,25 @@ import { assetBlobPath, assetStoreDir } from "./assets";
 const execFileP = promisify(execFile);
 
 const FFMPEG_BIN = process.env.FFMPEG_BIN || "ffmpeg";
+// ffprobe normally ships beside ffmpeg; follow a custom FFMPEG_BIN's naming.
+const FFPROBE_BIN =
+  process.env.FFPROBE_BIN ||
+  (/ffmpeg[^/\\]*$/.test(FFMPEG_BIN) ? FFMPEG_BIN.replace(/ffmpeg([^/\\]*)$/, "ffprobe$1") : "ffprobe");
 
-// Inputs are capped by the analyzer (viewable.py MAX_ASSET_SIZE, 20MB), so a
-// transcode is bounded work, but MPEG-2 decode plus encoding on a modest
-// server can still take tens of seconds. Kill anything that runs away.
-const FFMPEG_TIMEOUT_MS = 120_000;
+// A 5MB trailer transcodes in seconds, a 1GiB DVD VOB is upward of an hour of
+// MPEG-2 decode + re-encode on a modest server — scale the kill switch with
+// the input instead of guessing one number for both.
+const TIMEOUT_BASE_MS = 120_000;
+const TIMEOUT_PER_MB_MS = 6_000;
+const TIMEOUT_MAX_MS = 6 * 3_600_000;
+
+function transcodeTimeoutMs(inputBytes: number): number {
+  return Math.min(TIMEOUT_BASE_MS + Math.ceil(inputBytes / 1e6) * TIMEOUT_PER_MB_MS, TIMEOUT_MAX_MS);
+}
+
+// A poster still decodes a few dozen frames even from a 1GiB input (the seek
+// is on the input side), so a flat timeout is enough.
+const THUMB_TIMEOUT_MS = 120_000;
 
 /** Mimes ensureTranscode can convert. */
 export function transcodable(mime: string): boolean {
@@ -86,37 +104,139 @@ export function transcodePath(sha256: string, ext: string): string {
   return join(assetStoreDir(), ".transcode", `${sha256}${ext}`);
 }
 
+/** Where a blob's cached poster still lives. Caller must have validated `sha256`. */
+export function thumbPath(sha256: string): string {
+  return join(assetStoreDir(), ".thumb", `${sha256}.jpg`);
+}
+
+async function nonEmpty(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).size > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** The cached transcode under either extension, no matter which profile this
+ *  server would pick — precomputed MP4s must serve from a VP9-only box. */
+async function cachedTranscode(sha256: string): Promise<{ path: string; mime: string } | null> {
+  const mp4 = transcodePath(sha256, ".mp4");
+  if (await nonEmpty(mp4)) return { path: mp4, mime: "video/mp4" };
+  const webm = transcodePath(sha256, ".webm");
+  if (await nonEmpty(webm)) return { path: webm, mime: "video/webm" };
+  return null;
+}
+
 // One transcode per blob at a time: a gallery of players can fire several
-// requests for the same asset before the first transcode finishes.
-const inFlight = new Map<string, Promise<{ path: string; mime: string }>>();
+// requests for the same asset before the first transcode finishes. The job
+// entry keeps what the status probe needs to report progress.
+interface Job {
+  promise: Promise<{ path: string; mime: string }>;
+  progressPath: string;
+  durationUs: number | null;
+}
+
+const inFlight = new Map<string, Job>();
+
+// Blobs whose last transcode attempt failed, so the status probe can answer
+// "failed" instead of letting a client poll forever. A fresh ensureTranscode
+// (a new playback attempt) clears the mark and retries.
+const failed = new Set<string>();
 
 /**
  * The cached browser-playable transcode for this blob, produced on first use.
  * Throws when ffmpeg is missing, errors on the input, or times out.
  */
 export async function ensureTranscode(sha256: string): Promise<{ path: string; mime: string }> {
+  const cached = await cachedTranscode(sha256);
+  if (cached) return cached;
+  const running = inFlight.get(sha256);
+  if (running) return running.promise;
+
   const p = await transcodeProfile();
-  if (!p) throw new Error("ffmpeg not available");
+  if (!p) {
+    failed.add(sha256); // let the status probe answer "failed", not "none" forever
+    throw new Error("ffmpeg not available");
+  }
+  failed.delete(sha256);
   const out = transcodePath(sha256, p.ext);
+  const job: Job = {
+    progressPath: `${out}.${randomBytes(4).toString("hex")}.progress`,
+    durationUs: null,
+    promise: undefined as unknown as Promise<{ path: string; mime: string }>,
+  };
+  job.promise = transcode(sha256, out, p, job)
+    .catch((err) => {
+      failed.add(sha256);
+      throw err;
+    })
+    .finally(() => {
+      inFlight.delete(sha256);
+      rm(job.progressPath, { force: true }).catch(() => {});
+    });
+  inFlight.set(sha256, job);
+  return job.promise;
+}
+
+/** Input duration in microseconds via ffprobe, or null (missing binary, or a
+ *  stream it can't put a duration on). Best-effort — only progress reporting
+ *  depends on it. */
+async function probeDurationUs(path: string): Promise<number | null> {
   try {
-    if ((await stat(out)).size > 0) return { path: out, mime: p.mime };
+    const { stdout } = await execFileP(
+      FFPROBE_BIN,
+      ["-v", "error", "-show_entries", "format=duration", "-of", "default=nw=1:nk=1", path],
+      { timeout: 15_000 }
+    );
+    const seconds = Number.parseFloat(stdout.trim());
+    return Number.isFinite(seconds) && seconds > 0 ? Math.round(seconds * 1e6) : null;
   } catch {
-    // Not cached yet.
+    return null;
   }
-  let job = inFlight.get(sha256);
-  if (!job) {
-    job = transcode(sha256, out, p).finally(() => inFlight.delete(sha256));
-    inFlight.set(sha256, job);
+}
+
+/** Percent complete of a running job, from ffmpeg's -progress file, or null
+ *  while it hasn't started writing (or the duration is unknown). */
+async function jobPercent(job: Job): Promise<number | null> {
+  if (!job.durationUs) return null;
+  let text: string;
+  try {
+    text = await readFile(job.progressPath, "utf8");
+  } catch {
+    return null;
   }
-  return job;
+  const matches = text.match(/^out_time_us=(\d+)$/gm);
+  if (!matches?.length) return null;
+  const outUs = Number(matches[matches.length - 1].slice("out_time_us=".length));
+  return Math.max(0, Math.min(99, Math.round((outUs / job.durationUs) * 100)));
+}
+
+export type TranscodeStatus =
+  | { state: "ready"; path: string; mime: string }
+  | { state: "transcoding"; percent: number | null }
+  | { state: "failed" }
+  | { state: "none" };
+
+/** Where this blob's transcode stands, without starting one. */
+export async function transcodeStatus(sha256: string): Promise<TranscodeStatus> {
+  const cached = await cachedTranscode(sha256);
+  if (cached) return { state: "ready", ...cached };
+  const running = inFlight.get(sha256);
+  if (running) return { state: "transcoding", percent: await jobPercent(running) };
+  if (failed.has(sha256)) return { state: "failed" };
+  return { state: "none" };
 }
 
 async function transcode(
   sha256: string,
   out: string,
-  p: TranscodeProfile
+  p: TranscodeProfile,
+  job: Job
 ): Promise<{ path: string; mime: string }> {
   await mkdir(dirname(out), { recursive: true });
+  const input = assetBlobPath(sha256);
+  const size = (await stat(input)).size;
+  job.durationUs = await probeDurationUs(input);
   // Private temp name in the final dir, atomically renamed on success, so a
   // concurrent request in another process never streams a partial file.
   const tmp = `${out}.${randomBytes(4).toString("hex")}.part`;
@@ -124,9 +244,11 @@ async function transcode(
     "-hide_banner",
     "-loglevel",
     "error",
+    "-progress",
+    job.progressPath,
     "-y",
     "-i",
-    assetBlobPath(sha256),
+    input,
     // First video + first audio track only: DVD VOBs carry alternate audio
     // tracks and subpicture/nav streams a browser player has no UI for.
     "-map",
@@ -143,12 +265,69 @@ async function transcode(
     tmp,
   ];
   try {
-    await execFileP(FFMPEG_BIN, args, { timeout: FFMPEG_TIMEOUT_MS, maxBuffer: 4_000_000 });
+    await execFileP(FFMPEG_BIN, args, { timeout: transcodeTimeoutMs(size), maxBuffer: 4_000_000 });
     if ((await stat(tmp)).size === 0) throw new Error("empty transcode");
     await rename(tmp, out);
     return { path: out, mime: p.mime };
   } catch (err) {
     await rm(tmp, { force: true });
     throw err;
+  }
+}
+
+// One thumbnail per blob at a time, same reason as transcodes.
+const thumbsInFlight = new Map<string, Promise<string>>();
+
+/**
+ * The cached poster still (JPEG) for this video blob, produced on first use.
+ * Works for every stored video format — the still needs only a decoder.
+ * Throws when ffmpeg is missing or can't find a frame.
+ */
+export async function ensureThumb(sha256: string): Promise<string> {
+  const out = thumbPath(sha256);
+  if (await nonEmpty(out)) return out;
+  let job = thumbsInFlight.get(sha256);
+  if (!job) {
+    job = thumb(sha256, out).finally(() => thumbsInFlight.delete(sha256));
+    thumbsInFlight.set(sha256, job);
+  }
+  return job;
+}
+
+async function thumb(sha256: string, out: string): Promise<string> {
+  await mkdir(dirname(out), { recursive: true });
+  const input = assetBlobPath(sha256);
+  await stat(input); // missing blob: fail before spawning ffmpeg
+  // A quarter in (bounded) skips studio logos and fade-ins; the thumbnail
+  // filter then picks the most representative of the next frames, dodging
+  // black frames around the seek point. Falls back to the very start for
+  // clips too short to seek into.
+  const durationUs = await probeDurationUs(input);
+  const seekSec = durationUs ? Math.min(Math.max((durationUs / 1e6) * 0.25, 1), 45) : 3;
+  const tmp = `${out}.${randomBytes(4).toString("hex")}.part`;
+  const argsAt = (seek: number) => [
+    "-hide_banner", "-loglevel", "error", "-y",
+    ...(seek > 0 ? ["-ss", String(seek)] : []),
+    "-i", input,
+    "-map", "0:v:0", "-dn", "-sn", "-an",
+    "-vf", "yadif=deint=interlaced,thumbnail=48,scale=trunc(min(iw\\,512)/2)*2:-2",
+    "-frames:v", "1", "-c:v", "mjpeg", "-q:v", "4", "-f", "image2",
+    tmp,
+  ];
+  try {
+    for (const seek of seekSec > 0 ? [seekSec, 0] : [0]) {
+      try {
+        await execFileP(FFMPEG_BIN, argsAt(seek), { timeout: THUMB_TIMEOUT_MS, maxBuffer: 4_000_000 });
+        if ((await stat(tmp)).size > 0) {
+          await rename(tmp, out);
+          return out;
+        }
+      } catch {
+        // Retry from the start (a clip shorter than the seek), then give up.
+      }
+    }
+    throw new Error("no frame extracted");
+  } finally {
+    await rm(tmp, { force: true });
   }
 }

--- a/web/src/lib/submission-assets.ts
+++ b/web/src/lib/submission-assets.ts
@@ -6,8 +6,14 @@ import type { Pool } from "pg";
 import type { AssetRef, BuildRecord } from "./types";
 import { isSha256 } from "./validate";
 
-/** Per-blob hard cap — mirrors MAX_ASSET_SIZE in the adapter's viewable.py. */
+/** Per-blob hard caps — mirror max_size() in the adapter's viewable.py:
+ *  videos ship whole up to DVD-VOB scale, everything else stays small. */
 export const MAX_ASSET_BLOB_BYTES = 20 * 1024 * 1024;
+export const MAX_VIDEO_BLOB_BYTES = 1280 * 1024 * 1024;
+
+function maxBlobBytes(kind: unknown): number {
+  return kind === "video" ? MAX_VIDEO_BLOB_BYTES : MAX_ASSET_BLOB_BYTES;
+}
 
 /** Cap on one build's summed (claimed) asset bytes; uploads past it refuse. */
 export const MAX_BUILD_ASSET_BYTES = 4 * 1024 * 1024 * 1024;
@@ -25,7 +31,7 @@ function collect(assets: AssetRef[] | null | undefined): ReferencedAssets {
   for (const a of assets ?? []) {
     if (!isSha256(a.sha256) || sizes.has(a.sha256)) continue;
     const size = Number(a.size);
-    if (!Number.isInteger(size) || size <= 0 || size > MAX_ASSET_BLOB_BYTES) continue;
+    if (!Number.isInteger(size) || size <= 0 || size > maxBlobBytes(a.kind)) continue;
     sizes.set(a.sha256, size);
     totalBytes += size;
   }

--- a/web/tests/ffmpeg.test.ts
+++ b/web/tests/ffmpeg.test.ts
@@ -8,10 +8,13 @@ import { promisify } from "node:util";
 import { assetBlobPath } from "../src/lib/assets";
 import {
   detectProfile,
+  ensureThumb,
   ensureTranscode,
+  thumbPath,
   transcodable,
   transcodePath,
   transcodeProfile,
+  transcodeStatus,
 } from "../src/lib/ffmpeg";
 
 const execFileP = promisify(execFile);
@@ -124,6 +127,77 @@ test("ensureTranscode rejects a blob missing from the store", async (t) => {
   const dir = await tempStore();
   try {
     await assert.rejects(ensureTranscode("cc".repeat(32)));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureTranscode serves a precomputed transcode of either extension", async (t) => {
+  const profile = await transcodeProfile();
+  if (!profile) return t.skip("ffmpeg not installed");
+  const dir = await tempStore();
+  try {
+    // Plant a cached transcode under the extension the local profile would
+    // NOT produce — a transcode shipped in from a better-equipped machine.
+    const sha = "dd".repeat(32);
+    const otherExt = profile.ext === ".mp4" ? ".webm" : ".mp4";
+    const planted = transcodePath(sha, otherExt);
+    await mkdir(dirname(planted), { recursive: true });
+    await writeFile(planted, Buffer.from("sentinel"));
+
+    const video = await ensureTranscode(sha); // no blob in store: must not transcode
+    assert.equal(video.path, planted);
+    assert.equal(video.mime, otherExt === ".webm" ? "video/webm" : "video/mp4");
+    assert.deepEqual(await transcodeStatus(sha), { state: "ready", path: planted, mime: video.mime });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("transcodeStatus reports failed after a rejected transcode, none when idle", async (t) => {
+  if (!(await transcodeProfile())) return t.skip("ffmpeg not installed");
+  const dir = await tempStore();
+  try {
+    const sha = "ee".repeat(32);
+    assert.deepEqual(await transcodeStatus(sha), { state: "none" });
+    await putBlob(sha, Buffer.from("\x00\x00\x01\xbajunk", "latin1"));
+    await assert.rejects(ensureTranscode(sha));
+    assert.deepEqual(await transcodeStatus(sha), { state: "failed" });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureThumb extracts a JPEG still and caches it", async (t) => {
+  if (!(await transcodeProfile())) return t.skip("ffmpeg not installed");
+  const dir = await tempStore();
+  try {
+    const sha = "ff".repeat(32);
+    await putBlob(sha, await mpegFixture(dir));
+    const out = await ensureThumb(sha);
+    assert.equal(out, thumbPath(sha));
+    const bytes = await readFile(out);
+    // JPEG SOI marker.
+    assert.deepEqual([...bytes.subarray(0, 3)], [0xff, 0xd8, 0xff]);
+
+    // Second call serves the cache, so the file must not be rewritten.
+    const before = (await stat(out)).mtimeMs;
+    assert.equal(await ensureThumb(sha), out);
+    assert.equal((await stat(out)).mtimeMs, before);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureThumb rejects junk and a missing blob", async (t) => {
+  if (!(await transcodeProfile())) return t.skip("ffmpeg not installed");
+  const dir = await tempStore();
+  try {
+    const sha = "ab".repeat(32);
+    await putBlob(sha, Buffer.from("not a video at all"));
+    await assert.rejects(ensureThumb(sha));
+    await assert.rejects(stat(thumbPath(sha)));
+    await assert.rejects(ensureThumb("cd".repeat(32)));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/web/tests/lib.test.ts
+++ b/web/tests/lib.test.ts
@@ -217,7 +217,7 @@ test("orderAssets accepts a per-kind cap map (missing kind = uncapped)", () => {
 
 // --- submission asset uploads ---------------------------------------------------
 
-import { referencedAssets, MAX_ASSET_BLOB_BYTES } from "../src/lib/submission-assets";
+import { referencedAssets, MAX_ASSET_BLOB_BYTES, MAX_VIDEO_BLOB_BYTES } from "../src/lib/submission-assets";
 import type { Pool } from "pg";
 
 function fakePool(subRow?: { record: BuildRecord; status: string }, buildRow?: { record: BuildRecord }) {
@@ -238,11 +238,20 @@ test("referencedAssets dedupes shared blobs and drops malformed refs", async () 
     { path: "/B.PNG", sha256: "not-hex", size: 10, mime: "image/png", kind: "image" },
     { path: "/C.PNG", sha256: "aa".repeat(32), size: 0, mime: "image/png", kind: "image" },
     { path: "/D.PNG", sha256: "bb".repeat(32), size: MAX_ASSET_BLOB_BYTES + 1, mime: "image/png", kind: "image" },
+    // Videos alone get the DVD-VOB-scale allowance.
+    { path: "/V1.VOB", sha256: "11".repeat(32), size: MAX_ASSET_BLOB_BYTES + 1, mime: "video/mpeg", kind: "video" },
+    { path: "/V2.VOB", sha256: "22".repeat(32), size: MAX_VIDEO_BLOB_BYTES + 1, mime: "video/mpeg", kind: "video" },
   ];
   const refs = await referencedAssets(fakePool({ record: minimalRecord(assets), status: "queued" }), "ab".repeat(32));
   assert.ok(refs);
-  assert.deepEqual([...refs.sizes.entries()], [[sha, 10]]);
-  assert.equal(refs.totalBytes, 10);
+  assert.deepEqual(
+    [...refs.sizes.entries()],
+    [
+      [sha, 10],
+      ["11".repeat(32), MAX_ASSET_BLOB_BYTES + 1],
+    ]
+  );
+  assert.equal(refs.totalBytes, 10 + MAX_ASSET_BLOB_BYTES + 1);
 });
 
 test("referencedAssets falls back from rejected submission to the library build", async () => {


### PR DESCRIPTION
DVD-sized videos were demoted to hex snippets by the 20MB asset cap, which broke the VOB files on DVD-Video discs. Videos now ship whole up to 1.25GiB, streamed into the store instead of buffered, and the web transcode runs in the background with a status endpoint the player polls when an input outlives the soft wait.

Gallery cards and the viewer now show poster stills pulled from each video by ffmpeg, cached next to the transcodes. The transcode cache also accepts either output format, so MP4s produced on a machine with libx264 serve from a VP9-only server.