### PR TITLE
Treat archives as directories

### DIFF
--- a/crates/curator-core/src/adapter.rs
+++ b/crates/curator-core/src/adapter.rs
@@ -166,8 +166,8 @@ pub struct RawFile {
     #[serde(default)]
     pub unreadable: bool,
     /// True for a file listed from inside an archive member (`/DIR/A.ZIP/...`).
-    /// Members appear in the contents tree and text corpus only — composites and
-    /// structural features skip them, so the archive stays one opaque file for
+    /// Members appear in the contents tree, text corpus, and structural counts,
+    /// but composites skip them — the archive stays one opaque file for
     /// identity. The adapter also never fingerprints them (no chunks/shingle).
     #[serde(default)]
     pub in_archive: bool,

--- a/crates/curator-core/src/adapter.rs
+++ b/crates/curator-core/src/adapter.rs
@@ -165,6 +165,12 @@ pub struct RawFile {
     pub sha256: Option<String>,
     #[serde(default)]
     pub unreadable: bool,
+    /// True for a file listed from inside an archive member (`/DIR/A.ZIP/...`).
+    /// Members appear in the contents tree and text corpus only — composites and
+    /// structural features skip them, so the archive stays one opaque file for
+    /// identity. The adapter also never fingerprints them (no chunks/shingle).
+    #[serde(default)]
+    pub in_archive: bool,
     /// FastCDC content-defined chunks as [blake3_63bit, length]. Absent for
     /// directories.
     #[serde(default)]

--- a/crates/curator-core/src/fingerprint.rs
+++ b/crates/curator-core/src/fingerprint.rs
@@ -204,12 +204,10 @@ pub fn structural(system: &str, files: &[RawFile]) -> Structural {
     let mut max_depth = 0u32;
     let mut ext_histogram: BTreeMap<String, u64> = BTreeMap::new();
 
+    // Structural features describe the *listing* (what the tree shows), so
+    // archive members count here — unlike composites, where the archive is
+    // one opaque file.
     for f in files {
-        // Archive members stay out of the structural features too, so a build's
-        // counts/histogram match what composites cover.
-        if f.in_archive {
-            continue;
-        }
         let depth = f.path.trim_matches('/').split('/').count() as u32;
         max_depth = max_depth.max(depth);
         if f.is_dir {
@@ -536,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn archive_members_do_not_change_composites_or_structural() {
+    fn archive_members_do_not_change_composites_but_count_structurally() {
         let base = vec![file("/GAME.BIN", A), file("/PATCH.ZIP", B)];
         let mut bad_member = member("/PATCH.ZIP/broken.dat", C);
         bad_member.unreadable = true;
@@ -555,11 +553,12 @@ mod tests {
         );
         assert_eq!(composites(&listed).incomplete_files, 0);
 
+        // Structural features describe the listing, so members DO count there.
         let s = structural("PSX", &listed);
-        assert_eq!(s.file_count, 2);
-        assert_eq!(s.total_size, 20);
-        assert!(s.ext_histogram.get("txt").is_none());
-        assert_eq!(s.max_depth, 1); // member depth doesn't count either
+        assert_eq!(s.file_count, 4);
+        assert_eq!(s.total_size, 40);
+        assert_eq!(s.ext_histogram.get("txt"), Some(&1));
+        assert_eq!(s.max_depth, 3);
     }
 
     #[test]

--- a/crates/curator-core/src/fingerprint.rs
+++ b/crates/curator-core/src/fingerprint.rs
@@ -155,7 +155,9 @@ pub fn composites(files: &[RawFile]) -> Composites {
     let mut incomplete: u32 = 0;
 
     for f in files {
-        if f.is_dir {
+        // Archive members don't exist as far as identity is concerned: the
+        // archive file's own sha1 already covers their bytes.
+        if f.is_dir || f.in_archive {
             continue;
         }
         if f.unreadable {
@@ -203,6 +205,11 @@ pub fn structural(system: &str, files: &[RawFile]) -> Structural {
     let mut ext_histogram: BTreeMap<String, u64> = BTreeMap::new();
 
     for f in files {
+        // Archive members stay out of the structural features too, so a build's
+        // counts/histogram match what composites cover.
+        if f.in_archive {
+            continue;
+        }
         let depth = f.path.trim_matches('/').split('/').count() as u32;
         max_depth = max_depth.max(depth);
         if f.is_dir {
@@ -396,13 +403,26 @@ pub fn build_tree(files: &[RawFile]) -> Vec<Node> {
     finish_dir(root)
 }
 
-fn finish_dir(d: DirBuild) -> Vec<Node> {
+fn finish_dir(mut d: DirBuild) -> Vec<Node> {
     // Directories first, then files; each alphabetical (BTreeMap keeps key order).
     let mut out: Vec<Node> = Vec::with_capacity(d.dirs.len() + d.files.len());
-    for (name, sub) in d.dirs {
-        let date = sub.date.clone();
-        let size = sub.size;
-        out.push(Node::Dir { name, date, size, children: finish_dir(sub) });
+    for (name, sub) in std::mem::take(&mut d.dirs) {
+        let mut date = sub.date.clone();
+        let mut size = sub.size;
+        let mut md5 = None;
+        let mut sha1 = None;
+        let mut sha256 = None;
+        // An archive listed as a directory is both a file (its own record) and
+        // a dir (its members' paths): merge into one dir node carrying the
+        // file's metadata instead of showing same-named siblings.
+        if let Some(Node::File { date: fd, size: fs, md5: fm, sha1: f1, sha256: f2, .. }) =
+            d.files.remove(&name)
+        {
+            date = date.or(fd);
+            size = size.or(fs);
+            (md5, sha1, sha256) = (fm, f1, f2);
+        }
+        out.push(Node::Dir { name, date, size, md5, sha1, sha256, children: finish_dir(sub) });
     }
     out.extend(d.files.into_values());
     out
@@ -427,6 +447,7 @@ mod tests {
             sha1: Some(sha1.into()),
             sha256: None,
             unreadable: false,
+            in_archive: false,
             chunks: vec![],
             shingle: vec![],
         }
@@ -442,9 +463,14 @@ mod tests {
             sha1: None,
             sha256: None,
             unreadable: false,
+            in_archive: false,
             chunks: vec![],
             shingle: vec![],
         }
+    }
+
+    fn member(path: &str, sha1: &str) -> RawFile {
+        RawFile { in_archive: true, ..file(path, sha1) }
     }
 
     #[test]
@@ -506,6 +532,60 @@ mod tests {
         match data {
             Node::Dir { children, .. } => assert_eq!(children[0].name(), "SUB"),
             _ => panic!("DATA should be a directory"),
+        }
+    }
+
+    #[test]
+    fn archive_members_do_not_change_composites_or_structural() {
+        let base = vec![file("/GAME.BIN", A), file("/PATCH.ZIP", B)];
+        let mut bad_member = member("/PATCH.ZIP/broken.dat", C);
+        bad_member.unreadable = true;
+        let listed = vec![
+            file("/GAME.BIN", A),
+            file("/PATCH.ZIP", B),
+            member("/PATCH.ZIP/deep/readme.txt", C),
+            bad_member,
+        ];
+        // The archive contributes exactly its own sha1, members nothing at all —
+        // not even to the incomplete-files count.
+        assert_eq!(composites(&base).content_hash, composites(&listed).content_hash);
+        assert_eq!(
+            composites(&base).filtered_content_hash,
+            composites(&listed).filtered_content_hash
+        );
+        assert_eq!(composites(&listed).incomplete_files, 0);
+
+        let s = structural("PSX", &listed);
+        assert_eq!(s.file_count, 2);
+        assert_eq!(s.total_size, 20);
+        assert!(s.ext_histogram.get("txt").is_none());
+        assert_eq!(s.max_depth, 1); // member depth doesn't count either
+    }
+
+    #[test]
+    fn build_tree_merges_archive_file_into_its_dir() {
+        let mut zip = file("/DATA/PATCH.ZIP", A);
+        zip.md5 = Some("aabb".into());
+        zip.sha256 = Some("ccdd".into());
+        let tree = build_tree(&[
+            zip,
+            member("/DATA/PATCH.ZIP/src/main.c", B),
+            member("/DATA/PATCH.ZIP/title.png", C),
+        ]);
+        let Node::Dir { children: data, .. } = &tree[0] else { panic!("DATA should be a dir") };
+        // One node for the archive — a dir carrying the file's own hashes/size.
+        assert_eq!(data.len(), 1);
+        match &data[0] {
+            Node::Dir { name, size, md5, sha1, sha256, children, .. } => {
+                assert_eq!(name, "PATCH.ZIP");
+                assert_eq!(*size, Some(10));
+                assert_eq!(md5.as_deref(), Some("aabb"));
+                assert_eq!(sha1.as_deref(), Some(A));
+                assert_eq!(sha256.as_deref(), Some("ccdd"));
+                let names: Vec<&str> = children.iter().map(|n| n.name()).collect();
+                assert_eq!(names, vec!["src", "title.png"]);
+            }
+            _ => panic!("PATCH.ZIP should have become a dir node"),
         }
     }
 

--- a/crates/curator-core/src/render.rs
+++ b/crates/curator-core/src/render.rs
@@ -125,13 +125,23 @@ pub fn to_dat_xml(record: &BuildRecord) -> String {
 
 fn write_node(s: &mut String, indent: usize, node: &Node) {
     match node {
-        Node::Dir { name, date, size, children } => {
+        Node::Dir { name, date, size, md5, sha1, sha256, children } => {
             let mut a = vec![("name", name.clone())];
             if let Some(d) = date {
                 a.push(("date", d.clone()));
             }
             if let Some(sz) = size {
                 a.push(("size", sz.to_string()));
+            }
+            // Present on archives listed as directories — the archive file's own hashes.
+            if let Some(x) = md5 {
+                a.push(("md5", x.clone()));
+            }
+            if let Some(x) = sha1 {
+                a.push(("sha1", x.clone()));
+            }
+            if let Some(x) = sha256 {
+                a.push(("sha256", x.clone()));
             }
             if children.is_empty() {
                 write_empty(s, indent, "directory", &a);

--- a/crates/curator-core/src/schema.rs
+++ b/crates/curator-core/src/schema.rs
@@ -17,9 +17,10 @@ pub const FINGERPRINT_PROFILE: &str = "v1";
 /// classified as an image (previously a head snippet); 4 = TIFF likewise;
 /// 5 = PDF and PostScript (.eps/.ps/.ai) as `kind: "document"`; 6 = videos
 /// ship whole up to DVD-VOB scale (previously capped with everything else at
-/// 20MB). A record below the current value gets its assets re-extracted on
-/// the next analyze.
-pub const ASSET_PROFILE: u32 = 6;
+/// 20MB); 7 = archives (zip/7z/rar/tar/cab/…) extracted as if directories,
+/// their members' assets riding under `<archive path>/...`. A record below
+/// the current value gets its assets re-extracted on the next analyze.
+pub const ASSET_PROFILE: u32 = 7;
 
 /// A fully analyzed disc image / container — image-independent and self-describing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -263,6 +264,14 @@ pub enum Node {
         date: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         size: Option<u64>,
+        /// An archive listed as a directory is still a file with bytes of its
+        /// own: these are that file's hashes (absent on plain directories).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        md5: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sha1: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sha256: Option<String>,
         children: Vec<Node>,
     },
     File {

--- a/crates/curator-ffi/src/lib.rs
+++ b/crates/curator-ffi/src/lib.rs
@@ -171,14 +171,15 @@ fn entry_from_row(r: curator_core::db::LibraryRow) -> LibraryEntry {
 
 fn node_to_ffi(node: &Node) -> FileNode {
     match node {
-        Node::Dir { name, date, size, children } => FileNode {
+        Node::Dir { name, date, size, md5, sha1, sha256, children } => FileNode {
             name: name.clone(),
             is_dir: true,
             size: *size,
             date: date.clone(),
-            md5: None,
-            sha1: None,
-            sha256: None,
+            // Present on archives listed as directories (the archive's own hashes).
+            md5: md5.clone(),
+            sha1: sha1.clone(),
+            sha256: sha256.clone(),
             unreadable: false,
             children: children.iter().map(node_to_ffi).collect(),
         },

--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -1543,7 +1543,7 @@ mod app {
             }
         };
         let title = match node {
-            Node::Dir { name, date, size, children } => {
+            Node::Dir { name, date, size, md5, sha1, sha256, children } => {
                 row("Name", name);
                 if let Some(d) = date {
                     row("Date", d);
@@ -1552,7 +1552,21 @@ mod app {
                     row("Size", &human_size(*sz));
                 }
                 row("Items", &children.len().to_string());
-                "Directory"
+                // An archive listed as a directory: show the file's own hashes.
+                if let Some(h) = md5 {
+                    row("MD5", h);
+                }
+                if let Some(h) = sha1 {
+                    row("SHA-1", h);
+                }
+                if let Some(h) = sha256 {
+                    row("SHA-256", h);
+                }
+                if sha1.is_some() || sha256.is_some() || md5.is_some() {
+                    "Archive"
+                } else {
+                    "Directory"
+                }
             }
             Node::File { name, date, size, md5, sha1, sha256, unreadable } => {
                 row("Name", name);

--- a/macos/Sources/CuratorApp/ContentView.swift
+++ b/macos/Sources/CuratorApp/ContentView.swift
@@ -421,9 +421,12 @@ struct NodeDetail: View {
         if let node {
             let f = node.node
             Form {
+                // A dir node with hashes is an archive listed as a directory:
+                // it has bytes (and hashes) of its own.
+                let isArchive = f.isDir && (f.sha1 != nil || f.sha256 != nil || f.md5 != nil)
                 LabeledContent("Name", value: f.name)
-                LabeledContent("Type", value: f.isDir ? "Directory" : "File")
-                if !f.isDir { LabeledContent("Size", value: humanSize(f.size)) }
+                LabeledContent("Type", value: f.isDir ? (isArchive ? "Archive" : "Directory") : "File")
+                if !f.isDir || isArchive { LabeledContent("Size", value: humanSize(f.size)) }
                 if let d = f.date { LabeledContent("Date", value: d) }
                 if f.unreadable { LabeledContent("Status", value: "Unreadable (bad dump)") }
                 if let h = f.md5 { HashRow(label: "MD5", value: h) }

--- a/ps2exe-adapter/curator_adapter/cli.py
+++ b/ps2exe-adapter/curator_adapter/cli.py
@@ -85,7 +85,10 @@ def _clean_component(c):
 
 
 def _clean_path(p):
-    parts = [_clean_component(c) for c in p.strip("/").split("/") if c]
+    # "." / ".." only occur in archive member names (never in disc paths); drop
+    # them so a hostile or sloppy member name can't dress the tree up with fake
+    # parent components.
+    parts = [_clean_component(c) for c in p.strip("/").split("/") if c and c not in (".", "..")]
     return "/" + "/".join(parts)
 
 
@@ -453,15 +456,92 @@ def _gather_info(processor, reader, system, mods):
     }
 
 
-def _hash_files(reader, manager):
+# Archives found *inside* a volume are listed and asset-extracted as if they
+# were directories: members ride under "<archive path>/..." with in_archive on,
+# so they show up in the contents tree and the asset store. Identity stays
+# untouched — composite hashing sees only the archive file's own hashes, and
+# members carry no chunk/shingle fingerprints (the consumer skips in_archive
+# records everywhere but listing/search). Detection is by leading bytes (plus
+# tar's magic at offset 257); anything ArchiveWrapper can't open (bare gzip of
+# a single file, InstallShield cab, passworded/corrupt archives) quietly stays
+# a plain file.
+_ARCHIVE_SNIFF_BYTES = 512
+_ARCHIVE_MAX_DEPTH = 3
+
+_ARCHIVE_MAGICS = (
+    b"PK\x03\x04",          # zip
+    b"7z\xBC\xAF\x27\x1C",  # 7z
+    b"Rar\x21\x1A\x07",     # rar (v4 prefix of v5)
+    b"MSCF",                # microsoft cabinet
+    b"\x1F\x8B\x08",        # gzip (a .tar.gz; a bare .gz fails to open and stays a file)
+    b"BZh",                 # bzip2
+    b"\xFD7zXZ\x00",        # xz
+)
+
+
+def _looks_like_archive(head):
+    return bool(head) and (head.startswith(_ARCHIVE_MAGICS) or head[257:262] == b"ustar")
+
+
+class _ArchiveSource:
+    """Member handle wrapper giving ArchiveWrapper the `.name` it expects;
+    everything else (read/readinto/seek/…) proxies to the handle."""
+
+    def __init__(self, fh, name):
+        self._fh = fh
+        self.name = name
+
+    def __getattr__(self, attr):
+        return getattr(self._fh, attr)
+
+
+def _open_member_archive(reader, entry, path, manager):
+    """A CompressedPathReader over an archive member, or None when the member
+    can't be opened as one (unsupported/corrupt/passworded). The caller must
+    hand the result to _close_member_archive, which also releases the
+    decompression spool and the member handle."""
+    if str(_PS2EXE_DIR) not in sys.path:  # set by _import_ps2exe in normal runs
+        sys.path.insert(0, str(_PS2EXE_DIR))
+    from common.iso_path_reader.methods.compressed import CompressedPathReader  # noqa: E402
+    from utils.archives import ArchiveWrapper  # noqa: E402
+
+    fh = None
+    try:
+        fh = reader.open_file(entry)
+        if hasattr(fh, "__enter__"):
+            fh.__enter__()
+        src = fh if getattr(fh, "name", None) else _ArchiveSource(fh, path)
+        return CompressedPathReader(ArchiveWrapper(src, reader, manager), src, reader)
+    except Exception as e:  # noqa: BLE001 — any failure means "not an archive we can read"
+        logging.getLogger("curator-adapter").debug("could not open %s as archive: %s", path, e)
+        if fh is not None:
+            _close_handle(fh)
+        return None
+
+
+def _close_handle(fh):
+    with contextlib.suppress(Exception):
+        fh.__exit__(None, None, None) if hasattr(fh, "__exit__") else fh.close()
+
+
+def _close_member_archive(child):
+    with contextlib.suppress(Exception):
+        child.close()
+    if child.fp is not None:
+        _close_handle(child.fp)
+
+
+def _hash_files(reader, manager, prefix="", depth=0):
     files = []
     file_list = list(reader.iso_iterator(reader.get_root_dir(), recursive=True, include_dirs=True))
     with manager.counter(total=len(file_list), desc="Hashing files", unit="files") as pbar, \
             manager.counter(total=0, unit="B", file_name="") as hbar:
         for f in file_list:
-            path = reader.get_file_path(f)
+            path = prefix + _clean_path(reader.get_file_path(f).replace("\\", "/"))
             is_dir = bool(reader.is_directory(f))
-            rec = {"path": _clean_path(path), "is_dir": is_dir}
+            rec = {"path": path, "is_dir": is_dir}
+            if depth:
+                rec["in_archive"] = True
             date = None
             try:
                 date = reader.get_file_date(f)
@@ -477,25 +557,52 @@ def _hash_files(reader, manager):
             except Exception:  # noqa: BLE001
                 pass
 
+            head = None
             if not is_dir:
-                _hash_one(reader, f, rec, size, hbar)
+                # Members skip the chunk/shingle fingerprints: build-level
+                # similarity must keep seeing the archive as one opaque file.
+                head = _hash_one(reader, f, rec, size, hbar, fingerprints=depth == 0)
 
             files.append(rec)
+            if head is not None and depth < _ARCHIVE_MAX_DEPTH and _looks_like_archive(head):
+                files.extend(_archive_member_files(reader, f, path, manager, depth))
             pbar.update()
     return files
 
 
-def _hash_one(reader, f, rec, size, hbar):
+def _archive_member_files(reader, entry, path, manager, depth):
+    """Hash an archive member's own members as `<path>/...` records. Best-effort:
+    an archive that can't be opened or dies mid-listing just stays a plain file."""
+    child = _open_member_archive(reader, entry, path, manager)
+    if child is None:
+        return []
+    try:
+        return _hash_files(child, manager, prefix=path, depth=depth + 1)
+    except Exception as e:  # noqa: BLE001 — passworded/unsupported/corrupt
+        logging.getLogger("curator-adapter").warning("archive listing failed for %s: %s", path, e)
+        return []
+    finally:
+        _close_member_archive(child)
+
+
+def _hash_one(reader, f, rec, size, hbar, fingerprints=True):
+    """Hash one file into `rec`, returning its leading bytes (for archive
+    sniffing), or None when the file was unreadable."""
     md5 = hashlib.md5(usedforsecurity=False)
     sha1 = hashlib.sha1(usedforsecurity=False)
     sha256 = hashlib.sha256()
     read = 0
+    head = b""
     # Content-defined chunks, streamed so even multi-GB files are chunked
     # without buffering them whole.
-    chunker = _StreamingChunker()
+    chunker = _StreamingChunker() if fingerprints else None
     # Byte-shingle resemblance signature for large files only — the big blobs
     # where scattered small edits matter; tiny files lean on their whole-file hash.
-    shingler = _ShingleSignature() if size is not None and size >= _SHINGLE_MIN_SIZE else None
+    shingler = (
+        _ShingleSignature()
+        if fingerprints and size is not None and size >= _SHINGLE_MIN_SIZE
+        else None
+    )
     hbar.total = float(size or 0)
     hbar.count = 0.0
     hbar.update(incr=0, file_name=os.path.basename(rec["path"]))
@@ -509,7 +616,10 @@ def _hash_one(reader, f, rec, size, hbar):
                 md5.update(chunk)
                 sha1.update(chunk)
                 sha256.update(chunk)
-                chunker.update(chunk)
+                if len(head) < _ARCHIVE_SNIFF_BYTES:
+                    head += chunk[: _ARCHIVE_SNIFF_BYTES - len(head)]
+                if chunker is not None:
+                    chunker.update(chunk)
                 if shingler is not None:
                     shingler.update(chunk)
                 read += len(chunk)
@@ -520,7 +630,7 @@ def _hash_one(reader, f, rec, size, hbar):
     except Exception as e:  # noqa: BLE001
         logging.getLogger("curator-adapter").debug("hash failed for %s: %s", rec["path"], e)
         rec["unreadable"] = True
-        return
+        return None
 
     if read:
         rec["md5"] = md5.hexdigest()
@@ -528,15 +638,17 @@ def _hash_one(reader, f, rec, size, hbar):
         rec["sha256"] = sha256.hexdigest()
         if size is not None and read != size:
             rec["unreadable"] = True
-        chunks = chunker.finish()
-        if chunks:
-            rec["chunks"] = chunks
+        if chunker is not None:
+            chunks = chunker.finish()
+            if chunks:
+                rec["chunks"] = chunks
         if shingler is not None:
             sig = shingler.finish()
             if sig is not None:
                 rec["shingle"] = sig
     elif size:
         rec["unreadable"] = True
+    return head
 
 
 def _chunk_pair(data):
@@ -726,17 +838,18 @@ def extract(path, out_dir):
     return {"assets": _process(path, basename, parent_dir, mods, manager, work)}
 
 
-def _extract_assets(reader, out_dir, manager):
+def _extract_assets(reader, out_dir, manager, prefix="", depth=0):
     from . import viewable
 
     # Candidate list first, bytes second — the same two-step the hashing pass
     # uses, so one-pass archive streams see opens in iterator order only.
     # Every non-empty file is a candidate: viewable types ship whole, everything
     # else (unknown extension, oversized, sniff mismatch below) ships as a raw
-    # head snippet the UIs render as a hex view.
+    # head snippet the UIs render as a hex view. Archive members are candidates
+    # too, extracted through the same recursion as the hashing pass.
     entries = []
     for f in reader.iso_iterator(reader.get_root_dir(), recursive=True, include_dirs=False):
-        path = _clean_path(reader.get_file_path(f))
+        path = prefix + _clean_path(reader.get_file_path(f).replace("\\", "/"))
         try:
             size = int(reader.get_file_size(f))
         except Exception:  # noqa: BLE001
@@ -754,6 +867,8 @@ def _extract_assets(reader, out_dir, manager):
             if classified is None:
                 head = _read_head(reader, f, viewable.SNIPPET_BYTES)
                 asset = (head, viewable.SNIPPET_MIME, viewable.SNIPPET_KIND) if head else None
+                if head and depth < _ARCHIVE_MAX_DEPTH and _looks_like_archive(head):
+                    out.extend(_archive_member_assets(reader, f, path, out_dir, manager, depth))
             else:
                 kind, mime = classified
                 if size is not None and size > viewable.MAX_ASSET_SIZE:
@@ -787,6 +902,21 @@ def _extract_assets(reader, out_dir, manager):
             _store_blob(out_dir, sha, data)
             out.append({"path": path, "sha256": sha, "size": len(data), "mime": mime, "kind": kind})
     return out
+
+
+def _archive_member_assets(reader, entry, path, out_dir, manager, depth):
+    """Extract an archive member's own members as `<path>/...` assets.
+    Best-effort, like the listing pass."""
+    child = _open_member_archive(reader, entry, path, manager)
+    if child is None:
+        return []
+    try:
+        return _extract_assets(child, out_dir, manager, prefix=path, depth=depth + 1)
+    except Exception as e:  # noqa: BLE001 — passworded/unsupported/corrupt
+        logging.getLogger("curator-adapter").warning("archive extraction failed for %s: %s", path, e)
+        return []
+    finally:
+        _close_member_archive(child)
 
 
 def _read_capped(reader, f, cap):

--- a/ps2exe-adapter/curator_adapter/cli.py
+++ b/ps2exe-adapter/curator_adapter/cli.py
@@ -459,9 +459,9 @@ def _gather_info(processor, reader, system, mods):
 # Archives found *inside* a volume are listed and asset-extracted as if they
 # were directories: members ride under "<archive path>/..." with in_archive on,
 # so they show up in the contents tree and the asset store. Identity stays
-# untouched — composite hashing sees only the archive file's own hashes, and
-# members carry no chunk/shingle fingerprints (the consumer skips in_archive
-# records everywhere but listing/search). Detection is by leading bytes (plus
+# untouched — composite hashing sees only the archive file's own hashes (the
+# consumer skips in_archive records there), and members carry no chunk/shingle
+# fingerprints. Detection is by leading bytes (plus
 # tar's magic at offset 257); anything ArchiveWrapper can't open (bare gzip of
 # a single file, InstallShield cab, passworded/corrupt archives) quietly stays
 # a plain file.

--- a/ps2exe-adapter/tests/test_archives.py
+++ b/ps2exe-adapter/tests/test_archives.py
@@ -1,0 +1,114 @@
+"""Archives inside a volume list and asset-extract as if they were directories.
+
+These run the real ArchiveWrapper/CompressedPathReader stack from lib/ps2exe over
+in-memory zip fixtures served through a minimal fake volume reader.
+"""
+
+import hashlib
+import io
+import zipfile
+
+from curator_adapter import viewable
+from curator_adapter.cli import _extract_assets, _hash_files
+from curator_adapter.progress import ProgressManager
+
+
+class FakeVolume:
+    """Minimal volume reader: files as {path: bytes}, no directories."""
+
+    def __init__(self, files):
+        self.files = list(files.items())
+
+    def get_root_dir(self):
+        return None
+
+    def iso_iterator(self, _root, recursive=True, include_dirs=False):
+        return iter(range(len(self.files)))
+
+    def is_directory(self, f):
+        return False
+
+    def get_file_date(self, f):
+        return None
+
+    def get_file_path(self, f):
+        return self.files[f][0]
+
+    def get_file_size(self, f):
+        return len(self.files[f][1])
+
+    def open_file(self, f):
+        return io.BytesIO(self.files[f][1])
+
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+SRC = b"int main(void) { return 0; }\n"
+
+
+def make_zip(members):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        for name, data in members.items():
+            z.writestr(name, data)
+    return buf.getvalue()
+
+
+def hash_files(files):
+    recs = _hash_files(FakeVolume(files), ProgressManager())
+    return {r["path"]: r for r in recs}
+
+
+def test_zip_members_are_listed_as_directory_contents():
+    zip_bytes = make_zip({"src/main.c": SRC, "title.png": PNG})
+    recs = hash_files({"/README.TXT": b"hello", "/DATA/PROTO.ZIP": zip_bytes})
+
+    # The archive itself stays a normal, fully hashed file (identity input).
+    z = recs["/DATA/PROTO.ZIP"]
+    assert "in_archive" not in z
+    assert z["sha1"] == hashlib.sha1(zip_bytes).hexdigest()
+
+    # Members ride under the archive's path, hashed but unfingerprinted.
+    m = recs["/DATA/PROTO.ZIP/src/main.c"]
+    assert m["in_archive"] is True
+    assert m["size"] == len(SRC)
+    assert m["sha1"] == hashlib.sha1(SRC).hexdigest()
+    assert m["sha256"] == hashlib.sha256(SRC).hexdigest()
+    assert "chunks" not in m and "shingle" not in m
+    assert recs["/DATA/PROTO.ZIP/title.png"]["md5"] == hashlib.md5(PNG).hexdigest()
+
+
+def test_nested_archives_recurse():
+    inner = make_zip({"deep.txt": b"bottom"})
+    outer = make_zip({"inner.zip": inner})
+    recs = hash_files({"/A.ZIP": outer})
+
+    assert recs["/A.ZIP/inner.zip"]["in_archive"] is True
+    deep = recs["/A.ZIP/inner.zip/deep.txt"]
+    assert deep["in_archive"] is True
+    assert deep["sha1"] == hashlib.sha1(b"bottom").hexdigest()
+
+
+def test_corrupt_archive_stays_a_plain_file():
+    fake = b"PK\x03\x04" + b"\xde\xad\xbe\xef" * 64
+    recs = hash_files({"/BROKEN.ZIP": fake, "/OK.BIN": b"fine"})
+
+    assert recs["/BROKEN.ZIP"]["sha1"] == hashlib.sha1(fake).hexdigest()
+    assert "unreadable" not in recs["/BROKEN.ZIP"]
+    assert [p for p in recs if p.startswith("/BROKEN.ZIP/")] == []
+
+
+def test_member_assets_are_extracted(tmp_path):
+    zip_bytes = make_zip({"art/title.png": PNG, "notes.txt": b"prototype notes\n"})
+    out = _extract_assets(FakeVolume({"/DATA/PROTO.ZIP": zip_bytes}), str(tmp_path), ProgressManager())
+    assets = {a["path"]: a for a in out}
+
+    # The archive keeps its own head-snippet asset (hex view) …
+    z = assets["/DATA/PROTO.ZIP"]
+    assert z["kind"] == viewable.SNIPPET_KIND
+
+    # … and its viewable members ship whole under prefixed paths.
+    png = assets["/DATA/PROTO.ZIP/art/title.png"]
+    assert (png["kind"], png["mime"], png["size"]) == ("image", "image/png", len(PNG))
+    blob = (tmp_path / png["sha256"][:2] / png["sha256"]).read_bytes()
+    assert blob == PNG
+    assert assets["/DATA/PROTO.ZIP/notes.txt"]["kind"] == "text"

--- a/web/src/lib/fingerprint.ts
+++ b/web/src/lib/fingerprint.ts
@@ -60,6 +60,11 @@ export function flattenFiles(nodes: Node[] | undefined, prefix = ""): FileRow[] 
   for (const n of nodes ?? []) {
     const path = prefix + "/" + n.name;
     if (n.type === "dir") {
+      // An archive listed as a directory carries its own hashes: it is still a
+      // file of the build, so it keeps its row alongside its members'.
+      if (n.md5 || n.sha1 || n.sha256) {
+        out.push({ path, name: n.name, size: n.size ?? null, md5: n.md5, sha1: n.sha1, sha256: n.sha256 });
+      }
       out.push(...flattenFiles(n.children, path));
     } else {
       out.push({ path, name: n.name, size: n.size ?? null, md5: n.md5, sha1: n.sha1, sha256: n.sha256 });

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -24,7 +24,17 @@ export interface Structural {
 }
 
 export type Node =
-  | { type: "dir"; name: string; date?: string; size?: number; children: Node[] }
+  | {
+      type: "dir";
+      name: string;
+      date?: string;
+      size?: number;
+      /** Present on archives listed as directories — the archive file's own hashes. */
+      md5?: string;
+      sha1?: string;
+      sha256?: string;
+      children: Node[];
+    }
   | {
       type: "file";
       name: string;

--- a/web/tests/lib.test.ts
+++ b/web/tests/lib.test.ts
@@ -1,7 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { tlshDiff } from "../src/lib/tlsh";
-import { hexToId63, toSigned64, lshBands, setJaccard, minhashJaccard } from "../src/lib/fingerprint";
+import { hexToId63, toSigned64, lshBands, setJaccard, minhashJaccard, flattenFiles } from "../src/lib/fingerprint";
+import type { Node } from "../src/lib/types";
 import { TIERS, fusedScore, applicableTiers, type TierKey } from "../src/lib/tiers";
 
 // Real fixtures generated with py-tlsh (the reference implementation) — this pins the
@@ -45,6 +46,33 @@ test("lshBands folds a 128-slot signature into 16 deterministic bands", () => {
   const sig2 = sig.slice();
   sig2[0] = 999999n;
   assert.notDeepEqual(lshBands(sig2), a);
+});
+
+test("flattenFiles keeps an archive-dir's own row alongside its members", () => {
+  const tree: Node[] = [
+    {
+      type: "dir",
+      name: "DATA",
+      children: [
+        {
+          // An archive listed as a directory: carries the archive file's hashes.
+          type: "dir",
+          name: "PROTO.ZIP",
+          size: 100,
+          sha1: "aa".repeat(20),
+          children: [{ type: "file", name: "main.c", size: 5, sha1: "bb".repeat(20) }],
+        },
+        { type: "file", name: "GAME.BIN", size: 7, sha1: "cc".repeat(20) },
+      ],
+    },
+  ];
+  const rows = flattenFiles(tree);
+  assert.deepEqual(
+    rows.map((r) => r.path),
+    ["/DATA/PROTO.ZIP", "/DATA/PROTO.ZIP/main.c", "/DATA/GAME.BIN"]
+  );
+  // A plain directory (no hashes) still contributes no row of its own.
+  assert.equal(rows.some((r) => r.path === "/DATA"), false);
 });
 
 test("setJaccard = intersection / union", () => {


### PR DESCRIPTION
Archives found inside a build (zip, 7z, rar, tar, cab) are now listed and asset-extracted as if they were directories. Members appear under the archive's path in the contents tree and their viewable files land in the asset store, up to three levels of nesting.

Identity is untouched: composites and structural features still see each archive as one opaque file, and members carry no chunk or shingle fingerprints. The tree shows the archive as a directory node carrying the file's own hashes, and the asset profile bumps to 7 so existing records backfill member assets on the next analyze.