### PR TITLE
Show lot on moderation list

### DIFF
--- a/web/src/app/moderate/page.tsx
+++ b/web/src/app/moderate/page.tsx
@@ -13,6 +13,7 @@ interface Submission {
   name: string;
   system: string;
   file_count: number;
+  lot: string | null;
 }
 
 const FILTERS = ["queued", "accepted", "rejected", ""] as const;
@@ -169,6 +170,14 @@ export default function Moderate() {
                   <span>{s.file_count ?? "?"} files</span>
                   <span>by {s.nickname}</span>
                   <span className="font-mono">{s.sha256.slice(0, 12)}…</span>
+                  {s.lot && (
+                    <Link
+                      href={`/builds?lot=${encodeURIComponent(s.lot)}`}
+                      className="rounded bg-amber-100 px-1.5 py-0.5 font-medium text-amber-900 hover:underline dark:bg-amber-900/40 dark:text-amber-200"
+                    >
+                      {s.lot}
+                    </Link>
+                  )}
                   <StatusBadge status={s.status} />
                 </div>
               </div>

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -789,19 +789,23 @@ export interface SubmissionListItem {
   name: string;
   system: string;
   file_count: number;
+  /** Lot of the ingested build (accepted submissions only; set by moderators after accept). */
+  lot: string | null;
 }
 
 /// List submissions (optionally filtered by status), newest first.
 export async function listSubmissions(pool: Pool, status?: string, limit = 200): Promise<SubmissionListItem[]> {
-  const where = status ? "WHERE status=$1" : "";
+  const where = status ? "WHERE q.status=$1" : "";
   const params = status ? [status, limit] : [limit];
   const r = await pool.query(
-    `SELECT sha256, nickname, status, submitted_at, reviewed_at,
-            record->'image'->>'name'         AS name,
-            record->'info'->>'system'        AS system,
-            (record->'structural'->>'file_count')::bigint AS file_count
-     FROM submission_queue ${where}
-     ORDER BY submitted_at DESC LIMIT $${status ? 2 : 1}`,
+    `SELECT q.sha256, q.nickname, q.status, q.submitted_at, q.reviewed_at,
+            q.record->'image'->>'name'         AS name,
+            q.record->'info'->>'system'        AS system,
+            (q.record->'structural'->>'file_count')::bigint AS file_count,
+            b.lot
+     FROM submission_queue q
+     LEFT JOIN builds b ON b.sha256 = q.sha256 ${where}
+     ORDER BY q.submitted_at DESC LIMIT $${status ? 2 : 1}`,
     params
   );
   return r.rows as SubmissionListItem[];


### PR DESCRIPTION
The moderation queue now shows each accepted build's lot as a chip linking to the lot's builds list. Lots live on the ingested build row, so listSubmissions joins builds by sha256 and returns null for queued or rejected entries.

The endpoint is moderator only, so private lots are fine to show here.