### PR TITLE
Add S3 blob store backend

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -20,8 +20,29 @@ Populates `builds`, `files`, `build_fileset`, `build_chunk_signature`,
 `build_resemblance`, `exe_fp`, `audio_fp`, and `build_asset`, computing the
 `text_embedding` (all-MiniLM-L6-v2) and LSH bands at ingest. A `.zip` bundle
 also carries the viewable-asset blobs (`assets/<sha256>` members), which land
-in the content-addressed store at `ASSET_STORE_DIR` (default `./asset-store`)
-for the build page's inline asset viewer.
+in the content-addressed blob store for the build page's inline asset viewer.
+
+## Blob store
+
+Asset and repo blobs live in a content-addressed store (`src/lib/blobstore.ts`)
+with two backends:
+
+- **local** (default): `<ASSET_STORE_DIR>/<sha256[:2]>/<sha256>`, rooted at
+  `./asset-store`.
+- **s3**: any S3-compatible object store, selected by setting
+  `ASSET_S3_ENDPOINT`. Keys mirror the local layout under
+  `ASSET_S3_PREFIX` in `ASSET_S3_BUCKET` (default `curator`). Credentials come
+  from `ASSET_S3_ACCESS_KEY_ID`/`ASSET_S3_SECRET_ACCESS_KEY` (or the SDK's
+  default chain); `ASSET_S3_REGION` defaults to `us-east-1`, and
+  `ASSET_S3_INSECURE_TLS=1` accepts a self-signed endpoint certificate.
+  Reads still stream through the app's routes, so the bucket needs no public
+  access. `ASSET_STORE_DIR` remains the local root for upload staging and the
+  ffmpeg caches.
+
+`npm run push-assets` uploads an existing local store to the s3 backend:
+the one-time migration when a deployment flips to `ASSET_S3_ENDPOINT`
+(idempotent, keeps local files). Scripts read `.env`/`.env.local` like the
+app, so the store settings live in one place.
 
 ## API
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,10 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1089.0",
+        "@aws-sdk/lib-storage": "^3.1089.0",
         "@huggingface/transformers": "^4.2.0",
+        "@smithy/node-http-handler": "^4.9.7",
         "@types/pngjs": "^6.0.5",
         "bmp-js": "^0.1.0",
         "diff": "^9.0.0",
@@ -45,6 +48,344 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.18.tgz",
+      "integrity": "sha512-IImkbEyXdV6/uaF5r6Wkk+8718mQw1ll83j0a4a30R3JM/rHVFdWAiT4jtJpFjJiIwM/oJ6SxIxr0z2TaQUGqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1089.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1089.0.tgz",
+      "integrity": "sha512-Sc+JOtNeP+v+XdP9Rb4Hh+uhiNO2hh/CZQbKYooNakhOIgK6/K0cjoDCEGeFmkG0vf2DopTmSctzKlcKwy1BPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.18",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.64",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.1089.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1089.0.tgz",
+      "integrity": "sha512-Ly0bsr49in42ZRtnRbwaBo/0xv7kCWSu1/qT9V56s9JGsunJzzmTIFlvz7dwy6ISK/Dh3mFc5vrO91sj3G3YhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.1089.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.64.tgz",
+      "integrity": "sha512-RBi43anhDBUv+HCfxCOXwGOE7GmT4n7ChV04Mwr22RhXTNcamW/iWnJlOotDPCZSrJ4dEvhZSiWWQMwLX+ZhFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1796,6 +2137,87 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@smithy/core": {
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
+      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.10.tgz",
+      "integrity": "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.7.tgz",
+      "integrity": "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
+      "integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.6.tgz",
+      "integrity": "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -3138,6 +3560,12 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -7235,6 +7663,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-browserify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -7832,6 +8284,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -9,10 +9,14 @@
     "lint": "eslint",
     "test": "node --import tsx --test tests/*.test.ts",
     "ingest": "tsx scripts/ingest.ts",
-    "attach-repo": "tsx scripts/attach-repo.ts"
+    "attach-repo": "tsx scripts/attach-repo.ts",
+    "push-assets": "tsx scripts/push-assets.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1089.0",
+    "@aws-sdk/lib-storage": "^3.1089.0",
     "@huggingface/transformers": "^4.2.0",
+    "@smithy/node-http-handler": "^4.9.7",
     "@types/pngjs": "^6.0.5",
     "bmp-js": "^0.1.0",
     "diff": "^9.0.0",

--- a/web/scripts/attach-repo.ts
+++ b/web/scripts/attach-repo.ts
@@ -15,8 +15,9 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import git from "isomorphic-git";
 import pg from "pg";
-import { assetBlobPath, assetStoreDir } from "../src/lib/assets";
+import { storeBlobBytes, storeDescription } from "../src/lib/blobstore";
 import { resolveBuild } from "../src/lib/queries";
+import { loadDotEnv } from "./dotenv";
 import { buildHref } from "../src/lib/slug";
 import {
   REPO_MANIFEST_VERSION,
@@ -106,17 +107,6 @@ async function peelToCommit(
   return null;
 }
 
-/** Staged write into the content-addressed store (the ingest.ts idiom): a
- *  crash can't leave a truncated blob under its final name. */
-function storeBlob(sha256: string, data: Uint8Array): boolean {
-  const dest = assetBlobPath(sha256);
-  if (fs.existsSync(dest)) return false;
-  fs.mkdirSync(path.dirname(dest), { recursive: true });
-  const tmp = `${dest}.tmp${process.pid}`;
-  fs.writeFileSync(tmp, data);
-  fs.renameSync(tmp, dest);
-  return true;
-}
 
 const ident = (i: { name: string; email: string; timestamp: number; timezoneOffset: number }): RepoIdent => ({
   name: i.name,
@@ -126,6 +116,7 @@ const ident = (i: { name: string; email: string; timestamp: number; timezoneOffs
 });
 
 async function main() {
+  loadDotEnv();
   const opts = parseArgs(process.argv.slice(2));
 
   const hex = opts.build.toLowerCase();
@@ -257,7 +248,7 @@ async function main() {
       const sha256 = createHash("sha256").update(blob).digest("hex");
       // Git's own binary heuristic: a NUL byte in the head of the file.
       const binary = blob.subarray(0, 8000).includes(0) ? 1 : 0;
-      if (storeBlob(sha256, blob)) written++;
+      if (await storeBlobBytes(sha256, blob)) written++;
       blobs[oid] = [sha256, blob.length, binary];
       if (++done % 500 === 0) console.log(`  blobs: ${done}/${blobOids.size}`);
     }
@@ -279,7 +270,7 @@ async function main() {
         `manifest is ${(manifestBytes.length / 1e6).toFixed(0)}MB — consider a v2 interned format before attaching many repos this size`
       );
     }
-    storeBlob(manifestSha, manifestBytes);
+    await storeBlobBytes(manifestSha, manifestBytes);
 
     await pool.query(
       `INSERT INTO build_repo (build_sha256, name, manifest_sha256, head_oid, head_ref, commit_count)
@@ -292,7 +283,7 @@ async function main() {
 
     console.log(`attached "${name}" to ${build.name} (${build.sha256.slice(0, 10)})`);
     console.log(
-      `  ${commits.length} commits, ${Object.keys(trees).length} trees, ${blobOids.size} blobs (${written} new in ${assetStoreDir()})`
+      `  ${commits.length} commits, ${Object.keys(trees).length} trees, ${blobOids.size} blobs (${written} new in ${storeDescription()})`
     );
     console.log(`  manifest ${manifestSha} (${(manifestBytes.length / 1024).toFixed(0)}KB)`);
     console.log(`  ${buildHref(build.sha256, build.name)}/repo/${encodeURIComponent(name)}`);

--- a/web/scripts/dotenv.ts
+++ b/web/scripts/dotenv.ts
@@ -1,0 +1,17 @@
+// Next loads .env/.env.local into the server automatically; tsx scripts get
+// nothing, which was fine while the only knob was DATABASE_URL (always passed
+// on the command line) but not for the blob-store settings that live beside
+// the app. Mirror Next's behavior: .env first, .env.local on top — though as
+// process.loadEnvFile never overrides what's already set, variables from the
+// environment win over both, and precedence between the files means "first
+// load wins" here, so .env.local is loaded first.
+
+export function loadDotEnv(): void {
+  for (const f of [".env.local", ".env"]) {
+    try {
+      process.loadEnvFile(f);
+    } catch {
+      // no such file — nothing to load
+    }
+  }
+}

--- a/web/scripts/ingest.ts
+++ b/web/scripts/ingest.ts
@@ -15,9 +15,12 @@ import { spawn, execFileSync } from "node:child_process";
 import readline from "node:readline";
 import type { Readable } from "node:stream";
 import pg from "pg";
-import { assetBlobPath, assetStoreDir } from "../src/lib/assets";
+import { missingBlobs, storeBlobFromFile, storeDescription } from "../src/lib/blobstore";
 import { ingestRecordTx, refreshAudioIdf } from "../src/lib/ingest";
 import type { BuildRecord } from "../src/lib/types";
+import { loadDotEnv } from "./dotenv";
+
+loadDotEnv();
 
 // What this importer understands. A bundle whose manifest disagrees is rejected
 // up front: a different fingerprint profile makes the similarity tiers
@@ -65,10 +68,10 @@ function readManifest(zipPath: string): Manifest {
 }
 
 /** Unpack the bundle's asset blobs (`assets/<sha256>` members) into the
- *  content-addressed store. Blobs already present are skipped; writes are
- *  staged + renamed so a crash can't leave a truncated blob under its final
- *  name. Returns how many blobs were added. */
-function unpackAssets(zipPath: string): number {
+ *  content-addressed store. Blobs already present are skipped; writes land
+ *  under their final name only once complete (storeBlobFromFile), so a crash
+ *  can't leave a truncated blob. Returns how many blobs were added. */
+async function unpackAssets(zipPath: string): Promise<number> {
   let listing: string;
   try {
     listing = execFileSync("unzip", ["-Z1", zipPath, "assets/*"], {
@@ -82,7 +85,7 @@ function unpackAssets(zipPath: string): number {
     .split("\n")
     .map((l) => l.trim().replace(/^assets\//, ""))
     .filter((s) => /^[0-9a-f]{64}$/.test(s));
-  const missing = shas.filter((s) => !fs.existsSync(assetBlobPath(s)));
+  const missing = await missingBlobs(shas);
   if (missing.length === 0) return 0;
 
   const staging = fs.mkdtempSync(path.join(os.tmpdir(), "curator-assets-"));
@@ -92,12 +95,7 @@ function unpackAssets(zipPath: string): number {
     for (const sha of missing) {
       const src = path.join(staging, "assets", sha);
       if (!fs.existsSync(src)) continue;
-      const dest = assetBlobPath(sha);
-      fs.mkdirSync(path.dirname(dest), { recursive: true });
-      const tmp = `${dest}.tmp${process.pid}`;
-      fs.copyFileSync(src, tmp);
-      fs.renameSync(tmp, dest);
-      n++;
+      if ((await storeBlobFromFile(sha, src)) === "stored") n++;
     }
     return n;
   } finally {
@@ -134,8 +132,8 @@ async function main() {
   try {
     // Blobs before rows: once a build_asset row exists, its blob is servable.
     if (bundle.endsWith(".zip")) {
-      const added = unpackAssets(bundle);
-      if (added > 0) console.log(`unpacked ${added} asset blob(s) into ${assetStoreDir()}`);
+      const added = await unpackAssets(bundle);
+      if (added > 0) console.log(`unpacked ${added} asset blob(s) into ${storeDescription()}`);
     }
     const { lines, done } = openRecords(bundle);
     const rl = readline.createInterface({ input: lines, crlfDelay: Infinity });

--- a/web/scripts/push-assets.ts
+++ b/web/scripts/push-assets.ts
@@ -17,9 +17,9 @@ import {
 } from "../src/lib/blobstore";
 import { loadDotEnv } from "./dotenv";
 
-// Parallel uploads: most blobs are small, so a few in flight hide the
-// per-request latency without swamping the endpoint when big ones line up.
-const UPLOAD_CONCURRENCY = 4;
+// Parallel uploads: most blobs are small, so per-request latency (not
+// bandwidth) dominates — tune PUSH_CONCURRENCY up for a far-away endpoint.
+const UPLOAD_CONCURRENCY = Math.max(1, Number(process.env.PUSH_CONCURRENCY) || 8);
 
 async function main() {
   loadDotEnv();

--- a/web/scripts/push-assets.ts
+++ b/web/scripts/push-assets.ts
@@ -1,0 +1,70 @@
+// Push every blob in the local content-addressed store to the S3 backend —
+// the one-time migration when a deployment flips from local disk to S3 (and
+// an idempotent re-sync if it's ever partially done: blobs the bucket already
+// has are skipped). Local files are left in place; delete the local store
+// only after flipping the app over and confirming it serves.
+// Usage: npm run push-assets        (env ASSET_STORE_DIR + ASSET_S3_*)
+
+import fs from "node:fs";
+import path from "node:path";
+import {
+  assetBlobPath,
+  assetStoreDir,
+  missingBlobs,
+  s3Enabled,
+  storeBlobFromFile,
+  storeDescription,
+} from "../src/lib/blobstore";
+import { loadDotEnv } from "./dotenv";
+
+// Parallel uploads: most blobs are small, so a few in flight hide the
+// per-request latency without swamping the endpoint when big ones line up.
+const UPLOAD_CONCURRENCY = 4;
+
+async function main() {
+  loadDotEnv();
+  if (!s3Enabled()) {
+    console.error("ASSET_S3_ENDPOINT is not set — nothing to push to");
+    process.exit(1);
+  }
+
+  const root = assetStoreDir();
+  const shas: string[] = [];
+  for (const shard of fs.readdirSync(root).filter((d) => /^[0-9a-f]{2}$/.test(d)).sort()) {
+    for (const name of fs.readdirSync(path.join(root, shard))) {
+      if (/^[0-9a-f]{64}$/.test(name)) shas.push(name); // skips .tmp leftovers
+    }
+  }
+  console.log(`local store ${root}: ${shas.length} blob(s)`);
+
+  const missing = await missingBlobs(shas);
+  console.log(`${shas.length - missing.length} already in ${storeDescription()}, pushing ${missing.length}`);
+
+  let pushed = 0;
+  let failed = 0;
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(UPLOAD_CONCURRENCY, missing.length) }, async () => {
+      for (;;) {
+        const i = next++;
+        if (i >= missing.length) return;
+        const sha = missing[i];
+        try {
+          await storeBlobFromFile(sha, assetBlobPath(sha), { keepSource: true });
+          pushed++;
+        } catch (e) {
+          failed++;
+          console.error(`  ${sha}: ${(e as Error).message}`);
+        }
+        if ((pushed + failed) % 200 === 0) console.log(`  ${pushed + failed}/${missing.length}`);
+      }
+    })
+  );
+  console.log(`pushed ${pushed} blob(s)${failed ? `, ${failed} FAILED` : ""}`);
+  if (failed) process.exitCode = 1;
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/web/src/app/api/asset/[sha256]/png/route.ts
+++ b/web/src/app/api/asset/[sha256]/png/route.ts
@@ -1,6 +1,5 @@
-import { readFile } from "node:fs/promises";
 import type { NextRequest } from "next/server";
-import { assetBlobPath } from "@/lib/assets";
+import { readBlob } from "@/lib/blobstore";
 import { getPool } from "@/lib/db";
 import { gsAvailable, gsRenderable, gsToPng } from "@/lib/gs";
 import { pngConvertible, toPng, WEB_SAFE_IMAGE } from "@/lib/imgpng";
@@ -39,10 +38,8 @@ export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256
     return Response.json({ error: `no PNG conversion for ${meta.mime}` }, { status: 415 });
   }
 
-  let bytes: Buffer;
-  try {
-    bytes = await readFile(assetBlobPath(sha256));
-  } catch {
+  const bytes = await readBlob(sha256);
+  if (bytes === null) {
     return Response.json({ error: "asset bytes not in store" }, { status: 404 });
   }
 

--- a/web/src/app/api/asset/[sha256]/route.ts
+++ b/web/src/app/api/asset/[sha256]/route.ts
@@ -1,9 +1,7 @@
-import fs from "node:fs";
-import fsp from "node:fs/promises";
 import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
 import { unstable_cache } from "next/cache";
-import { assetBlobPath } from "@/lib/assets";
+import { blobSize, openBlobStream } from "@/lib/blobstore";
 import { getPool } from "@/lib/db";
 import { parseRange } from "@/lib/range";
 import { isSha256 } from "@/lib/validate";
@@ -59,11 +57,8 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
     return new Response(null, { status: 304, headers: { "Cache-Control": CACHE, ETag: `"${sha256}"` } });
   }
 
-  const blob = assetBlobPath(sha256);
-  let stat: fs.Stats;
-  try {
-    stat = await fsp.stat(blob);
-  } catch {
+  const size = await blobSize(sha256);
+  if (size === null) {
     // Metadata ingested but the bundle carrying the bytes hasn't landed yet.
     return Response.json({ error: "asset bytes not in store" }, { status: 404 });
   }
@@ -86,15 +81,15 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   };
 
   // Single-range support so <audio>/<video> can seek.
-  const range = parseRange(request.headers.get("range"), stat.size);
+  const range = parseRange(request.headers.get("range"), size);
+  const stream = await openBlobStream(sha256, range ?? undefined);
+  if (!stream) return Response.json({ error: "asset bytes not in store" }, { status: 404 });
   if (range) {
-    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${stat.size}`;
+    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${size}`;
     headers["Content-Length"] = String(range.end - range.start + 1);
-    const stream = fs.createReadStream(blob, { start: range.start, end: range.end });
     return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
   }
 
-  headers["Content-Length"] = String(stat.size);
-  const stream = fs.createReadStream(blob);
+  headers["Content-Length"] = String(size);
   return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
 }

--- a/web/src/app/api/repo/[sha256]/blame/route.ts
+++ b/web/src/app/api/repo/[sha256]/blame/route.ts
@@ -1,7 +1,6 @@
-import { readFile } from "node:fs/promises";
 import type { NextRequest } from "next/server";
-import { assetBlobPath } from "@/lib/assets";
 import { blameLines, type BlameCommitDto } from "@/lib/blame";
+import { readBlob } from "@/lib/blobstore";
 import { entryAt, fileLog, commitSubject, resolveRev } from "@/lib/repo-manifest";
 import { loadRepo, repoAttached } from "@/lib/repo";
 import { normalizeAssetPath } from "@/lib/slug";
@@ -56,10 +55,15 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   let versions: string[];
   try {
     versions = await Promise.all(
-      chain.map((e) => (e.blob ? readFile(assetBlobPath(idx.blobs.get(e.blob)![0]), "utf8") : ""))
+      chain.map(async (e) => {
+        if (!e.blob) return "";
+        const raw = await readBlob(idx.blobs.get(e.blob)![0]);
+        if (raw === null) throw new Error("missing blob");
+        return raw.toString("utf8");
+      })
     );
   } catch {
-    // Row + manifest landed but some blob hasn't synced to this host yet.
+    // Row + manifest landed but some blob hasn't synced to this store yet.
     return Response.json({ error: "blob bytes not in store" }, { status: 404 });
   }
 

--- a/web/src/app/api/repo/[sha256]/blob/[oid]/route.ts
+++ b/web/src/app/api/repo/[sha256]/blob/[oid]/route.ts
@@ -1,8 +1,6 @@
-import fs from "node:fs";
-import fsp from "node:fs/promises";
 import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
-import { assetBlobPath } from "@/lib/assets";
+import { blobSize, openBlobStream } from "@/lib/blobstore";
 import { loadRepo, repoAttached } from "@/lib/repo";
 import { isSha256 } from "@/lib/validate";
 
@@ -50,12 +48,9 @@ export async function GET(
     return new Response(null, { status: 304, headers: { "Cache-Control": CACHE, ETag: `"${oid}"` } });
   }
 
-  const blob = assetBlobPath(storeSha);
-  let stat: fs.Stats;
-  try {
-    stat = await fsp.stat(blob);
-  } catch {
-    // Row + manifest landed but this blob hasn't synced to this host yet.
+  const size = await blobSize(storeSha);
+  if (size === null) {
+    // Row + manifest landed but this blob hasn't synced to this store yet.
     return Response.json({ error: "blob bytes not in store" }, { status: 404 });
   }
 
@@ -71,15 +66,15 @@ export async function GET(
     "Accept-Ranges": "bytes",
   };
 
-  const range = parseRange(request.headers.get("range"), stat.size);
+  const range = parseRange(request.headers.get("range"), size);
+  const stream = await openBlobStream(storeSha, range ?? undefined);
+  if (!stream) return Response.json({ error: "blob bytes not in store" }, { status: 404 });
   if (range) {
-    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${stat.size}`;
+    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${size}`;
     headers["Content-Length"] = String(range.end - range.start + 1);
-    const stream = fs.createReadStream(blob, { start: range.start, end: range.end });
     return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
   }
 
-  headers["Content-Length"] = String(stat.size);
-  const stream = fs.createReadStream(blob);
+  headers["Content-Length"] = String(size);
   return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
 }

--- a/web/src/app/api/repo/[sha256]/og/route.tsx
+++ b/web/src/app/api/repo/[sha256]/og/route.tsx
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { NextRequest } from "next/server";
 import { ImageResponse } from "next/og";
-import { assetBlobPath } from "@/lib/assets";
+import { readBlob } from "@/lib/blobstore";
 import { diffRows, type DiffRow } from "@/lib/linediff";
 import { loadRepo, repoAttached } from "@/lib/repo";
 import {
@@ -62,7 +62,7 @@ async function blobText(idx: RepoIndex, oid: string | null): Promise<string | nu
   const info = idx.blobs.get(oid);
   if (!info || info[2] === 1 || info[1] > MAX_SNIPPET_BLOB) return null;
   try {
-    return (await readFile(assetBlobPath(info[0]))).toString("utf8");
+    return (await readBlob(info[0]))?.toString("utf8") ?? null;
   } catch {
     return null;
   }

--- a/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
-import { assetBlobPath, assetStagingPath } from "@/lib/assets";
+import { assetStagingPath, blobExists, storeBlobFromFile } from "@/lib/blobstore";
 import { referencedAssets, MAX_BUILD_ASSET_BYTES } from "@/lib/submission-assets";
 import { rateLimitCheck, clientKey } from "@/lib/ratelimit";
 import { isSha256 } from "@/lib/validate";
@@ -57,8 +57,7 @@ export async function PUT(
     return Response.json({ error: "build's total asset bytes exceed the cap" }, { status: 413 });
   }
 
-  const dest = assetBlobPath(assetSha);
-  if (fs.existsSync(dest)) return Response.json({ sha256: assetSha, status: "exists" });
+  if (await blobExists(assetSha)) return Response.json({ sha256: assetSha, status: "exists" });
 
   const rawOffset = new URL(request.url).searchParams.get("offset") ?? "0";
   const offset = Number(rawOffset);
@@ -118,14 +117,9 @@ export async function PUT(
     return Response.json({ error: "staged bytes do not hash to the asset sha256" }, { status: 422 });
   }
 
-  await fsp.mkdir(path.dirname(dest), { recursive: true });
-  try {
-    await fsp.rename(part, dest);
-  } catch (e) {
-    // A concurrent upload of the same blob may have finalized first — same bytes.
-    if (!fs.existsSync(dest)) throw e;
-    await fsp.rm(part, { force: true }).catch(() => {});
-    return Response.json({ sha256: assetSha, status: "exists" });
-  }
+  // A concurrent upload of the same blob may have finalized first — same
+  // bytes either way, so "exists" is as good as "stored".
+  const outcome = await storeBlobFromFile(assetSha, part);
+  if (outcome === "exists") return Response.json({ sha256: assetSha, status: "exists" });
   return Response.json({ sha256: assetSha, status: "stored" }, { status: 201 });
 }

--- a/web/src/app/api/submissions/[sha256]/assets/route.ts
+++ b/web/src/app/api/submissions/[sha256]/assets/route.ts
@@ -1,7 +1,6 @@
-import fs from "node:fs";
 import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
-import { assetBlobPath } from "@/lib/assets";
+import { missingBlobs } from "@/lib/blobstore";
 import { referencedAssets } from "@/lib/submission-assets";
 import { rateLimit, clientKey } from "@/lib/ratelimit";
 import { isSha256 } from "@/lib/validate";
@@ -22,6 +21,6 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   const refs = await referencedAssets(getPool(), sha256);
   if (!refs) return Response.json({ error: "not found" }, { status: 404 });
 
-  const missing = [...refs.sizes.keys()].filter((sha) => !fs.existsSync(assetBlobPath(sha)));
+  const missing = await missingBlobs([...refs.sizes.keys()]);
   return Response.json({ sha256, referenced: refs.sizes.size, missing });
 }

--- a/web/src/app/builds/[buildId]/opengraph-image.tsx
+++ b/web/src/app/builds/[buildId]/opengraph-image.tsx
@@ -6,9 +6,8 @@
 // pane when the build has a PNG/JPEG/BMP/TGA/TIFF asset whose bytes are in the
 // blob store (largest first: big files are screenshots, tiny ones are icons/textures).
 
-import { readFile } from "node:fs/promises";
 import { ImageResponse } from "next/og";
-import { assetBlobPath } from "@/lib/assets";
+import { readBlob } from "@/lib/blobstore";
 import { getPool } from "@/lib/db";
 import { pngConvertible, toPng } from "@/lib/imgpng";
 import { buildFacts, displayTitle } from "@/lib/meta";
@@ -36,7 +35,8 @@ async function findScreenshot(sha256: string): Promise<string | null> {
   // the bytes) or undecodable — fall through to the next-largest candidate.
   for (const row of r.rows as Array<{ sha256: string; mime: string }>) {
     try {
-      const bytes = await readFile(assetBlobPath(row.sha256));
+      const bytes = await readBlob(row.sha256);
+      if (bytes === null) continue;
       // satori can't decode BMP or TGA — hand it PNG bytes instead.
       if (pngConvertible(row.mime)) {
         return `data:image/png;base64,${toPng(row.mime, bytes).toString("base64")}`;

--- a/web/src/lib/assets.ts
+++ b/web/src/lib/assets.ts
@@ -1,27 +1,12 @@
-// The on-disk content-addressed blob store backing the asset viewer. Blobs are
-// extracted by the desktop analyzer, shipped inside export bundles, and placed
-// here by scripts/ingest.ts; the API route streams them out by sha256.
+// Asset-domain helpers over the content-addressed blob store (blobstore.ts).
+// Blobs are extracted by the desktop analyzer, shipped inside export bundles,
+// and stored by scripts/ingest.ts; the API routes stream them out by sha256.
 
-import path from "node:path";
-import { open } from "node:fs/promises";
+import { readBlobHead } from "./blobstore";
 import { hexPreview } from "./hexdump";
 
-/** Root of the blob store. Blobs live at `<root>/<sha256[:2]>/<sha256>`. */
-export function assetStoreDir(): string {
-  // Default sits next to the app (survives the deploy rsync, excluded from git).
-  return process.env.ASSET_STORE_DIR || path.join(process.cwd(), "asset-store");
-}
-
-/** Absolute path of one blob. Caller must have validated `sha256` (isSha256). */
-export function assetBlobPath(sha256: string): string {
-  return path.join(assetStoreDir(), sha256.slice(0, 2), sha256);
-}
-
-/** Staging file for a blob's chunked upload (`.staging` can't collide with the
- *  two-hex-char blob dirs). Caller must have validated `sha256`. */
-export function assetStagingPath(sha256: string): string {
-  return path.join(assetStoreDir(), ".staging", `${sha256}.part`);
-}
+// Path helpers re-exported for the store-layout consumers (staging, tests).
+export { assetBlobPath, assetStagingPath, assetStoreDir } from "./blobstore";
 
 /** Display order for asset kinds on the build pages. */
 export const ASSET_KIND_ORDER = ["image", "audio", "video", "document", "source", "text", "binary"] as const;
@@ -46,17 +31,7 @@ export function orderAssets<T extends { kind: string }>(
 
 /** Leading bytes of a blob, or null when it is missing from the store. */
 export async function readAssetBytes(sha256: string, maxBytes = 2048): Promise<Buffer | null> {
-  let fh;
-  try {
-    fh = await open(assetBlobPath(sha256), "r");
-    const buf = Buffer.alloc(maxBytes);
-    const { bytesRead } = await fh.read(buf, 0, maxBytes, 0);
-    return buf.subarray(0, bytesRead);
-  } catch {
-    return null;
-  } finally {
-    await fh?.close();
-  }
+  return readBlobHead(sha256, maxBytes);
 }
 
 /** Leading bytes of a text blob decoded as lossy UTF-8 for an excerpt card, or

--- a/web/src/lib/blobstore.ts
+++ b/web/src/lib/blobstore.ts
@@ -1,0 +1,349 @@
+// The content-addressed blob store backing the asset viewer, the attached-repo
+// viewer, and the submission upload path — one facade, two backends:
+//
+// - local (default): blobs at `<ASSET_STORE_DIR>/<sha256[:2]>/<sha256>`, the
+//   layout ingest has always produced.
+// - s3: an S3-compatible object store, selected by setting ASSET_S3_ENDPOINT
+//   (in production the same versitygw service the wiki's uploads go to, with
+//   a bucket of its own). Keys mirror the local layout —
+//   `<ASSET_S3_PREFIX><sha256[:2]>/<sha256>` — so versitygw's POSIX backend
+//   lays the bucket out on disk exactly like a local store.
+//
+// Under the s3 backend ASSET_STORE_DIR still serves as the local root for
+// what must stay on disk: upload staging (.staging), ffmpeg's derivative
+// caches (.transcode, .thumb), and sources materialized for ffmpeg (.fetch).
+//
+// Config (s3 backend): ASSET_S3_ENDPOINT, ASSET_S3_BUCKET (default
+// "curator"), ASSET_S3_PREFIX (default "", for scratch/test namespaces),
+// ASSET_S3_REGION (default "us-east-1"), ASSET_S3_ACCESS_KEY_ID +
+// ASSET_S3_SECRET_ACCESS_KEY (else the SDK's default credential chain), and
+// ASSET_S3_INSECURE_TLS=1 to accept a self-signed endpoint certificate.
+
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { randomBytes } from "node:crypto";
+import { Agent } from "node:https";
+import type { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { Upload } from "@aws-sdk/lib-storage";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+
+/** Root of the local store (blobs on the local backend; staging and caches
+ *  always). Defaults next to the app: survives the deploy rsync, git-ignored. */
+export function assetStoreDir(): string {
+  return process.env.ASSET_STORE_DIR || path.join(process.cwd(), "asset-store");
+}
+
+/** Local path of one blob. Caller must have validated `sha256` (isSha256). */
+export function assetBlobPath(sha256: string): string {
+  return path.join(assetStoreDir(), sha256.slice(0, 2), sha256);
+}
+
+/** Staging file for a blob's chunked upload (`.staging` can't collide with the
+ *  two-hex-char blob dirs). Caller must have validated `sha256`. */
+export function assetStagingPath(sha256: string): string {
+  return path.join(assetStoreDir(), ".staging", `${sha256}.part`);
+}
+
+/** Whether blob reads/writes go to the S3 backend. */
+export function s3Enabled(): boolean {
+  return !!process.env.ASSET_S3_ENDPOINT;
+}
+
+/** Where blobs land, for operator-facing log lines. */
+export function storeDescription(): string {
+  if (!s3Enabled()) return assetStoreDir();
+  return `${process.env.ASSET_S3_ENDPOINT}/${s3Bucket()}/${s3Prefix()}`;
+}
+
+function s3Bucket(): string {
+  return process.env.ASSET_S3_BUCKET || "curator";
+}
+
+function s3Prefix(): string {
+  return process.env.ASSET_S3_PREFIX || "";
+}
+
+function s3Key(sha256: string): string {
+  return `${s3Prefix()}${sha256.slice(0, 2)}/${sha256}`;
+}
+
+// One client per process; the config is env-fixed for the process lifetime.
+let client: S3Client | null = null;
+
+function s3(): S3Client {
+  if (!client) {
+    const accessKeyId = process.env.ASSET_S3_ACCESS_KEY_ID;
+    const secretAccessKey = process.env.ASSET_S3_SECRET_ACCESS_KEY;
+    client = new S3Client({
+      endpoint: process.env.ASSET_S3_ENDPOINT,
+      region: process.env.ASSET_S3_REGION || "us-east-1",
+      // versitygw/minio address buckets by path, not virtual host.
+      forcePathStyle: true,
+      ...(accessKeyId && secretAccessKey
+        ? { credentials: { accessKeyId, secretAccessKey } }
+        : {}),
+      ...(process.env.ASSET_S3_INSECURE_TLS === "1"
+        ? {
+            requestHandler: new NodeHttpHandler({
+              httpsAgent: new Agent({ rejectUnauthorized: false }),
+            }),
+          }
+        : {}),
+    });
+  }
+  return client;
+}
+
+/** Errors that mean "no such object", as opposed to a broken store. */
+function isMissing(err: unknown): boolean {
+  const e = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return e?.name === "NoSuchKey" || e?.name === "NotFound" || e?.$metadata?.httpStatusCode === 404;
+}
+
+function httpStatus(err: unknown): number | undefined {
+  return (err as { $metadata?: { httpStatusCode?: number } })?.$metadata?.httpStatusCode;
+}
+
+/** Byte size of a blob, or null when it is missing from the store. */
+export async function blobSize(sha256: string): Promise<number | null> {
+  if (s3Enabled()) {
+    try {
+      const r = await s3().send(new HeadObjectCommand({ Bucket: s3Bucket(), Key: s3Key(sha256) }));
+      return r.ContentLength ?? null;
+    } catch (err) {
+      if (isMissing(err)) return null;
+      throw err;
+    }
+  }
+  try {
+    return (await fsp.stat(assetBlobPath(sha256))).size;
+  } catch {
+    return null;
+  }
+}
+
+export async function blobExists(sha256: string): Promise<boolean> {
+  return (await blobSize(sha256)) !== null;
+}
+
+// Bounds concurrent HEADs in missingBlobs (and nothing else): high enough to
+// hide the per-request latency, low enough to be a polite S3 client.
+const EXISTS_CONCURRENCY = 16;
+
+/** The subset of `shas` missing from the store, in input order. */
+export async function missingBlobs(shas: string[]): Promise<string[]> {
+  if (!s3Enabled()) return shas.filter((s) => !fs.existsSync(assetBlobPath(s)));
+  const present = new Array<boolean>(shas.length);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(EXISTS_CONCURRENCY, shas.length) }, async () => {
+      for (;;) {
+        const i = next++;
+        if (i >= shas.length) return;
+        present[i] = await blobExists(shas[i]);
+      }
+    })
+  );
+  return shas.filter((_, i) => !present[i]);
+}
+
+/** A readable stream over a blob (optionally one byte range), or null when it
+ *  is missing from the store. */
+export async function openBlobStream(
+  sha256: string,
+  range?: { start: number; end: number }
+): Promise<Readable | null> {
+  if (s3Enabled()) {
+    try {
+      const r = await s3().send(
+        new GetObjectCommand({
+          Bucket: s3Bucket(),
+          Key: s3Key(sha256),
+          ...(range ? { Range: `bytes=${range.start}-${range.end}` } : {}),
+        })
+      );
+      return r.Body as Readable;
+    } catch (err) {
+      if (isMissing(err)) return null;
+      throw err;
+    }
+  }
+  // open() first so a missing blob is a null, not a later stream error event.
+  try {
+    const fh = await fsp.open(assetBlobPath(sha256), "r");
+    return fh.createReadStream(range ? { start: range.start, end: range.end } : {});
+  } catch {
+    return null;
+  }
+}
+
+/** A whole blob in memory, or null when it is missing from the store.
+ *  Callers cap sizes (convert/preview paths); don't hand this a DVD image. */
+export async function readBlob(sha256: string): Promise<Buffer | null> {
+  if (s3Enabled()) {
+    try {
+      const r = await s3().send(new GetObjectCommand({ Bucket: s3Bucket(), Key: s3Key(sha256) }));
+      return Buffer.from(await r.Body!.transformToByteArray());
+    } catch (err) {
+      if (isMissing(err)) return null;
+      throw err;
+    }
+  }
+  try {
+    return await fsp.readFile(assetBlobPath(sha256));
+  } catch {
+    return null;
+  }
+}
+
+/** Leading bytes of a blob, or null when it is missing from the store. */
+export async function readBlobHead(sha256: string, maxBytes = 2048): Promise<Buffer | null> {
+  if (s3Enabled()) {
+    try {
+      const r = await s3().send(
+        new GetObjectCommand({
+          Bucket: s3Bucket(),
+          Key: s3Key(sha256),
+          Range: `bytes=0-${maxBytes - 1}`,
+        })
+      );
+      return Buffer.from(await r.Body!.transformToByteArray());
+    } catch (err) {
+      if (isMissing(err)) return null;
+      // An empty object satisfies no byte range (416) but does exist.
+      if (httpStatus(err) === 416) {
+        return (await blobSize(sha256)) === null ? null : Buffer.alloc(0);
+      }
+      throw err;
+    }
+  }
+  let fh;
+  try {
+    fh = await fsp.open(assetBlobPath(sha256), "r");
+    const buf = Buffer.alloc(maxBytes);
+    const { bytesRead } = await fh.read(buf, 0, maxBytes, 0);
+    return buf.subarray(0, bytesRead);
+  } catch {
+    return null;
+  } finally {
+    await fh?.close();
+  }
+}
+
+/** Move a completed local file into the store ("exists" means an identical
+ *  blob was already stored — content-addressed, so concurrent writers of the
+ *  same key can only race harmlessly). Consumes `src` unless `keepSource` is
+ *  set (the migration script pushes the local store without eating it). */
+export async function storeBlobFromFile(
+  sha256: string,
+  src: string,
+  opts?: { keepSource?: boolean }
+): Promise<"stored" | "exists"> {
+  const cleanup = async () => {
+    if (!opts?.keepSource) await fsp.rm(src, { force: true });
+  };
+  if (s3Enabled()) {
+    if (await blobExists(sha256)) {
+      await cleanup();
+      return "exists";
+    }
+    // Multipart so multi-GB video blobs upload in bounded memory with
+    // per-part retries.
+    await new Upload({
+      client: s3(),
+      params: { Bucket: s3Bucket(), Key: s3Key(sha256), Body: fs.createReadStream(src) },
+    }).done();
+    await cleanup();
+    return "stored";
+  }
+  const dest = assetBlobPath(sha256);
+  if (fs.existsSync(dest)) {
+    await cleanup();
+    return "exists";
+  }
+  await fsp.mkdir(path.dirname(dest), { recursive: true });
+  // Copy to a private temp name in the final dir, then rename, so a crash
+  // can't leave a truncated blob under its final name.
+  const copyIn = async () => {
+    const tmp = `${dest}.tmp${process.pid}`;
+    await fsp.copyFile(src, tmp);
+    await fsp.rename(tmp, dest);
+    await cleanup();
+  };
+  if (opts?.keepSource) {
+    await copyIn();
+    return "stored";
+  }
+  try {
+    // Same-filesystem fast path (upload staging lives inside the store root).
+    await fsp.rename(src, dest);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+      // Cross-device source (ingest stages under os.tmpdir).
+      await copyIn();
+    } else if (fs.existsSync(dest)) {
+      await cleanup();
+      return "exists";
+    } else {
+      throw err;
+    }
+  }
+  return "stored";
+}
+
+/** Write one in-memory blob into the store. True when newly stored, false
+ *  when an identical blob was already there. */
+export async function storeBlobBytes(sha256: string, data: Uint8Array): Promise<boolean> {
+  if (s3Enabled()) {
+    if (await blobExists(sha256)) return false;
+    await s3().send(
+      new PutObjectCommand({
+        Bucket: s3Bucket(),
+        Key: s3Key(sha256),
+        Body: data,
+        ContentLength: data.byteLength,
+      })
+    );
+    return true;
+  }
+  const dest = assetBlobPath(sha256);
+  if (fs.existsSync(dest)) return false;
+  await fsp.mkdir(path.dirname(dest), { recursive: true });
+  const tmp = `${dest}.tmp${process.pid}`;
+  await fsp.writeFile(tmp, data);
+  await fsp.rename(tmp, dest);
+  return true;
+}
+
+/** Run `fn` with a blob available at a local path — the store file itself on
+ *  the local backend, a temp copy under `.fetch/` on s3 (ffmpeg wants a real
+ *  file it can seek). Returns null when the blob is missing from the store. */
+export async function withBlobFile<T>(
+  sha256: string,
+  fn: (localPath: string) => Promise<T>
+): Promise<T | null> {
+  if (!s3Enabled()) {
+    const p = assetBlobPath(sha256);
+    if (!fs.existsSync(p)) return null;
+    return fn(p);
+  }
+  const stream = await openBlobStream(sha256);
+  if (!stream) return null;
+  const dir = path.join(assetStoreDir(), ".fetch");
+  await fsp.mkdir(dir, { recursive: true });
+  const tmp = path.join(dir, `${sha256}.${randomBytes(4).toString("hex")}`);
+  try {
+    await pipeline(stream, fs.createWriteStream(tmp));
+    return await fn(tmp);
+  } finally {
+    await fsp.rm(tmp, { force: true });
+  }
+}

--- a/web/src/lib/ffmpeg.ts
+++ b/web/src/lib/ffmpeg.ts
@@ -20,7 +20,7 @@ import { randomBytes } from "node:crypto";
 import { mkdir, readFile, rename, rm, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
-import { assetBlobPath, assetStoreDir } from "./assets";
+import { assetStoreDir, withBlobFile } from "./blobstore";
 
 const execFileP = promisify(execFile);
 
@@ -234,45 +234,50 @@ async function transcode(
   job: Job
 ): Promise<{ path: string; mime: string }> {
   await mkdir(dirname(out), { recursive: true });
-  const input = assetBlobPath(sha256);
-  const size = (await stat(input)).size;
-  job.durationUs = await probeDurationUs(input);
-  // Private temp name in the final dir, atomically renamed on success, so a
-  // concurrent request in another process never streams a partial file.
-  const tmp = `${out}.${randomBytes(4).toString("hex")}.part`;
-  const args = [
-    "-hide_banner",
-    "-loglevel",
-    "error",
-    "-progress",
-    job.progressPath,
-    "-y",
-    "-i",
-    input,
-    // First video + first audio track only: DVD VOBs carry alternate audio
-    // tracks and subpicture/nav streams a browser player has no UI for.
-    "-map",
-    "0:v:0",
-    "-map",
-    "0:a:0?",
-    "-dn",
-    "-sn",
-    // Deinterlace frames flagged interlaced (DVD content usually is), and
-    // keep dimensions even (4:2:0 encoders reject odd sizes).
-    "-vf",
-    "yadif=deint=interlaced,scale=trunc(iw/2)*2:trunc(ih/2)*2",
-    ...p.args,
-    tmp,
-  ];
-  try {
-    await execFileP(FFMPEG_BIN, args, { timeout: transcodeTimeoutMs(size), maxBuffer: 4_000_000 });
-    if ((await stat(tmp)).size === 0) throw new Error("empty transcode");
-    await rename(tmp, out);
-    return { path: out, mime: p.mime };
-  } catch (err) {
-    await rm(tmp, { force: true });
-    throw err;
-  }
+  // ffmpeg needs a seekable local file — withBlobFile materializes the blob
+  // when the store is remote (and is a no-op pass-through when it's local).
+  const result = await withBlobFile(sha256, async (input) => {
+    const size = (await stat(input)).size;
+    job.durationUs = await probeDurationUs(input);
+    // Private temp name in the final dir, atomically renamed on success, so a
+    // concurrent request in another process never streams a partial file.
+    const tmp = `${out}.${randomBytes(4).toString("hex")}.part`;
+    const args = [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-progress",
+      job.progressPath,
+      "-y",
+      "-i",
+      input,
+      // First video + first audio track only: DVD VOBs carry alternate audio
+      // tracks and subpicture/nav streams a browser player has no UI for.
+      "-map",
+      "0:v:0",
+      "-map",
+      "0:a:0?",
+      "-dn",
+      "-sn",
+      // Deinterlace frames flagged interlaced (DVD content usually is), and
+      // keep dimensions even (4:2:0 encoders reject odd sizes).
+      "-vf",
+      "yadif=deint=interlaced,scale=trunc(iw/2)*2:trunc(ih/2)*2",
+      ...p.args,
+      tmp,
+    ];
+    try {
+      await execFileP(FFMPEG_BIN, args, { timeout: transcodeTimeoutMs(size), maxBuffer: 4_000_000 });
+      if ((await stat(tmp)).size === 0) throw new Error("empty transcode");
+      await rename(tmp, out);
+      return { path: out, mime: p.mime };
+    } catch (err) {
+      await rm(tmp, { force: true });
+      throw err;
+    }
+  });
+  if (result === null) throw new Error("blob missing from store");
+  return result;
 }
 
 // One thumbnail per blob at a time, same reason as transcodes.
@@ -296,38 +301,40 @@ export async function ensureThumb(sha256: string): Promise<string> {
 
 async function thumb(sha256: string, out: string): Promise<string> {
   await mkdir(dirname(out), { recursive: true });
-  const input = assetBlobPath(sha256);
-  await stat(input); // missing blob: fail before spawning ffmpeg
-  // A quarter in (bounded) skips studio logos and fade-ins; the thumbnail
-  // filter then picks the most representative of the next frames, dodging
-  // black frames around the seek point. Falls back to the very start for
-  // clips too short to seek into.
-  const durationUs = await probeDurationUs(input);
-  const seekSec = durationUs ? Math.min(Math.max((durationUs / 1e6) * 0.25, 1), 45) : 3;
-  const tmp = `${out}.${randomBytes(4).toString("hex")}.part`;
-  const argsAt = (seek: number) => [
-    "-hide_banner", "-loglevel", "error", "-y",
-    ...(seek > 0 ? ["-ss", String(seek)] : []),
-    "-i", input,
-    "-map", "0:v:0", "-dn", "-sn", "-an",
-    "-vf", "yadif=deint=interlaced,thumbnail=48,scale=trunc(min(iw\\,512)/2)*2:-2",
-    "-frames:v", "1", "-c:v", "mjpeg", "-q:v", "4", "-f", "image2",
-    tmp,
-  ];
-  try {
-    for (const seek of seekSec > 0 ? [seekSec, 0] : [0]) {
-      try {
-        await execFileP(FFMPEG_BIN, argsAt(seek), { timeout: THUMB_TIMEOUT_MS, maxBuffer: 4_000_000 });
-        if ((await stat(tmp)).size > 0) {
-          await rename(tmp, out);
-          return out;
+  const result = await withBlobFile(sha256, async (input) => {
+    // A quarter in (bounded) skips studio logos and fade-ins; the thumbnail
+    // filter then picks the most representative of the next frames, dodging
+    // black frames around the seek point. Falls back to the very start for
+    // clips too short to seek into.
+    const durationUs = await probeDurationUs(input);
+    const seekSec = durationUs ? Math.min(Math.max((durationUs / 1e6) * 0.25, 1), 45) : 3;
+    const tmp = `${out}.${randomBytes(4).toString("hex")}.part`;
+    const argsAt = (seek: number) => [
+      "-hide_banner", "-loglevel", "error", "-y",
+      ...(seek > 0 ? ["-ss", String(seek)] : []),
+      "-i", input,
+      "-map", "0:v:0", "-dn", "-sn", "-an",
+      "-vf", "yadif=deint=interlaced,thumbnail=48,scale=trunc(min(iw\\,512)/2)*2:-2",
+      "-frames:v", "1", "-c:v", "mjpeg", "-q:v", "4", "-f", "image2",
+      tmp,
+    ];
+    try {
+      for (const seek of seekSec > 0 ? [seekSec, 0] : [0]) {
+        try {
+          await execFileP(FFMPEG_BIN, argsAt(seek), { timeout: THUMB_TIMEOUT_MS, maxBuffer: 4_000_000 });
+          if ((await stat(tmp)).size > 0) {
+            await rename(tmp, out);
+            return out;
+          }
+        } catch {
+          // Retry from the start (a clip shorter than the seek), then give up.
         }
-      } catch {
-        // Retry from the start (a clip shorter than the seek), then give up.
       }
+      throw new Error("no frame extracted");
+    } finally {
+      await rm(tmp, { force: true });
     }
-    throw new Error("no frame extracted");
-  } finally {
-    await rm(tmp, { force: true });
-  }
+  });
+  if (result === null) throw new Error("blob missing from store");
+  return result;
 }

--- a/web/src/lib/repo.ts
+++ b/web/src/lib/repo.ts
@@ -4,9 +4,8 @@
 // + indexed form, not unstable_cache (which would re-serialize the whole
 // manifest into Next's incremental cache per revalidation window).
 
-import { readFile } from "node:fs/promises";
 import { unstable_cache } from "next/cache";
-import { assetBlobPath } from "./assets";
+import { readBlob } from "./blobstore";
 import { getPool } from "./db";
 import { indexManifest, REPO_MANIFEST_VERSION, type RepoIndex, type RepoManifest } from "./repo-manifest";
 
@@ -28,9 +27,11 @@ export async function loadRepo(manifestSha256: string): Promise<RepoIndex | null
   }
   let manifest: RepoManifest;
   try {
-    manifest = JSON.parse(await readFile(assetBlobPath(manifestSha256), "utf8")) as RepoManifest;
+    const raw = await readBlob(manifestSha256);
+    if (raw === null) return null; // row landed before the blob synced
+    manifest = JSON.parse(raw.toString("utf8")) as RepoManifest;
   } catch {
-    return null; // row landed before the blob synced, or the store is elsewhere
+    return null; // unparseable manifest blob
   }
   if (manifest.version !== REPO_MANIFEST_VERSION) return null;
   const idx = indexManifest(manifest);

--- a/web/tests/blobstore.test.ts
+++ b/web/tests/blobstore.test.ts
@@ -1,0 +1,104 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  assetBlobPath,
+  blobExists,
+  blobSize,
+  missingBlobs,
+  openBlobStream,
+  readBlob,
+  readBlobHead,
+  storeBlobBytes,
+  storeBlobFromFile,
+  withBlobFile,
+} from "../src/lib/blobstore";
+
+// Local backend only (the s3 backend needs a live endpoint). The store dir is
+// read per call, so pointing the env at a temp dir scopes every path in this
+// file to it.
+async function tempStore(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "blobstore-test-"));
+  process.env.ASSET_STORE_DIR = dir;
+  return dir;
+}
+
+const SHA_A = "aa".repeat(32);
+const SHA_B = "bb".repeat(32);
+
+async function drain(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const c of stream) chunks.push(c as Buffer);
+  return Buffer.concat(chunks);
+}
+
+test("blob reads answer null for a missing blob and bytes for a stored one", async () => {
+  await tempStore();
+  assert.equal(await blobSize(SHA_A), null);
+  assert.equal(await blobExists(SHA_A), false);
+  assert.equal(await readBlob(SHA_A), null);
+  assert.equal(await readBlobHead(SHA_A), null);
+  assert.equal(await openBlobStream(SHA_A), null);
+
+  assert.equal(await storeBlobBytes(SHA_A, Buffer.from("hello blob")), true);
+  assert.equal(await blobSize(SHA_A), 10);
+  assert.equal((await readBlob(SHA_A))?.toString(), "hello blob");
+  assert.equal((await readBlobHead(SHA_A, 5))?.toString(), "hello");
+  // Re-storing an existing blob is a no-op.
+  assert.equal(await storeBlobBytes(SHA_A, Buffer.from("hello blob")), false);
+});
+
+test("openBlobStream serves whole blobs and byte ranges", async () => {
+  await tempStore();
+  await storeBlobBytes(SHA_A, Buffer.from("0123456789"));
+  assert.equal((await drain((await openBlobStream(SHA_A))!)).toString(), "0123456789");
+  assert.equal((await drain((await openBlobStream(SHA_A, { start: 2, end: 5 }))!)).toString(), "2345");
+});
+
+test("missingBlobs preserves input order", async () => {
+  await tempStore();
+  await storeBlobBytes(SHA_B, Buffer.from("x"));
+  assert.deepEqual(await missingBlobs([SHA_A, SHA_B]), [SHA_A]);
+  assert.deepEqual(await missingBlobs([SHA_B]), []);
+});
+
+test("storeBlobFromFile moves, copies on keepSource, and answers exists", async () => {
+  const dir = await tempStore();
+  const src = join(dir, "staged.part");
+
+  await writeFile(src, "staged bytes");
+  assert.equal(await storeBlobFromFile(SHA_A, src), "stored");
+  assert.equal(existsSync(src), false); // consumed
+  assert.equal((await readBlob(SHA_A))?.toString(), "staged bytes");
+
+  await writeFile(src, "staged bytes");
+  assert.equal(await storeBlobFromFile(SHA_A, src), "exists");
+  assert.equal(existsSync(src), false); // consumed even when already stored
+
+  await writeFile(src, "kept bytes");
+  assert.equal(await storeBlobFromFile(SHA_B, src, { keepSource: true }), "stored");
+  assert.equal((await readFile(src)).toString(), "kept bytes"); // source intact
+  assert.equal((await readBlob(SHA_B))?.toString(), "kept bytes");
+});
+
+test("withBlobFile hands the local blob path through and null when missing", async () => {
+  await tempStore();
+  assert.equal(await withBlobFile(SHA_A, async () => "ran"), null);
+  await storeBlobBytes(SHA_A, Buffer.from("payload"));
+  const got = await withBlobFile(SHA_A, async (p) => {
+    assert.equal(p, assetBlobPath(SHA_A)); // local backend: no temp copy
+    return (await readFile(p)).toString();
+  });
+  assert.equal(got, "payload");
+});
+
+test("readBlobHead of an empty blob answers empty, not missing", async () => {
+  await tempStore();
+  const blob = assetBlobPath(SHA_A);
+  await mkdir(dirname(blob), { recursive: true });
+  await writeFile(blob, "");
+  assert.equal((await readBlobHead(SHA_A))?.length, 0);
+});


### PR DESCRIPTION
Asset and repo blobs now go through a storage facade (src/lib/blobstore.ts) with the existing local filesystem layout as the default and an S3-compatible backend selected by ASSET_S3_ENDPOINT. Reads keep streaming through the app's routes, so the bucket stays private and unlisted-build semantics are unchanged.

Upload staging and the ffmpeg caches stay on local disk, with remote sources materialized to a temp file for transcoding. npm run push-assets migrates an existing local store into the bucket (idempotent, keeps local files).