### PR TITLE
Transcode ADPCM WAVs for browser playback

### DIFF
--- a/web/src/app/api/asset/[sha256]/audio/route.ts
+++ b/web/src/app/api/asset/[sha256]/audio/route.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { Readable } from "node:stream";
+import type { NextRequest } from "next/server";
+import { readBlobHead } from "@/lib/blobstore";
+import { getPool } from "@/lib/db";
+import { ensureAudioTranscode } from "@/lib/ffmpeg";
+import { parseRange } from "@/lib/range";
+import { isSha256 } from "@/lib/validate";
+import { wavBrowserPlayable } from "@/lib/wav";
+
+export const runtime = "nodejs";
+
+// GET /api/asset/<sha256>/audio — where <audio> should stream a WAV from.
+// Console builds carry WAVs whose codec is an ADPCM variant browsers won't
+// decode (e.g. Xbox ADPCM, format tag 0x0069). The extractor stamps them all
+// audio/wav, so the codec check reads the fmt chunk from the blob itself.
+// Natively playable WAVs (PCM, float, A-law, µ-law) redirect to the raw asset
+// route, keeping one copy in the browser cache. The rest are transcoded once
+// to 16-bit PCM WAV, cached on disk, and streamed with Range support. The URL
+// is content-addressed, so responses cache hard.
+
+const CACHE = "public, max-age=31536000, immutable";
+const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const r = await getPool().query(
+    "SELECT path, mime FROM build_asset WHERE sha256=$1 LIMIT 1",
+    [sha256]
+  );
+  const meta = r.rows[0] as { path: string; mime: string } | undefined;
+  if (!meta) return Response.json({ error: "not found" }, { status: 404 });
+
+  if (meta.mime !== "audio/wav") {
+    // Only WAV hides its codec behind one mime; every other audio format we
+    // extract plays as-is.
+    return /^audio\//.test(meta.mime)
+      ? Response.redirect(new URL(`/api/asset/${sha256}`, request.url), 308)
+      : Response.json({ error: `no audio transcode for ${meta.mime}` }, { status: 415 });
+  }
+
+  // The browser already holds an immutable copy of the transcode (this ETag
+  // is only ever set on transcoded responses): never re-send the bytes.
+  if (request.headers.get("if-none-match") === `"${sha256}-audio"`) {
+    return new Response(null, {
+      status: 304,
+      headers: { "Cache-Control": CACHE, ETag: `"${sha256}-audio"` },
+    });
+  }
+
+  const head = await readBlobHead(sha256);
+  if (head === null) return Response.json({ error: "asset bytes not in store" }, { status: 404 });
+  if (wavBrowserPlayable(head)) {
+    return Response.redirect(new URL(`/api/asset/${sha256}`, request.url), 308);
+  }
+
+  // No soft-wait/202 dance like video: ADPCM to PCM runs far faster than
+  // real time, so even the biggest WAVs in the corpus finish within the
+  // request.
+  let audioPath: string;
+  try {
+    audioPath = await ensureAudioTranscode(sha256);
+  } catch {
+    // No usable ffmpeg, blob missing from the store, or ffmpeg rejected or
+    // timed out on the input.
+    return Response.json({ error: "untranscodable audio" }, { status: 415 });
+  }
+  const stat = await fsp.stat(audioPath);
+
+  const name = meta.path.split("/").pop() || `${sha256}.wav`;
+  const asciiName = name.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+  const headers: Record<string, string> = {
+    "Content-Type": "audio/wav",
+    "Content-Disposition": `inline; filename="${asciiName}"`,
+    "Cache-Control": CACHE,
+    ETag: `"${sha256}-audio"`,
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": CSP,
+    "Accept-Ranges": "bytes",
+  };
+
+  // Single-range support so <audio> can seek.
+  const range = parseRange(request.headers.get("range"), stat.size);
+  if (range) {
+    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${stat.size}`;
+    headers["Content-Length"] = String(range.end - range.start + 1);
+    const stream = fs.createReadStream(audioPath, { start: range.start, end: range.end });
+    return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
+  }
+
+  headers["Content-Length"] = String(stat.size);
+  const stream = fs.createReadStream(audioPath);
+  return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
+}

--- a/web/src/app/api/asset/[sha256]/audio/route.ts
+++ b/web/src/app/api/asset/[sha256]/audio/route.ts
@@ -34,12 +34,19 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   const meta = r.rows[0] as { path: string; mime: string } | undefined;
   if (!meta) return Response.json({ error: "not found" }, { status: 404 });
 
+  // Relative Location: request.url behind the reverse proxy is the internal
+  // origin (localhost:6800), which must never leak into a redirect target.
+  const toRaw = () =>
+    new Response(null, {
+      status: 308,
+      headers: { Location: `/api/asset/${sha256}`, "Cache-Control": CACHE },
+    });
+
   if (meta.mime !== "audio/wav") {
-    // Only WAV hides its codec behind one mime; every other audio format we
+    // Only WAV hides its codec behind one mime. Every other audio format we
     // extract plays as-is.
-    return /^audio\//.test(meta.mime)
-      ? Response.redirect(new URL(`/api/asset/${sha256}`, request.url), 308)
-      : Response.json({ error: `no audio transcode for ${meta.mime}` }, { status: 415 });
+    if (/^audio\//.test(meta.mime)) return toRaw();
+    return Response.json({ error: `no audio transcode for ${meta.mime}` }, { status: 415 });
   }
 
   // The browser already holds an immutable copy of the transcode (this ETag
@@ -53,9 +60,7 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
 
   const head = await readBlobHead(sha256);
   if (head === null) return Response.json({ error: "asset bytes not in store" }, { status: 404 });
-  if (wavBrowserPlayable(head)) {
-    return Response.redirect(new URL(`/api/asset/${sha256}`, request.url), 308);
-  }
+  if (wavBrowserPlayable(head)) return toRaw();
 
   // No soft-wait/202 dance like video: ADPCM to PCM runs far faster than
   // real time, so even the biggest WAVs in the corpus finish within the

--- a/web/src/app/api/asset/[sha256]/video/route.ts
+++ b/web/src/app/api/asset/[sha256]/video/route.ts
@@ -40,7 +40,12 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   if (!meta) return Response.json({ error: "not found" }, { status: 404 });
 
   if (meta.mime === "video/mp4" || meta.mime === "video/webm") {
-    return Response.redirect(new URL(`/api/asset/${sha256}`, request.url), 308);
+    // Relative Location: request.url behind the reverse proxy is the internal
+    // origin (localhost:6800), which must never leak into a redirect target.
+    return new Response(null, {
+      status: 308,
+      headers: { Location: `/api/asset/${sha256}`, "Cache-Control": CACHE },
+    });
   }
   if (!transcodable(meta.mime)) {
     return Response.json({ error: `no video transcode for ${meta.mime}` }, { status: 415 });

--- a/web/src/app/builds/[buildId]/AssetViewer.tsx
+++ b/web/src/app/builds/[buildId]/AssetViewer.tsx
@@ -36,6 +36,14 @@ export function videoSrc(a: ViewableAsset): string {
   return a.mime === "video/mpeg" ? `${assetUrl(a)}/video` : assetUrl(a);
 }
 
+/** Where <audio> should point: WAVs go through the server's codec sniff,
+ *  since console builds are full of ADPCM WAVs browsers won't decode. Those
+ *  come back as a PCM transcode (native ones redirect to the raw bytes).
+ *  Every other audio mime we extract plays as-is. */
+export function audioSrc(a: ViewableAsset): string {
+  return a.mime === "audio/wav" ? `${assetUrl(a)}/audio` : assetUrl(a);
+}
+
 /** Poster still for a video asset (server-side ffmpeg frame grab). */
 export function videoThumbSrc(a: ViewableAsset): string {
   return `${assetUrl(a)}/thumb`;
@@ -307,7 +315,6 @@ function DocumentBody({ asset }: { asset: ViewableAsset }) {
 
 function Body({ asset }: { asset: ViewableAsset }) {
   const [failed, setFailed] = useState(false);
-  const url = assetUrl(asset);
   if (failed) {
     return <p className="p-6 text-sm text-red-500">Failed to load media.</p>;
   }
@@ -325,7 +332,9 @@ function Body({ asset }: { asset: ViewableAsset }) {
         />
       );
     case "audio":
-      return <audio controls src={url} className="w-[min(40rem,85vw)]" onError={() => setFailed(true)} />;
+      return (
+        <audio controls src={audioSrc(asset)} className="w-[min(40rem,85vw)]" onError={() => setFailed(true)} />
+      );
     case "video":
       return <VideoBody asset={asset} />;
     case "document":

--- a/web/src/app/builds/[buildId]/AudioEmbed.tsx
+++ b/web/src/app/builds/[buildId]/AudioEmbed.tsx
@@ -5,11 +5,12 @@
 // full buffers only), so the decode is lazy: when the embed scrolls into view
 // for small files, or on first play. The decode fetch warms the browser's HTTP
 // cache — blobs are immutable — so the <audio> element's own load is free.
-// Files whose codec the browser can't decode still play natively if possible;
-// the waveform just stays a flat placeholder.
+// WAVs stream via audioSrc (ADPCM variants come back as a server-side PCM
+// transcode). Anything the browser still can't decode keeps a flat
+// placeholder waveform.
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { assetUrl, humanSize, type ViewableAsset } from "./AssetViewer";
+import { audioSrc, humanSize, type ViewableAsset } from "./AssetViewer";
 import { useOpenAsset } from "./AssetViewerHost";
 
 const BARS = 160;
@@ -51,7 +52,7 @@ function fmtTime(s: number): string {
 }
 
 export default function AudioEmbed({ asset }: { asset: ViewableAsset }) {
-  const url = assetUrl(asset);
+  const url = audioSrc(asset);
   const openAsset = useOpenAsset();
   const rootRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);

--- a/web/src/lib/ffmpeg.ts
+++ b/web/src/lib/ffmpeg.ts
@@ -1,5 +1,6 @@
 // ffmpeg-backed transcoding: MPEG-1/2 program streams (.mpg, DVD .vob) and
-// bare MPEG video elementary streams to a format browsers actually play.
+// bare MPEG video elementary streams to a format browsers actually play, and
+// ADPCM-family WAVs (Xbox ADPCM and friends) to plain 16-bit PCM WAV.
 // Like Ghostscript in gs.ts, ffmpeg is a soft dependency: feature-detected at
 // runtime, and callers degrade (download-only viewer) when it's missing.
 //
@@ -271,6 +272,54 @@ async function transcode(
       if ((await stat(tmp)).size === 0) throw new Error("empty transcode");
       await rename(tmp, out);
       return { path: out, mime: p.mime };
+    } catch (err) {
+      await rm(tmp, { force: true });
+      throw err;
+    }
+  });
+  if (result === null) throw new Error("blob missing from store");
+  return result;
+}
+
+// One audio transcode per blob at a time, same reason as video transcodes.
+const audioInFlight = new Map<string, Promise<string>>();
+
+/**
+ * The cached browser-playable PCM WAV for this audio blob, produced on first
+ * use. For WAVs whose codec browsers won't decode (ADPCM variants, per the
+ * wav.ts sniff). Every ffmpeg encodes pcm_s16le, so unlike video there is no
+ * output-profile detection: a missing binary just rejects.
+ * Throws when ffmpeg is missing, errors on the input, or times out.
+ */
+export async function ensureAudioTranscode(sha256: string): Promise<string> {
+  const out = transcodePath(sha256, ".wav");
+  if (await nonEmpty(out)) return out;
+  let job = audioInFlight.get(sha256);
+  if (!job) {
+    job = transcodeAudio(sha256, out).finally(() => audioInFlight.delete(sha256));
+    audioInFlight.set(sha256, job);
+  }
+  return job;
+}
+
+async function transcodeAudio(sha256: string, out: string): Promise<string> {
+  await mkdir(dirname(out), { recursive: true });
+  const result = await withBlobFile(sha256, async (input) => {
+    const size = (await stat(input)).size;
+    const tmp = `${out}.${randomBytes(4).toString("hex")}.part`;
+    const args = [
+      "-hide_banner", "-loglevel", "error", "-y",
+      "-i", input,
+      "-map", "0:a:0",
+      "-c:a", "pcm_s16le",
+      "-f", "wav",
+      tmp,
+    ];
+    try {
+      await execFileP(FFMPEG_BIN, args, { timeout: transcodeTimeoutMs(size), maxBuffer: 4_000_000 });
+      if ((await stat(tmp)).size === 0) throw new Error("empty transcode");
+      await rename(tmp, out);
+      return out;
     } catch (err) {
       await rm(tmp, { force: true });
       throw err;

--- a/web/src/lib/wav.ts
+++ b/web/src/lib/wav.ts
@@ -1,0 +1,43 @@
+// WAV container inspection: which codec is inside, and whether browsers
+// decode it natively (<audio> and WebAudio decodeAudioData alike). Console
+// builds are full of WAVs holding ADPCM variants (e.g. Xbox ADPCM, format
+// tag 0x0069) that no browser plays. Those route through the PCM transcode.
+
+// Format tags browsers ship decoders for: PCM, IEEE float, A-law, µ-law.
+const BROWSER_TAGS = new Set([0x0001, 0x0003, 0x0006, 0x0007]);
+
+/** The fmt chunk's format tag (WAVE_FORMAT_EXTENSIBLE resolved to its
+ *  SubFormat code), or null when `head` doesn't parse as a WAV. `head` needs
+ *  only the leading bytes of the file: the fmt chunk sits well within 2KB. */
+export function wavFormatTag(head: Buffer): number | null {
+  if (
+    head.length < 12 ||
+    head.toString("latin1", 0, 4) !== "RIFF" ||
+    head.toString("latin1", 8, 12) !== "WAVE"
+  ) {
+    return null;
+  }
+  let off = 12;
+  while (off + 8 <= head.length) {
+    const id = head.toString("latin1", off, off + 4);
+    const size = head.readUInt32LE(off + 4);
+    if (id === "fmt ") {
+      if (size < 2 || off + 10 > head.length) return null;
+      const tag = head.readUInt16LE(off + 8);
+      if (tag !== 0xfffe) return tag;
+      // WAVE_FORMAT_EXTENSIBLE: the real codec is the SubFormat GUID at fmt
+      // offset 24, whose first two bytes are the format tag.
+      return size >= 26 && off + 34 <= head.length ? head.readUInt16LE(off + 32) : null;
+    }
+    off += 8 + size + (size & 1); // chunks are word-aligned
+  }
+  return null;
+}
+
+/** Whether browsers play this WAV natively. Unparseable headers count as
+ *  playable: serving the raw bytes is the status-quo failure mode, and a
+ *  transcode of a file ffmpeg can't parse either would fail anyway. */
+export function wavBrowserPlayable(head: Buffer): boolean {
+  const tag = wavFormatTag(head);
+  return tag === null || BROWSER_TAGS.has(tag);
+}

--- a/web/tests/ffmpeg.test.ts
+++ b/web/tests/ffmpeg.test.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 import { assetBlobPath } from "../src/lib/assets";
 import {
   detectProfile,
+  ensureAudioTranscode,
   ensureThumb,
   ensureTranscode,
   thumbPath,
@@ -16,6 +17,7 @@ import {
   transcodeProfile,
   transcodeStatus,
 } from "../src/lib/ffmpeg";
+import { wavBrowserPlayable, wavFormatTag } from "../src/lib/wav";
 
 const execFileP = promisify(execFile);
 
@@ -198,6 +200,69 @@ test("ensureThumb rejects junk and a missing blob", async (t) => {
     await assert.rejects(ensureThumb(sha));
     await assert.rejects(stat(thumbPath(sha)));
     await assert.rejects(ensureThumb("cd".repeat(32)));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// Audio transcodes need only pcm_s16le, which every ffmpeg encodes, so the
+// binary being present is the whole gate (no output-profile detection).
+async function ffmpegPresent(): Promise<boolean> {
+  try {
+    await execFileP(process.env.FFMPEG_BIN || "ffmpeg", ["-version"], { timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** A 1s mono IMA ADPCM WAV (format tag 0x0011), undecodable in browsers. */
+async function adpcmFixture(dir: string): Promise<Buffer> {
+  const out = join(dir, "fixture-adpcm.wav");
+  await execFileP(process.env.FFMPEG_BIN || "ffmpeg", [
+    "-hide_banner", "-loglevel", "error", "-y",
+    "-f", "lavfi", "-i", "sine=frequency=440:duration=1",
+    "-c:a", "adpcm_ima_wav", "-f", "wav",
+    out,
+  ]);
+  return readFile(out);
+}
+
+test("ensureAudioTranscode converts an ADPCM WAV blob to PCM and caches it", async (t) => {
+  if (!(await ffmpegPresent())) return t.skip("ffmpeg not installed");
+  const dir = await tempStore();
+  try {
+    const sha = "1a".repeat(32);
+    const adpcm = await adpcmFixture(dir);
+    assert.equal(wavFormatTag(adpcm), 0x0011);
+    assert.equal(wavBrowserPlayable(adpcm), false);
+    await putBlob(sha, adpcm);
+
+    const out = await ensureAudioTranscode(sha);
+    assert.equal(out, transcodePath(sha, ".wav"));
+    const bytes = await readFile(out);
+    assert.equal(wavFormatTag(bytes), 0x0001);
+    assert.equal(wavBrowserPlayable(bytes), true);
+
+    // Second call serves the cache, so the file must not be rewritten.
+    const before = (await stat(out)).mtimeMs;
+    assert.equal(await ensureAudioTranscode(sha), out);
+    assert.equal((await stat(out)).mtimeMs, before);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensureAudioTranscode rejects junk and a missing blob", async (t) => {
+  if (!(await ffmpegPresent())) return t.skip("ffmpeg not installed");
+  const dir = await tempStore();
+  try {
+    const sha = "2b".repeat(32);
+    await putBlob(sha, Buffer.from("not audio at all"));
+    await assert.rejects(ensureAudioTranscode(sha));
+    // A failed transcode must leave no cached output (or stray .part files).
+    await assert.rejects(stat(transcodePath(sha, ".wav")));
+    await assert.rejects(ensureAudioTranscode("3c".repeat(32)));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/web/tests/wav.test.ts
+++ b/web/tests/wav.test.ts
@@ -1,0 +1,106 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { wavBrowserPlayable, wavFormatTag } from "../src/lib/wav";
+
+// Hand-rolled WAV headers: RIFF(size) WAVE, then chunks of id(4) size(4) data.
+
+function chunk(id: string, data: Buffer): Buffer {
+  const hdr = Buffer.alloc(8);
+  hdr.write(id, 0, 4, "latin1");
+  hdr.writeUInt32LE(data.length, 4);
+  return Buffer.concat([hdr, data, data.length & 1 ? Buffer.alloc(1) : Buffer.alloc(0)]);
+}
+
+function riff(...chunks: Buffer[]): Buffer {
+  const body = Buffer.concat([Buffer.from("WAVE", "latin1"), ...chunks]);
+  const hdr = Buffer.alloc(8);
+  hdr.write("RIFF", 0, 4, "latin1");
+  hdr.writeUInt32LE(body.length, 4);
+  return Buffer.concat([hdr, body]);
+}
+
+function fmt(tag: number): Buffer {
+  const b = Buffer.alloc(16);
+  b.writeUInt16LE(tag, 0); // wFormatTag
+  b.writeUInt16LE(1, 2); // channels
+  b.writeUInt32LE(44100, 4); // sample rate
+  b.writeUInt32LE(88200, 8); // byte rate
+  b.writeUInt16LE(2, 12); // block align
+  b.writeUInt16LE(16, 14); // bits per sample
+  return b;
+}
+
+/** WAVE_FORMAT_EXTENSIBLE fmt whose SubFormat GUID opens with `subTag`. */
+function fmtExtensible(subTag: number): Buffer {
+  const b = Buffer.alloc(40);
+  b.writeUInt16LE(0xfffe, 0);
+  b.writeUInt16LE(2, 2);
+  b.writeUInt32LE(48000, 4);
+  b.writeUInt32LE(384000, 8);
+  b.writeUInt16LE(8, 12);
+  b.writeUInt16LE(32, 14);
+  b.writeUInt16LE(22, 16); // cbSize
+  b.writeUInt16LE(32, 18); // valid bits per sample
+  b.writeUInt32LE(0x3, 20); // channel mask
+  b.writeUInt16LE(subTag, 24); // SubFormat GUID, leading format-tag bytes
+  return b;
+}
+
+const data = chunk("data", Buffer.alloc(64));
+
+test("wavFormatTag reads the fmt chunk's codec", () => {
+  assert.equal(wavFormatTag(riff(chunk("fmt ", fmt(0x0001)), data)), 0x0001);
+  assert.equal(wavFormatTag(riff(chunk("fmt ", fmt(0x0069)), data)), 0x0069);
+  assert.equal(wavFormatTag(riff(chunk("fmt ", fmt(0x0011)), data)), 0x0011);
+});
+
+test("wavFormatTag resolves WAVE_FORMAT_EXTENSIBLE to its SubFormat", () => {
+  assert.equal(wavFormatTag(riff(chunk("fmt ", fmtExtensible(0x0001)), data)), 0x0001);
+  assert.equal(wavFormatTag(riff(chunk("fmt ", fmtExtensible(0x0002)), data)), 0x0002);
+});
+
+test("wavFormatTag skips leading chunks to find fmt", () => {
+  const junk = chunk("LIST", Buffer.alloc(26, 0x20));
+  assert.equal(wavFormatTag(riff(junk, chunk("fmt ", fmt(0x0069)), data)), 0x0069);
+  // Odd-sized chunks are word-aligned, and the padding must not derail the walk.
+  const odd = chunk("LIST", Buffer.alloc(7, 0x20));
+  assert.equal(wavFormatTag(riff(odd, chunk("fmt ", fmt(0x0001)), data)), 0x0001);
+});
+
+test("wavFormatTag needs only the leading bytes of the file", () => {
+  const whole = riff(chunk("fmt ", fmt(0x0069)), data);
+  // Everything after the tag's two bytes (RIFF 12 + chunk header 8 + 2) is optional.
+  assert.equal(wavFormatTag(whole.subarray(0, 22)), 0x0069);
+});
+
+test("wavFormatTag is null on non-WAVs and truncated headers", () => {
+  assert.equal(wavFormatTag(Buffer.from("OggS....not a wav...")), null);
+  assert.equal(wavFormatTag(Buffer.alloc(0)), null);
+  const whole = riff(chunk("fmt ", fmt(0x0069)), data);
+  assert.equal(wavFormatTag(whole.subarray(0, 21)), null); // fmt tag cut off
+  assert.equal(wavFormatTag(riff(data)), null); // no fmt chunk at all
+});
+
+test("wavBrowserPlayable passes native codecs and unparseable heads only", () => {
+  for (const tag of [0x0001, 0x0003, 0x0006, 0x0007]) {
+    assert.equal(wavBrowserPlayable(riff(chunk("fmt ", fmt(tag)), data)), true, `tag ${tag}`);
+  }
+  assert.equal(wavBrowserPlayable(riff(chunk("fmt ", fmt(0x0069)), data)), false); // Xbox ADPCM
+  assert.equal(wavBrowserPlayable(riff(chunk("fmt ", fmt(0x0011)), data)), false); // IMA ADPCM
+  assert.equal(wavBrowserPlayable(riff(chunk("fmt ", fmt(0x0002)), data)), false); // MS ADPCM
+  assert.equal(wavBrowserPlayable(riff(chunk("fmt ", fmtExtensible(0x0002)), data)), false);
+  // Unparseable falls back to serving the raw bytes.
+  assert.equal(wavBrowserPlayable(Buffer.from("garbage")), true);
+});
+
+test("wavFormatTag parses a real Xbox ADPCM header", () => {
+  // The opening bytes of an actual Xbox build's WAV (Hunter, mc3ec01.wav).
+  const head = Buffer.from(
+    "52494646684f010057415645666d7420" +
+      "140000006900010044ac0000e6600000" +
+      "240004000200400064617461404f0100",
+    "hex"
+  );
+  assert.equal(wavFormatTag(head), 0x0069);
+  assert.equal(wavBrowserPlayable(head), false);
+});


### PR DESCRIPTION
Xbox builds carry WAVs encoded as Xbox ADPCM (format tag 0x0069), which no browser decodes, so the asset viewer's audio embeds showed "playback failed" (reported for the Hunter Xbox build). The extractor stamps every WAV audio/wav, so mime alone cannot tell these apart.

A new /api/asset/[sha256]/audio route sniffs the fmt chunk from the blob: natively playable WAVs (PCM, float, A-law, mu-law) redirect to the raw asset route, everything else is transcoded once to 16-bit PCM WAV via ffmpeg, cached next to the video transcodes, and streamed with Range support. WAV embeds and the lightbox player now point at this route.