### PR TITLE
Use Base UI for select controls

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1089.0",
         "@aws-sdk/lib-storage": "^3.1089.0",
+        "@base-ui/react": "^1.6.0",
         "@huggingface/transformers": "^4.2.0",
         "@smithy/node-http-handler": "^4.9.7",
         "@types/pngjs": "^6.0.5",
@@ -580,6 +581,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -626,6 +636,66 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.3.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+      "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {
@@ -1246,6 +1316,44 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
     },
     "node_modules/@huggingface/jinja": {
       "version": "0.5.9",
@@ -2574,7 +2682,7 @@
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3821,7 +3929,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7142,6 +7250,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
@@ -8283,6 +8397,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1089.0",
     "@aws-sdk/lib-storage": "^3.1089.0",
+    "@base-ui/react": "^1.6.0",
     "@huggingface/transformers": "^4.2.0",
     "@smithy/node-http-handler": "^4.9.7",
     "@types/pngjs": "^6.0.5",

--- a/web/src/app/builds/BuildsBrowser.tsx
+++ b/web/src/app/builds/BuildsBrowser.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useTransition } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import RowLink from "./RowLink";
+import Select from "@/components/Select";
 import { buildHref } from "@/lib/slug";
 import type { BuildListItem, BuildSortKey } from "@/lib/queries";
 
@@ -91,18 +92,13 @@ export default function BuildsBrowser({ rows, total, systems, page, perPage, q, 
           placeholder="Search builds…"
           className="h-9 w-80 rounded-md border border-neutral-300 bg-transparent px-3 text-sm outline-none placeholder:text-neutral-400 focus:border-neutral-500 dark:border-neutral-700"
         />
-        <select
+        <Select
           value={system}
-          onChange={(e) => navigate({ system: e.target.value, page: 1 })}
-          className="h-9 w-48 rounded-md border border-neutral-300 bg-transparent px-3 text-sm outline-none focus:border-neutral-500 dark:border-neutral-700"
-        >
-          <option value="">All systems</option>
-          {systems.map((s) => (
-            <option key={s} value={s}>
-              {s}
-            </option>
-          ))}
-        </select>
+          onChange={(v) => navigate({ system: v, page: 1 })}
+          ariaLabel="Filter by system"
+          className="h-9 w-48 px-3 text-sm"
+          options={[{ value: "", label: "All systems" }, ...systems.map((s) => ({ value: s, label: s }))]}
+        />
         {lot && (
           <button
             onClick={() => navigate({ lot: "", page: 1 })}

--- a/web/src/app/builds/[buildId]/repo/[name]/RepoViewer.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/RepoViewer.tsx
@@ -15,6 +15,7 @@
 // doesn't shift the page.
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import Select from "@/components/Select";
 import { initialExpanded, type TreeNode } from "@/lib/filetree";
 import { shortOid, type RepoCommit, type RepoLogEntryDto } from "@/lib/repo-manifest";
 import RepoCommitDiff from "./RepoCommitDiff";
@@ -281,8 +282,8 @@ export default function RepoViewer({
   );
 }
 
-// A plain select over the manifest's frozen refs; an arbitrary oid rev shows
-// as a synthetic (disabled-change) entry so the control always reflects state.
+// A select over the manifest's frozen refs; an arbitrary oid rev shows as a
+// synthetic disabled entry so the control always reflects state.
 function RevSelector({
   refs,
   headRef,
@@ -299,23 +300,19 @@ function RevSelector({
   const OID = "\0oid";
   const isNamed = value === "" || refs.some((r) => r.name === value);
   return (
-    <select
+    <Select
       value={isNamed ? value : OID}
-      onChange={(e) => {
-        if (e.target.value !== OID) onSelect(e.target.value);
+      onChange={(v) => {
+        if (v !== OID) onSelect(v);
       }}
-      className="rounded border border-neutral-200 bg-white px-2 py-1 font-mono text-xs dark:border-neutral-800 dark:bg-neutral-950"
-      aria-label="Revision"
-    >
-      <option value="">{headRef ? `${headRef} (HEAD)` : "HEAD"}</option>
-      {refs
-        .filter((r) => r.name !== headRef)
-        .map((r) => (
-          <option key={r.name} value={r.name}>
-            {r.name}
-          </option>
-        ))}
-      {!isNamed && <option value={OID}>{shortOid(revOid)}</option>}
-    </select>
+      ariaLabel="Revision"
+      className="px-2 py-1 font-mono text-xs"
+      popupClassName="font-mono text-xs"
+      options={[
+        { value: "", label: headRef ? `${headRef} (HEAD)` : "HEAD" },
+        ...refs.filter((r) => r.name !== headRef).map((r) => ({ value: r.name, label: r.name })),
+        ...(!isNamed ? [{ value: OID, label: shortOid(revOid), disabled: true }] : []),
+      ]}
+    />
   );
 }

--- a/web/src/components/Select.tsx
+++ b/web/src/components/Select.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Select as BaseSelect } from "@base-ui/react/select";
+
+export interface SelectOption {
+  value: string;
+  label: ReactNode;
+  disabled?: boolean;
+}
+
+// Styled wrapper over Base UI's Select with the controlled string-value shape
+// of a native <select>. Chrome (border, popup) is built in; call sites pass
+// sizing and typography for the trigger, and popupClassName when the popup
+// text should differ from the text-sm default.
+export default function Select({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+  className = "",
+  popupClassName = "text-sm",
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+  ariaLabel?: string;
+  className?: string;
+  popupClassName?: string;
+}) {
+  return (
+    <BaseSelect.Root
+      value={value}
+      onValueChange={(v) => {
+        if (v !== null) onChange(v);
+      }}
+      items={options}
+    >
+      <BaseSelect.Trigger
+        aria-label={ariaLabel}
+        className={`flex cursor-default select-none items-center justify-between gap-2 rounded-md border border-neutral-300 bg-transparent outline-none focus-visible:border-neutral-500 dark:border-neutral-700 ${className}`}
+      >
+        <BaseSelect.Value className="truncate" />
+        <BaseSelect.Icon className="flex shrink-0 text-neutral-400">
+          <svg className="size-2.5" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+            <path d="M2.5 4.5 6 8l3.5-3.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </BaseSelect.Icon>
+      </BaseSelect.Trigger>
+      <BaseSelect.Portal>
+        <BaseSelect.Positioner className="z-50 outline-none" sideOffset={4} alignItemWithTrigger={false}>
+          <BaseSelect.Popup
+            className={`max-h-[min(24rem,var(--available-height))] min-w-[var(--anchor-width)] overflow-y-auto rounded-md border border-neutral-200 bg-white py-1 shadow-lg outline-none dark:border-neutral-800 dark:bg-neutral-950 ${popupClassName}`}
+          >
+            {options.map((o) => (
+              <BaseSelect.Item
+                key={o.value}
+                value={o.value}
+                disabled={o.disabled}
+                className="grid cursor-default select-none grid-cols-[1rem_1fr] items-center gap-1 py-1 pl-2 pr-4 data-disabled:opacity-50 data-highlighted:bg-neutral-100 dark:data-highlighted:bg-neutral-800/80"
+              >
+                <BaseSelect.ItemIndicator className="col-start-1 flex justify-center">
+                  <svg className="size-2.5" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+                    <path d="M2 6.5 4.7 9l5-6" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </BaseSelect.ItemIndicator>
+                <BaseSelect.ItemText className="col-start-2 truncate">{o.label}</BaseSelect.ItemText>
+              </BaseSelect.Item>
+            ))}
+          </BaseSelect.Popup>
+        </BaseSelect.Positioner>
+      </BaseSelect.Portal>
+    </BaseSelect.Root>
+  );
+}


### PR DESCRIPTION
Replaces the two native select elements (the system filter on /builds and the repo viewer's revision selector) with a shared wrapper over Base UI's Select. The wrapper keeps the controlled string-value shape of a native select and bakes in the app's input styling, popup, and dark mode.

Adds @base-ui/react as the app's first UI component dependency. The revision selector's synthetic oid entry is now a disabled item instead of the old no-op option guard.