### PR TITLE
Make accepted submissions private by default

### DIFF
--- a/web/src/app/api/submissions/[sha256]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/route.ts
@@ -69,7 +69,9 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
     name = r.rows[0].record.image?.name ?? "";
     // Force: an accept must replace the live build wholesale — record, row
     // columns, and derived tables — even when the record looks unchanged.
-    await ingestRecord(c, r.rows[0].record, { force: true });
+    // New submissions start private (unlisted) until a moderator publishes
+    // them; re-accepting an existing build keeps its current visibility.
+    await ingestRecord(c, r.rows[0].record, { force: true, asPrivate: true });
     await c.query(
       "UPDATE submission_queue SET status='accepted', reviewed_at=now() WHERE sha256=$1",
       [sha256]

--- a/web/src/app/moderate/page.tsx
+++ b/web/src/app/moderate/page.tsx
@@ -105,7 +105,8 @@ export default function Moderate() {
         <Link href="/" className="text-sm text-neutral-500 hover:underline">Search &rarr;</Link>
       </div>
       <p className="mt-1 text-sm text-neutral-500">
-        Review contributor submissions. Accepting ingests the build into the library.
+        Review contributor submissions. Accepting ingests the build into the library
+        as private (unlisted); publish it from the build page when it is ready.
         While you are signed in, build pages also show moderator tools (rename, lot).
       </p>
 

--- a/web/src/lib/ingest.ts
+++ b/web/src/lib/ingest.ts
@@ -68,7 +68,7 @@ function buildDate(rec: BuildRecord): string | null {
 export async function ingestRecord(
   db: Queryable,
   rec: BuildRecord,
-  opts: { force?: boolean } = {}
+  opts: { force?: boolean; asPrivate?: boolean } = {}
 ): Promise<void> {
   rec = stripNulls(rec);
   const sha = rec.image.sha256;
@@ -94,10 +94,13 @@ export async function ingestRecord(
     if (seen.rows.length > 0) return;
   }
 
+  // `private` is set only on the initial INSERT — the ON CONFLICT branch leaves
+  // it alone, so re-ingesting (or re-accepting) a build never overrides a
+  // visibility choice a moderator has since made.
   await db.query(
     `INSERT INTO builds (sha256,name,system,size,md5,sha1,content_hash,filtered_content_hash,
-        file_count,total_size,max_depth,ext_histogram,text_doc,fingerprint_profile,record,build_date)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+        file_count,total_size,max_depth,ext_histogram,text_doc,fingerprint_profile,record,build_date,private)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)
      ON CONFLICT (sha256) DO UPDATE SET
         name=excluded.name, system=excluded.system, size=excluded.size,
         md5=excluded.md5, sha1=excluded.sha1,
@@ -109,7 +112,8 @@ export async function ingestRecord(
         record=excluded.record, build_date=excluded.build_date`,
     [sha, rec.image.name, rec.info?.system ?? "", rec.image.size, rec.image.md5, rec.image.sha1,
      comp.content_hash ?? null, comp.filtered_content_hash ?? null, st.file_count, st.total_size, st.max_depth,
-     JSON.stringify(st.ext_histogram ?? {}), capTextDoc(rec.text_doc ?? ""), rec.fingerprint_profile, rec, buildDate(rec)]
+     JSON.stringify(st.ext_histogram ?? {}), capTextDoc(rec.text_doc ?? ""), rec.fingerprint_profile, rec, buildDate(rec),
+     opts.asPrivate ?? false]
   );
 
   // Semantic embedding from the build's identity (see semanticDoc), not the

--- a/web/tests/lib.test.ts
+++ b/web/tests/lib.test.ts
@@ -206,6 +206,19 @@ test("ingest with assets [] clears build_asset (extracted, nothing viewable)", a
   assert.ok(!db.calls.some((c) => c.sql.includes("INSERT INTO build_asset")));
 });
 
+test("ingest sets private only on insert, per asPrivate", async () => {
+  for (const asPrivate of [true, false]) {
+    const db = fakeDb();
+    await ingestRecord(db, minimalRecord(), { asPrivate });
+    const insert = db.calls.find((c) => c.sql.includes("INSERT INTO builds"));
+    assert.ok(insert!.sql.includes("private"));
+    assert.equal(insert!.params![insert!.params!.length - 1], asPrivate);
+    // ON CONFLICT must not touch private: re-accepts keep moderator-set visibility.
+    const onConflict = insert!.sql.slice(insert!.sql.indexOf("ON CONFLICT"));
+    assert.ok(!onConflict.includes("private"));
+  }
+});
+
 test("ingest keeps well-formed asset rows and drops malformed ones", async () => {
   const good: AssetRef = { path: "/A.PNG", sha256: "cd".repeat(32), size: 10, mime: "image/png", kind: "image" };
   const badSha = { path: "/B.PNG", sha256: "../etc/passwd", size: 10, mime: "image/png", kind: "image" } as AssetRef;


### PR DESCRIPTION
Accepted submissions used to land public because ingest never set the private column. The moderation accept path now inserts new builds with private true, so they stay unlisted until published from the build page.

Re-accepting a build keeps whatever visibility a moderator already chose, and bulk corpus ingest still lands public. No migration needed, the private column shipped with #72.