### PR TITLE
Add archive deps to adapter CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,5 +158,5 @@ jobs:
         run: >-
           uv run --no-project --with numpy --with blake3==1.0.8 --with fastcdc==1.7.0
           --with pycdlib==1.14.0 --with bitarray==3.8.1 --with psutil==7.2.2
-          --with rarfile==4.2 --with libarchive-c==5.3
+          --with rarfile==4.2 --with libarchive-c==5.3 --with inflate64==1.0.4
           --with pytest pytest tests/ -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,14 @@ jobs:
         working-directory: ps2exe-adapter
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive   # ps2exe (the archive tests import its reader stack)
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
-      - name: pytest (skips the heavy ps2exe stack; pins match pyproject)
-        run: uv run --no-project --with numpy --with blake3==1.0.8 --with fastcdc==1.7.0 --with pytest pytest tests/ -q
+      - name: pytest (ps2exe deps limited to the archive stack, pins match pyproject)
+        run: >-
+          uv run --no-project --with numpy --with blake3==1.0.8 --with fastcdc==1.7.0
+          --with pycdlib==1.14.0 --with bitarray==3.8.1 --with psutil==7.2.2
+          --with rarfile==4.2 --with libarchive-c==5.3
+          --with pytest pytest tests/ -q


### PR DESCRIPTION
The archive tests added with the archives-as-directories change import the ps2exe reader stack, but the adapter CI job checked out without the submodule and ran without its deps. Every CI run since has failed there with ModuleNotFoundError.

This checks out submodules in that job and adds the five pinned deps the archive path needs (pycdlib, bitarray, psutil, rarfile, libarchive-c). Pins match pyproject and the full suite passes locally in the same isolated env.