### PR TITLE
Redirect media assets to public gateway

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -35,9 +35,13 @@ with two backends:
   from `ASSET_S3_ACCESS_KEY_ID`/`ASSET_S3_SECRET_ACCESS_KEY` (or the SDK's
   default chain); `ASSET_S3_REGION` defaults to `us-east-1`, and
   `ASSET_S3_INSECURE_TLS=1` accepts a self-signed endpoint certificate.
-  Reads still stream through the app's routes, so the bucket needs no public
-  access. `ASSET_STORE_DIR` remains the local root for upload staging and the
-  ffmpeg caches.
+  Reads stream through the app's routes by default, so the bucket needs no
+  public access. `ASSET_STORE_DIR` remains the local root for upload staging
+  and the ffmpeg caches. When a public gateway serves the bucket's key layout
+  directly, set `ASSET_PUBLIC_BASE` to its origin: the raw asset route then
+  308-redirects image/audio/video requests there (media sniffs fine without
+  extensions), while text, PDF, and downloads keep the app's typed and
+  sandboxed responses.
 
 `npm run push-assets` uploads an existing local store to the s3 backend:
 the one-time migration when a deployment flips to `ASSET_S3_ENDPOINT`

--- a/web/src/app/api/asset/[sha256]/route.ts
+++ b/web/src/app/api/asset/[sha256]/route.ts
@@ -1,6 +1,7 @@
 import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
 import { unstable_cache } from "next/cache";
+import { publicAssetUrl } from "@/lib/assets";
 import { blobSize, openBlobStream } from "@/lib/blobstore";
 import { getPool } from "@/lib/db";
 import { parseRange } from "@/lib/range";
@@ -51,6 +52,13 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
 
   const meta = await getMeta(sha256);
   if (!meta) return Response.json({ error: "not found" }, { status: 404 });
+
+  // Media bytes come straight off the public bucket gateway when one is
+  // configured — the redirect itself caches as hard as the content would.
+  const pub = publicAssetUrl(sha256, meta.mime);
+  if (pub) {
+    return new Response(null, { status: 308, headers: { Location: pub, "Cache-Control": CACHE } });
+  }
 
   // The browser already holds an immutable copy — never re-send the bytes.
   if (request.headers.get("if-none-match") === `"${sha256}"`) {

--- a/web/src/lib/assets.ts
+++ b/web/src/lib/assets.ts
@@ -8,6 +8,20 @@ import { hexPreview } from "./hexdump";
 // Path helpers re-exported for the store-layout consumers (staging, tests).
 export { assetBlobPath, assetStagingPath, assetStoreDir } from "./blobstore";
 
+/** Public gateway URL for one blob when ASSET_PUBLIC_BASE points at a host
+ *  serving the bucket's key layout directly (`<base>/<sha256[:2]>/<sha256>`),
+ *  else null (serve through the app). Only media that browsers render from a
+ *  sniffed body qualifies — the gateway has no extensions to type by, so
+ *  text/PDF display and download filenames still need the app's headers. SVG
+ *  is excluded: opened as a document on the gateway origin it could script,
+ *  and there is no CSP sandbox out there. */
+export function publicAssetUrl(sha256: string, mime: string): string | null {
+  const base = process.env.ASSET_PUBLIC_BASE;
+  if (!base) return null;
+  if (!/^(image|audio|video)\/[\w.+-]+$/.test(mime) || mime === "image/svg+xml") return null;
+  return `${base.replace(/\/+$/, "")}/${sha256.slice(0, 2)}/${sha256}`;
+}
+
 /** Display order for asset kinds on the build pages. */
 export const ASSET_KIND_ORDER = ["image", "audio", "video", "document", "source", "text", "binary"] as const;
 

--- a/web/tests/lib.test.ts
+++ b/web/tests/lib.test.ts
@@ -232,7 +232,26 @@ test("ingest keeps well-formed asset rows and drops malformed ones", async () =>
 
 // --- asset grouping helpers ---------------------------------------------------
 
-import { orderAssets, assetTotals } from "../src/lib/assets";
+import { orderAssets, assetTotals, publicAssetUrl } from "../src/lib/assets";
+
+test("publicAssetUrl hands off sniffable media and nothing else", () => {
+  const sha = "ab".repeat(32);
+  delete process.env.ASSET_PUBLIC_BASE;
+  assert.equal(publicAssetUrl(sha, "image/png"), null); // no gateway configured
+  process.env.ASSET_PUBLIC_BASE = "https://curator.example.org/";
+  try {
+    assert.equal(publicAssetUrl(sha, "image/png"), `https://curator.example.org/ab/${sha}`);
+    assert.ok(publicAssetUrl(sha, "audio/ogg"));
+    assert.ok(publicAssetUrl(sha, "video/mp4"));
+    // Needs the app's Content-Type/Disposition/CSP headers — no handoff.
+    assert.equal(publicAssetUrl(sha, "text/plain"), null);
+    assert.equal(publicAssetUrl(sha, "application/pdf"), null);
+    assert.equal(publicAssetUrl(sha, "application/octet-stream"), null);
+    assert.equal(publicAssetUrl(sha, "image/svg+xml"), null);
+  } finally {
+    delete process.env.ASSET_PUBLIC_BASE;
+  }
+});
 
 test("orderAssets groups by display kind and caps per kind", () => {
   const mk = (kind: string, n: number) => Array.from({ length: n }, (_, i) => ({ kind, path: `${kind}${i}` }));


### PR DESCRIPTION
With ASSET_PUBLIC_BASE set, the raw asset route 308-redirects image, audio, and video requests to the bucket gateway (curator.hiddenpalace.org serves the bucket's key layout directly), so media bytes no longer stream through the app. The redirect carries the same immutable cache headers as the content.

Text, PDF, and download responses keep coming from the app: the gateway serves extension-less keys as octet-stream, and those cases need real Content-Type, Content-Disposition, and CSP headers. SVG stays app-side too since the gateway origin has no CSP sandbox.