### PR TITLE
Buffer uploads locally, drain to bucket

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -35,9 +35,11 @@ with two backends:
   from `ASSET_S3_ACCESS_KEY_ID`/`ASSET_S3_SECRET_ACCESS_KEY` (or the SDK's
   default chain); `ASSET_S3_REGION` defaults to `us-east-1`, and
   `ASSET_S3_INSECURE_TLS=1` accepts a self-signed endpoint certificate.
-  Reads stream through the app's routes by default, so the bucket needs no
-  public access. `ASSET_STORE_DIR` remains the local root for upload staging
-  and the ffmpeg caches. When a public gateway serves the bucket's key layout
+  Reads are local-first (the local store doubles as a read cache and as the
+  write buffer): submission uploads land on local disk instantly and a
+  background drain pushes them to the bucket, so slow object stores never
+  gate the upload path. `ASSET_STORE_DIR` remains the local root for upload
+  staging and the ffmpeg caches. When a public gateway serves the bucket's key layout
   directly, set `ASSET_PUBLIC_BASE` to its origin: the raw asset route then
   308-redirects image/audio/video requests there (media sniffs fine without
   extensions), while text, PDF, and downloads keep the app's typed and

--- a/web/scripts/push-assets.ts
+++ b/web/scripts/push-assets.ts
@@ -13,7 +13,7 @@ import path from "node:path";
 import {
   assetBlobPath,
   assetStoreDir,
-  missingBlobs,
+  bucketMissingBlobs,
   s3Enabled,
   storeBlobFromFile,
   storeDescription,
@@ -61,7 +61,7 @@ async function main() {
   let failed = 0;
   for (let off = 0; off < shas.length; off += CHUNK) {
     const chunk = shas.slice(off, off + CHUNK);
-    const missing = await withRetry("existence sweep", () => missingBlobs(chunk));
+    const missing = await withRetry("existence sweep", () => bucketMissingBlobs(chunk));
     let next = 0;
     await Promise.all(
       Array.from({ length: Math.min(UPLOAD_CONCURRENCY, missing.length) }, async () => {

--- a/web/src/app/api/asset/[sha256]/route.ts
+++ b/web/src/app/api/asset/[sha256]/route.ts
@@ -2,7 +2,7 @@ import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
 import { unstable_cache } from "next/cache";
 import { publicAssetUrl } from "@/lib/assets";
-import { blobSize, openBlobStream } from "@/lib/blobstore";
+import { blobBuffered, blobSize, ensureDrainer, openBlobStream } from "@/lib/blobstore";
 import { getPool } from "@/lib/db";
 import { parseRange } from "@/lib/range";
 import { isSha256 } from "@/lib/validate";
@@ -55,8 +55,11 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
 
   // Media bytes come straight off the public bucket gateway when one is
   // configured — the redirect itself caches as hard as the content would.
+  // Freshly uploaded blobs still draining to the bucket stream from the
+  // local buffer instead (a redirect would point at a gateway 404).
+  ensureDrainer();
   const pub = publicAssetUrl(sha256, meta.mime);
-  if (pub) {
+  if (pub && !blobBuffered(sha256)) {
     return new Response(null, { status: 308, headers: { Location: pub, "Cache-Control": CACHE } });
   }
 

--- a/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
-import { assetStagingPath, blobExists, storeBlobFromFile } from "@/lib/blobstore";
+import { assetStagingPath, blobExists, ensureDrainer, storeBlobBuffered } from "@/lib/blobstore";
 import { referencedAssets, MAX_BUILD_ASSET_BYTES } from "@/lib/submission-assets";
 import { rateLimitCheck, clientKey } from "@/lib/ratelimit";
 import { isSha256 } from "@/lib/validate";
@@ -57,12 +57,15 @@ export async function PUT(
     return Response.json({ error: "build's total asset bytes exceed the cap" }, { status: 413 });
   }
 
-  if (await blobExists(assetSha)) return Response.json({ sha256: assetSha, status: "exists" });
-
   const rawOffset = new URL(request.url).searchParams.get("offset") ?? "0";
   const offset = Number(rawOffset);
   if (!Number.isInteger(offset) || offset < 0 || offset > claimed) {
     return Response.json({ error: "invalid offset" }, { status: 400 });
+  }
+  // Only the opening chunk pays the existence probe: a non-zero offset means
+  // this client is mid-upload, and the final rename is idempotent anyway.
+  if (offset === 0 && (await blobExists(assetSha))) {
+    return Response.json({ sha256: assetSha, status: "exists" });
   }
   if (!request.body) return Response.json({ error: "missing body" }, { status: 400 });
 
@@ -117,9 +120,11 @@ export async function PUT(
     return Response.json({ error: "staged bytes do not hash to the asset sha256" }, { status: 422 });
   }
 
-  // A concurrent upload of the same blob may have finalized first — same
-  // bytes either way, so "exists" is as good as "stored".
-  const outcome = await storeBlobFromFile(assetSha, part);
+  // Lands in the local write buffer (instant) and drains to the bucket in
+  // the background. A concurrent upload of the same blob may have finalized
+  // first — same bytes either way, so "exists" is as good as "stored".
+  ensureDrainer();
+  const outcome = await storeBlobBuffered(assetSha, part);
   if (outcome === "exists") return Response.json({ sha256: assetSha, status: "exists" });
   return Response.json({ sha256: assetSha, status: "stored" }, { status: 201 });
 }

--- a/web/src/lib/blobstore.ts
+++ b/web/src/lib/blobstore.ts
@@ -120,26 +120,43 @@ function httpStatus(err: unknown): number | undefined {
   return (err as { $metadata?: { httpStatusCode?: number } })?.$metadata?.httpStatusCode;
 }
 
+// Reads are local-first even with the s3 backend on: the local store doubles
+// as the write buffer for fresh uploads (drained to the bucket in the
+// background) and as the retained pre-migration copy, and a disk hit is three
+// orders of magnitude cheaper than a bucket round trip.
+
 /** Byte size of a blob, or null when it is missing from the store. */
 export async function blobSize(sha256: string): Promise<number | null> {
-  if (s3Enabled()) {
-    try {
-      const r = await s3().send(new HeadObjectCommand({ Bucket: s3Bucket(), Key: s3Key(sha256) }));
-      return r.ContentLength ?? null;
-    } catch (err) {
-      if (isMissing(err)) return null;
-      throw err;
-    }
-  }
   try {
     return (await fsp.stat(assetBlobPath(sha256))).size;
   } catch {
-    return null;
+    if (!s3Enabled()) return null;
+  }
+  try {
+    const r = await s3().send(new HeadObjectCommand({ Bucket: s3Bucket(), Key: s3Key(sha256) }));
+    return r.ContentLength ?? null;
+  } catch (err) {
+    if (isMissing(err)) return null;
+    throw err;
   }
 }
 
 export async function blobExists(sha256: string): Promise<boolean> {
-  return (await blobSize(sha256)) !== null;
+  if (fs.existsSync(assetBlobPath(sha256))) return true;
+  return s3Enabled() && (await bucketHasBlob(sha256));
+}
+
+/** Whether the BUCKET has the blob, ignoring local files — what the write
+ *  paths must ask, since with the buffer a local copy proves nothing about
+ *  the bucket. */
+async function bucketHasBlob(sha256: string): Promise<boolean> {
+  try {
+    await s3().send(new HeadObjectCommand({ Bucket: s3Bucket(), Key: s3Key(sha256) }));
+    return true;
+  } catch (err) {
+    if (isMissing(err)) return false;
+    throw err;
+  }
 }
 
 // Bounds concurrent requests in missingBlobs (and nothing else): high enough
@@ -164,15 +181,23 @@ async function listShard(shard: string): Promise<Set<string>> {
   return keys;
 }
 
-/** The subset of `shas` missing from the store, in input order.
- *
- *  On s3, big sets are answered by listing each referenced 2-hex shard once
- *  (one round trip covers every blob in the shard) instead of a HEAD per
- *  blob: a 4096-asset submission's check would otherwise take minutes of
- *  sequential-ish round trips and blow the desktop clients' HTTP timeouts. */
+/** The subset of `shas` missing from the store, in input order. Local files
+ *  (buffered uploads, the retained pre-migration copy) count as present; only
+ *  the remainder is checked against the bucket. */
 export async function missingBlobs(shas: string[]): Promise<string[]> {
-  if (!s3Enabled()) return shas.filter((s) => !fs.existsSync(assetBlobPath(s)));
+  const notLocal = shas.filter((s) => !fs.existsSync(assetBlobPath(s)));
+  if (!s3Enabled() || notLocal.length === 0) return notLocal;
+  return bucketMissingBlobs(notLocal);
+}
 
+/** The subset of `shas` the BUCKET lacks, in input order, ignoring local
+ *  files — the drainer's and migration script's notion of missing.
+ *
+ *  Big sets are answered by listing each referenced 2-hex shard once (one
+ *  round trip covers every blob in the shard) instead of a HEAD per blob:
+ *  a 4096-asset sweep would otherwise take minutes of sequential-ish round
+ *  trips. */
+export async function bucketMissingBlobs(shas: string[]): Promise<string[]> {
   if (shas.length <= LIST_THRESHOLD) {
     const present = new Array<boolean>(shas.length);
     let next = 0;
@@ -181,7 +206,7 @@ export async function missingBlobs(shas: string[]): Promise<string[]> {
         for (;;) {
           const i = next++;
           if (i >= shas.length) return;
-          present[i] = await blobExists(shas[i]);
+          present[i] = await bucketHasBlob(shas[i]);
         }
       })
     );
@@ -209,70 +234,47 @@ export async function openBlobStream(
   sha256: string,
   range?: { start: number; end: number }
 ): Promise<Readable | null> {
-  if (s3Enabled()) {
-    try {
-      const r = await s3().send(
-        new GetObjectCommand({
-          Bucket: s3Bucket(),
-          Key: s3Key(sha256),
-          ...(range ? { Range: `bytes=${range.start}-${range.end}` } : {}),
-        })
-      );
-      return r.Body as Readable;
-    } catch (err) {
-      if (isMissing(err)) return null;
-      throw err;
-    }
-  }
-  // open() first so a missing blob is a null, not a later stream error event.
+  // open() first so a missing blob is a fallthrough, not a stream error event.
   try {
     const fh = await fsp.open(assetBlobPath(sha256), "r");
     return fh.createReadStream(range ? { start: range.start, end: range.end } : {});
   } catch {
-    return null;
+    if (!s3Enabled()) return null;
+  }
+  try {
+    const r = await s3().send(
+      new GetObjectCommand({
+        Bucket: s3Bucket(),
+        Key: s3Key(sha256),
+        ...(range ? { Range: `bytes=${range.start}-${range.end}` } : {}),
+      })
+    );
+    return r.Body as Readable;
+  } catch (err) {
+    if (isMissing(err)) return null;
+    throw err;
   }
 }
 
 /** A whole blob in memory, or null when it is missing from the store.
  *  Callers cap sizes (convert/preview paths); don't hand this a DVD image. */
 export async function readBlob(sha256: string): Promise<Buffer | null> {
-  if (s3Enabled()) {
-    try {
-      const r = await s3().send(new GetObjectCommand({ Bucket: s3Bucket(), Key: s3Key(sha256) }));
-      return Buffer.from(await r.Body!.transformToByteArray());
-    } catch (err) {
-      if (isMissing(err)) return null;
-      throw err;
-    }
-  }
   try {
     return await fsp.readFile(assetBlobPath(sha256));
   } catch {
-    return null;
+    if (!s3Enabled()) return null;
+  }
+  try {
+    const r = await s3().send(new GetObjectCommand({ Bucket: s3Bucket(), Key: s3Key(sha256) }));
+    return Buffer.from(await r.Body!.transformToByteArray());
+  } catch (err) {
+    if (isMissing(err)) return null;
+    throw err;
   }
 }
 
 /** Leading bytes of a blob, or null when it is missing from the store. */
 export async function readBlobHead(sha256: string, maxBytes = 2048): Promise<Buffer | null> {
-  if (s3Enabled()) {
-    try {
-      const r = await s3().send(
-        new GetObjectCommand({
-          Bucket: s3Bucket(),
-          Key: s3Key(sha256),
-          Range: `bytes=0-${maxBytes - 1}`,
-        })
-      );
-      return Buffer.from(await r.Body!.transformToByteArray());
-    } catch (err) {
-      if (isMissing(err)) return null;
-      // An empty object satisfies no byte range (416) but does exist.
-      if (httpStatus(err) === 416) {
-        return (await blobSize(sha256)) === null ? null : Buffer.alloc(0);
-      }
-      throw err;
-    }
-  }
   let fh;
   try {
     fh = await fsp.open(assetBlobPath(sha256), "r");
@@ -280,9 +282,26 @@ export async function readBlobHead(sha256: string, maxBytes = 2048): Promise<Buf
     const { bytesRead } = await fh.read(buf, 0, maxBytes, 0);
     return buf.subarray(0, bytesRead);
   } catch {
-    return null;
+    if (!s3Enabled()) return null;
   } finally {
     await fh?.close();
+  }
+  try {
+    const r = await s3().send(
+      new GetObjectCommand({
+        Bucket: s3Bucket(),
+        Key: s3Key(sha256),
+        Range: `bytes=0-${maxBytes - 1}`,
+      })
+    );
+    return Buffer.from(await r.Body!.transformToByteArray());
+  } catch (err) {
+    if (isMissing(err)) return null;
+    // An empty object satisfies no byte range (416) but does exist.
+    if (httpStatus(err) === 416) {
+      return (await blobSize(sha256)) === null ? null : Buffer.alloc(0);
+    }
+    throw err;
   }
 }
 
@@ -299,7 +318,7 @@ export async function storeBlobFromFile(
     if (!opts?.keepSource) await fsp.rm(src, { force: true });
   };
   if (s3Enabled()) {
-    if (await blobExists(sha256)) {
+    if (await bucketHasBlob(sha256)) {
       await cleanup();
       return "exists";
     }
@@ -312,6 +331,18 @@ export async function storeBlobFromFile(
     await cleanup();
     return "stored";
   }
+  return storeBlobLocalFile(sha256, src, opts);
+}
+
+/** The local-filesystem store write (also the s3 backend's buffer write). */
+async function storeBlobLocalFile(
+  sha256: string,
+  src: string,
+  opts?: { keepSource?: boolean }
+): Promise<"stored" | "exists"> {
+  const cleanup = async () => {
+    if (!opts?.keepSource) await fsp.rm(src, { force: true });
+  };
   const dest = assetBlobPath(sha256);
   if (fs.existsSync(dest)) {
     await cleanup();
@@ -351,7 +382,7 @@ export async function storeBlobFromFile(
  *  when an identical blob was already there. */
 export async function storeBlobBytes(sha256: string, data: Uint8Array): Promise<boolean> {
   if (s3Enabled()) {
-    if (await blobExists(sha256)) return false;
+    if (await bucketHasBlob(sha256)) return false;
     await s3().send(
       new PutObjectCommand({
         Bucket: s3Bucket(),
@@ -378,11 +409,9 @@ export async function withBlobFile<T>(
   sha256: string,
   fn: (localPath: string) => Promise<T>
 ): Promise<T | null> {
-  if (!s3Enabled()) {
-    const p = assetBlobPath(sha256);
-    if (!fs.existsSync(p)) return null;
-    return fn(p);
-  }
+  const p = assetBlobPath(sha256);
+  if (fs.existsSync(p)) return fn(p);
+  if (!s3Enabled()) return null;
   const stream = await openBlobStream(sha256);
   if (!stream) return null;
   const dir = path.join(assetStoreDir(), ".fetch");
@@ -393,5 +422,92 @@ export async function withBlobFile<T>(
     return await fn(tmp);
   } finally {
     await fsp.rm(tmp, { force: true });
+  }
+}
+
+// --- write-buffer drain: freshly uploaded blobs -> bucket, in the background
+
+// Uploads land in the local store (instant for the submitter, no bucket round
+// trips on the request path) and are queued here; a background tick pushes
+// them to the bucket at whatever pace it accepts. Until a blob is confirmed
+// there, blobBuffered() answers true and the asset route holds off the public
+// gateway redirect. Drained blobs keep their local copy (the store doubles as
+// a read cache); reclaiming that disk stays a deliberate manual operation.
+
+const drainQueue = new Set<string>();
+let drainTimer: NodeJS.Timeout | null = null;
+let draining = false;
+let reconciledAt = 0;
+
+const DRAIN_TICK_MS = 30_000;
+const RECONCILE_MS = 60 * 60_000;
+
+/** True while a blob sits in the local buffer not yet confirmed in the
+ *  bucket — the gateway-redirect gate. */
+export function blobBuffered(sha256: string): boolean {
+  return drainQueue.has(sha256);
+}
+
+/** Start the background drain loop (idempotent, no-op without the s3
+ *  backend). The upload and asset routes call this so a restarted server
+ *  reconciles stranded blobs without waiting for the next upload. */
+export function ensureDrainer(): void {
+  if (!s3Enabled() || drainTimer) return;
+  drainTimer = setInterval(() => void drainTick().catch(() => {}), DRAIN_TICK_MS);
+  drainTimer.unref();
+}
+
+/** Store an uploaded file into the local buffer (the fast path the submitter
+ *  waits on) and queue it for the bucket. Consumes `src`. */
+export async function storeBlobBuffered(sha256: string, src: string): Promise<"stored" | "exists"> {
+  if (!s3Enabled()) return storeBlobFromFile(sha256, src);
+  const r = await storeBlobLocalFile(sha256, src);
+  drainQueue.add(sha256);
+  ensureDrainer();
+  // Soon, not per-blob: a burst of finalized uploads drains as one batch.
+  setTimeout(() => void drainTick().catch(() => {}), 3_000).unref();
+  return r;
+}
+
+async function drainTick(): Promise<void> {
+  if (draining) return;
+  draining = true;
+  try {
+    // Periodic reconcile: queue any local blob the bucket lacks, so blobs
+    // stranded by a crash or restart still drain (and a redirect never
+    // points at a gateway 404 for longer than one reconcile).
+    if (Date.now() - reconciledAt > RECONCILE_MS) {
+      reconciledAt = Date.now();
+      const root = assetStoreDir();
+      const local: string[] = [];
+      const shards = (await fsp.readdir(root).catch(() => [] as string[]))
+        .filter((d) => /^[0-9a-f]{2}$/.test(d));
+      for (const shard of shards) {
+        for (const name of await fsp.readdir(path.join(root, shard)).catch(() => [] as string[])) {
+          if (/^[0-9a-f]{64}$/.test(name)) local.push(name);
+        }
+      }
+      if (local.length) {
+        const missing = await bucketMissingBlobs(local);
+        for (const sha of missing) drainQueue.add(sha);
+        if (missing.length) console.log(`blobstore drain: reconcile queued ${missing.length} blob(s)`);
+      }
+    }
+    for (const sha of [...drainQueue]) {
+      if (!fs.existsSync(assetBlobPath(sha))) {
+        drainQueue.delete(sha); // nothing local to push (should not happen)
+        continue;
+      }
+      try {
+        await storeBlobFromFile(sha, assetBlobPath(sha), { keepSource: true });
+        drainQueue.delete(sha);
+      } catch (e) {
+        // Endpoint blip: leave the queue as is and retry next tick.
+        console.error(`blobstore drain: ${sha}: ${(e as Error).message}`);
+        break;
+      }
+    }
+  } finally {
+    draining = false;
   }
 }

--- a/web/tests/blobstore.test.ts
+++ b/web/tests/blobstore.test.ts
@@ -6,12 +6,14 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
   assetBlobPath,
+  blobBuffered,
   blobExists,
   blobSize,
   missingBlobs,
   openBlobStream,
   readBlob,
   readBlobHead,
+  storeBlobBuffered,
   storeBlobBytes,
   storeBlobFromFile,
   withBlobFile,
@@ -101,4 +103,39 @@ test("readBlobHead of an empty blob answers empty, not missing", async () => {
   await mkdir(dirname(blob), { recursive: true });
   await writeFile(blob, "");
   assert.equal((await readBlobHead(SHA_A))?.length, 0);
+});
+
+test("storeBlobBuffered without the s3 backend is a plain local store", async () => {
+  const dir = await tempStore();
+  const src = join(dir, "buffered.part");
+  await writeFile(src, "buffered bytes");
+  assert.equal(await storeBlobBuffered(SHA_A, src), "stored");
+  assert.equal(existsSync(src), false); // consumed
+  assert.equal((await readBlob(SHA_A))?.toString(), "buffered bytes");
+  assert.equal(blobBuffered(SHA_A), false); // no bucket, nothing to drain
+});
+
+// The env is read per call, so a locally present blob must be answered from
+// disk without the S3 client ever being built — an unroutable endpoint makes
+// any accidental network attempt fail loudly. Keep this test last: the
+// client memoizes its config on first construction.
+test("reads are local-first under the s3 backend", async () => {
+  await tempStore();
+  process.env.ASSET_S3_ENDPOINT = "https://127.0.0.1:1";
+  try {
+    const blob = assetBlobPath(SHA_A);
+    await mkdir(dirname(blob), { recursive: true });
+    await writeFile(blob, "local wins");
+    assert.equal((await readBlob(SHA_A))?.toString(), "local wins");
+    assert.equal(await blobSize(SHA_A), 10);
+    assert.equal(await blobExists(SHA_A), true);
+    assert.deepEqual(await missingBlobs([SHA_A]), []);
+    const got = await withBlobFile(SHA_A, async (p) => {
+      assert.equal(p, blob); // served from disk, not materialized
+      return "ok";
+    });
+    assert.equal(got, "ok");
+  } finally {
+    delete process.env.ASSET_S3_ENDPOINT;
+  }
 });


### PR DESCRIPTION
Submission uploads were paying bucket round trips inside every request (a HEAD per chunk plus a synchronous upload at the gateway's ~3.5 writes per second ceiling), which made submits crawl. Finalized blobs now land in the local store instantly, exactly like before the S3 backend, and a background drain pushes them to the bucket with an hourly reconcile catching anything stranded by a restart.

Reads become local-first with S3 fallthrough, which also makes asset checks near-instant while the local store exists. The gateway redirect is held for blobs still draining so it never points at a 404, and push-assets keeps its bucket-truth sweep via the new bucketMissingBlobs.