### PR TITLE
Raise GUI upload concurrency to 32

### DIFF
--- a/crates/curator-gui-win/src/main.rs
+++ b/crates/curator-gui-win/src/main.rs
@@ -2213,7 +2213,7 @@ mod app {
     const UPLOAD_CHUNK: usize = 4 * 1024 * 1024;
 
     /// How many asset blobs to upload at once.
-    const PARALLEL_UPLOADS: usize = 4;
+    const PARALLEL_UPLOADS: usize = 32;
 
     /// Give up after this many consecutive rate-limit waits on one chunk.
     const MAX_THROTTLE_RETRIES: u32 = 30;

--- a/macos/Sources/CuratorApp/AppModel.swift
+++ b/macos/Sources/CuratorApp/AppModel.swift
@@ -300,7 +300,7 @@ final class AppModel: ObservableObject {
     }
 
     /// How many asset blobs to upload at once.
-    private static let parallelUploads = 4
+    private static let parallelUploads = 32
 
     /// Upload the build's asset blobs that the server lacks and we hold locally,
     /// a few at a time — each is its own resumable PUT, so chunks of one blob


### PR DESCRIPTION
Both desktop GUIs uploaded asset blobs 4 at a time, which made large submissions slow. This raises the parallel upload count to 32 in the Mac and Windows apps.

Most blobs are small, so per request latency dominates and extra workers help. Verified with swift build and a cargo check against the x86_64-pc-windows-gnu target.