### PR TITLE
Convert BMP assets for Safari

### DIFF
--- a/web/src/app/api/asset/[sha256]/route.ts
+++ b/web/src/app/api/asset/[sha256]/route.ts
@@ -54,10 +54,13 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   if (!meta) return Response.json({ error: "not found" }, { status: 404 });
 
   // Media bytes come straight off the public bucket gateway when one is
-  // configured — the redirect itself caches as hard as the content would.
+  // configured. Temporary redirect with a bounded max-age, never a cached
+  // permanent one: the target embeds ASSET_PUBLIC_BASE, and when the gateway
+  // moved hosts (2026-07-18) browsers kept following year-long cached 308s
+  // to the dead host.
   const pub = publicAssetUrl(sha256, meta.mime);
   if (pub) {
-    return new Response(null, { status: 308, headers: { Location: pub, "Cache-Control": CACHE } });
+    return new Response(null, { status: 307, headers: { Location: pub, "Cache-Control": "public, max-age=3600" } });
   }
 
   // The browser already holds an immutable copy — never re-send the bytes.

--- a/web/src/app/builds/[buildId]/AssetViewer.tsx
+++ b/web/src/app/builds/[buildId]/AssetViewer.tsx
@@ -22,12 +22,16 @@ export function assetUrl(a: ViewableAsset): string {
   return `/api/asset/${a.sha256}`;
 }
 
-/** Where <img> should point: browsers render every image mime we extract
- *  except TGA and TIFF, which go through the server's PNG conversion. Kept in
- *  sync with pngConvertible (imgpng.ts) — not imported: that module pulls the
- *  decoders into the client bundle. */
+/** Where <img> should point: web-safe mimes load raw, while TGA, TIFF, and
+ *  BMP go through the server's PNG conversion. BMP is not browser-safe:
+ *  WebKit rejects common legacy variants (biClrUsed=2^24, as written by
+ *  90s-era tools) even when served as image/bmp. Kept in sync with
+ *  pngConvertible (imgpng.ts) — not imported: that module pulls the decoders
+ *  into the client bundle. */
 export function imageSrc(a: ViewableAsset): string {
-  return a.mime === "image/x-tga" || a.mime === "image/tiff" ? `${assetUrl(a)}/png` : assetUrl(a);
+  return a.mime === "image/bmp" || a.mime === "image/x-tga" || a.mime === "image/tiff"
+    ? `${assetUrl(a)}/png`
+    : assetUrl(a);
 }
 
 /** Where <video> should point: MP4/WebM play natively, while MPEG-1/2 program


### PR DESCRIPTION
WebKit refuses to decode legacy BMPs that carry biClrUsed of 2^24, a quirk of 90s era writers, even when served as image/bmp. Route BMP through the existing server side PNG conversion like TGA and TIFF so Safari can display them.

Also make the media gateway redirect a 307 with a one hour cache instead of a permanently cached 308. The redirect target embeds ASSET_PUBLIC_BASE, and browsers that cached redirects to the pre-rename gateway host kept following them after the host went away.