### PR TITLE
Animated 4-line loader for the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,19 +316,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,12 +432,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -813,19 +794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
- "web-time",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,12 +936,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,12 +1021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,7 +1045,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "indicatif",
  "native-tls",
  "prism-core",
  "serde_json",
@@ -1534,12 +1489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,16 +1768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "weedle2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,16 +1841,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1929,29 +1859,13 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1961,22 +1875,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1985,28 +1887,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2015,34 +1899,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/crates/prism-cli/Cargo.toml
+++ b/crates/prism-cli/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 [dependencies]
 prism-core = { path = "../prism-core" }
 clap = { version = "4", features = ["derive", "env"] }
-indicatif = "0.17"
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 ureq = { version = "2", default-features = false, features = ["native-tls"] }

--- a/crates/prism-cli/examples/loader_demo.rs
+++ b/crates/prism-cli/examples/loader_demo.rs
@@ -1,0 +1,53 @@
+//! Drives the 4-line loader with fake events so its look can be checked
+//! without analyzing a real disc image:
+//!
+//!   cargo run -p prism-cli --example loader_demo [seconds]
+
+use std::sync::Arc;
+use std::thread::sleep;
+use std::time::Duration;
+
+use prism_cli::progress::LoaderObserver;
+use prism_core::{Event, ProgressObserver};
+
+fn main() {
+    let secs: f32 = std::env::args()
+        .nth(1)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8.0);
+
+    let obs = Arc::new(LoaderObserver::new());
+    obs.batch(2, 12, "Ratchet - Deadlocked (Jul 20, 2005 prototype).iso");
+    obs.on_event(Event::CounterOpen {
+        id: 1,
+        label: "Decompressing".into(),
+        unit: "B".into(),
+        total: Some(1000.0),
+    });
+
+    let (files, steps) = (7usize, 100usize);
+    let total_steps = (files * steps) as f64;
+    let mut n = 0f64;
+    for f in 0..files {
+        let id = 10 + f as u64;
+        obs.on_event(Event::CounterOpen {
+            id,
+            label: format!("file{}.wav", f + 1),
+            unit: "B".into(),
+            total: Some(steps as f64),
+        });
+        for s in 0..steps {
+            obs.on_event(Event::Progress { id, count: s as f64 });
+            n += 1.0;
+            obs.on_event(Event::Progress { id: 1, count: 1000.0 * n / total_steps });
+            sleep(Duration::from_secs_f32(secs / total_steps as f32));
+        }
+        obs.on_event(Event::CounterClose { id });
+        if f == 2 {
+            obs.on_event(Event::Message("note: a scrolled status message".into()));
+        }
+    }
+    obs.on_event(Event::CounterClose { id: 1 });
+    obs.finish();
+    eprintln!("done");
+}

--- a/crates/prism-cli/src/lib.rs
+++ b/crates/prism-cli/src/lib.rs
@@ -4,8 +4,9 @@
 //! the local library, inspect a build's views, extract assets, and talk to the
 //! web service (Find Similar / Submit).
 
-mod progress;
+pub mod progress;
 mod service;
+mod tetra;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -18,7 +19,7 @@ use prism_core::db::{LibraryRow, LibrarySort};
 use prism_core::summary::{self, Section};
 use prism_core::{render, Analysis, Analyzer, Config, Node, Reader};
 
-use crate::progress::IndicatifObserver;
+use crate::progress::LoaderObserver;
 
 #[derive(Parser)]
 #[command(name = "prism", version, about = "Analyze disc images into DAT/JSON and add them to a local library")]
@@ -361,7 +362,7 @@ fn analyze(
 ) -> Result<()> {
     let total = files.len() as u64;
     for (i, path) in files.iter().enumerate() {
-        let observer = Arc::new(IndicatifObserver::new());
+        let observer = Arc::new(LoaderObserver::new());
         observer.batch(i as u64, total, path);
 
         let analysis = if force {
@@ -429,16 +430,17 @@ fn import(analyzer: &Analyzer, paths: &[String]) -> Result<()> {
     let total = files.len() as u64;
     let (mut imported, mut skipped) = (0u64, 0u64);
     for (i, path) in files.iter().enumerate() {
-        let observer = Arc::new(IndicatifObserver::new());
+        let observer = Arc::new(LoaderObserver::new());
         observer.batch(i as u64, total, path);
-        match analyzer.analyze(path, observer.clone()) {
+        let res = analyzer.analyze(path, observer.clone());
+        observer.finish();
+        match res {
             Ok(_) => imported += 1,
             Err(e) => {
                 skipped += 1;
                 eprintln!("  skipped {path}: {e}");
             }
         }
-        observer.finish();
     }
     println!("imported {imported}, skipped {skipped} unsupported");
     Ok(())
@@ -476,7 +478,7 @@ fn load_build(reader: &Reader, sha: &str) -> Result<Analysis> {
 /// treated as a library sha256/prefix.
 fn resolve_target(analyzer: &Analyzer, target: &str, force: bool) -> Result<Analysis> {
     if Path::new(target).exists() {
-        let observer = Arc::new(IndicatifObserver::new());
+        let observer = Arc::new(LoaderObserver::new());
         let analysis = if force {
             analyzer.reanalyze(target, observer.clone())
         } else {

--- a/crates/prism-cli/src/lib.rs
+++ b/crates/prism-cli/src/lib.rs
@@ -479,6 +479,7 @@ fn load_build(reader: &Reader, sha: &str) -> Result<Analysis> {
 fn resolve_target(analyzer: &Analyzer, target: &str, force: bool) -> Result<Analysis> {
     if Path::new(target).exists() {
         let observer = Arc::new(LoaderObserver::new());
+        observer.batch(0, 1, target);
         let analysis = if force {
             analyzer.reanalyze(target, observer.clone())
         } else {

--- a/crates/prism-cli/src/progress.rs
+++ b/crates/prism-cli/src/progress.rs
@@ -6,10 +6,9 @@
 //! the same rail. Falls back to plain line output when stderr is not a
 //! terminal.
 //!
-//! Consoles whose font lacks braille (legacy Windows conhost, WSL windows
-//! outside Windows Terminal) get an all-ASCII loader instead. The default is
-//! ASCII on Windows unless WT_SESSION marks a Windows Terminal session, and
-//! PRISM_ASCII=1 or =0 forces the choice on any platform.
+//! Windows console fonts are not reliable braille renderers, so on Windows
+//! and inside WSL the loader is all-ASCII. PRISM_ASCII=1 or =0 forces the
+//! choice on any platform.
 
 use std::io::{IsTerminal, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -33,6 +32,17 @@ static ASCII_MODE: AtomicBool = AtomicBool::new(false);
 
 fn ascii_mode() -> bool {
     ASCII_MODE.load(Ordering::Relaxed)
+}
+
+// WSL runs Linux binaries in a Windows console with the same font limits.
+fn wsl() -> bool {
+    if !cfg!(target_os = "linux") {
+        return false;
+    }
+    std::env::var_os("WSL_DISTRO_NAME").is_some()
+        || std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .map(|v| v.to_ascii_lowercase().contains("microsoft"))
+            .unwrap_or(false)
 }
 
 struct Counter {
@@ -93,7 +103,7 @@ impl LoaderObserver {
         let ascii = match std::env::var("PRISM_ASCII").ok().as_deref() {
             Some("1") => true,
             Some("0") => false,
-            _ => cfg!(windows) && std::env::var_os("WT_SESSION").is_none(),
+            _ => cfg!(windows) || wsl(),
         };
         ASCII_MODE.store(ascii, Ordering::Relaxed);
         let tty = std::io::stderr().is_terminal() && enable_vt();

--- a/crates/prism-cli/src/progress.rs
+++ b/crates/prism-cli/src/progress.rs
@@ -1,81 +1,252 @@
-//! Renders core progress events as indicatif bars.
+//! Renders core progress events as a 4-line loader on stderr: a tumbling
+//! braille tetrahedron beside the item being worked on, a blank line, and up
+//! to two progress rows (the first counter still open and the most recently
+//! opened one), each as a label column, a heavy-rule bar with a half-cell
+//! head, and a percentage. Indeterminate counters get a bouncing comet on
+//! the same rail. Falls back to plain line output when stderr is not a
+//! terminal.
 
-use std::collections::HashMap;
-use std::sync::Mutex;
+use std::io::{IsTerminal, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use prism_core::{Event, ProgressObserver};
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
-pub struct IndicatifObserver {
-    mp: MultiProgress,
-    bars: Mutex<HashMap<u64, ProgressBar>>,
+use crate::tetra;
+
+const REGION_H: usize = tetra::H + 1; // loader lines: one blank, then the spinner rows
+const BARW: usize = 30; // bar columns
+const LABELW: usize = 14; // label column width; longer labels truncate
+const BATCHW: usize = 58; // truncation budget for the item line
+const FRAME_US: u64 = 16_667; // 60fps
+
+struct Counter {
+    id: u64,
+    label: String,
+    total: Option<f64>,
+    count: f64,
 }
 
-impl IndicatifObserver {
+#[derive(Default)]
+struct State {
+    batch: Option<String>,
+    counters: Vec<Counter>,
+    pending: Vec<String>, // messages to scroll out above the loader
+}
+
+pub struct LoaderObserver {
+    tty: bool,
+    state: Arc<Mutex<State>>,
+    running: Arc<AtomicBool>,
+    thread: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl LoaderObserver {
     pub fn new() -> Self {
-        IndicatifObserver { mp: MultiProgress::new(), bars: Mutex::new(HashMap::new()) }
+        let tty = std::io::stderr().is_terminal();
+        let state = Arc::new(Mutex::new(State::default()));
+        let running = Arc::new(AtomicBool::new(true));
+        let thread = tty.then(|| {
+            let (state, running) = (state.clone(), running.clone());
+            std::thread::spawn(move || draw_loop(state, running))
+        });
+        LoaderObserver { tty, state, running, thread: Mutex::new(thread) }
     }
 
     pub fn batch(&self, index: u64, total: u64, name: &str) {
-        if total > 1 {
-            self.mp
-                .println(format!("[{}/{}] {}", index + 1, total, name))
-                .ok();
+        if self.tty {
+            let label = if total > 1 {
+                format!("[{}/{}] {}", index + 1, total, name)
+            } else {
+                name.to_string()
+            };
+            self.state.lock().unwrap().batch = Some(label);
+        } else if total > 1 {
+            eprintln!("[{}/{}] {}", index + 1, total, name);
         }
     }
 
     pub fn finish(&self) {
-        let mut bars = self.bars.lock().unwrap();
-        for (_, bar) in bars.drain() {
-            bar.finish_and_clear();
+        self.running.store(false, Ordering::SeqCst);
+        if let Some(t) = self.thread.lock().unwrap().take() {
+            let _ = t.join();
         }
     }
 }
 
-impl ProgressObserver for IndicatifObserver {
+impl Drop for LoaderObserver {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+impl ProgressObserver for LoaderObserver {
     fn on_event(&self, ev: Event) {
         match ev {
-            Event::CounterOpen { id, label, unit, total } => {
-                let bar = match total {
-                    Some(t) => {
-                        let pb = self.mp.add(ProgressBar::new(t as u64));
-                        let style = if unit == "B" {
-                            ProgressStyle::with_template(
-                                "  {msg:30!} {bar:30} {bytes}/{total_bytes} ({eta})",
-                            )
-                        } else {
-                            ProgressStyle::with_template("  {msg:30!} {bar:30} {pos}/{len}")
-                        };
-                        if let Ok(s) = style {
-                            pb.set_style(s);
-                        }
-                        pb
-                    }
-                    None => {
-                        let pb = self.mp.add(ProgressBar::new_spinner());
-                        pb.enable_steady_tick(std::time::Duration::from_millis(120));
-                        pb
-                    }
-                };
-                bar.set_message(label);
-                self.bars.lock().unwrap().insert(id, bar);
+            Event::CounterOpen { id, label, unit: _, total } => {
+                if self.tty {
+                    let mut st = self.state.lock().unwrap();
+                    st.counters.push(Counter { id, label, total, count: 0.0 });
+                }
             }
             Event::Progress { id, count } => {
-                if let Some(bar) = self.bars.lock().unwrap().get(&id) {
-                    bar.set_position(count as u64);
+                if self.tty {
+                    let mut st = self.state.lock().unwrap();
+                    if let Some(c) = st.counters.iter_mut().find(|c| c.id == id) {
+                        c.count = count;
+                    }
                 }
             }
             Event::CounterClose { id } => {
-                if let Some(bar) = self.bars.lock().unwrap().remove(&id) {
-                    bar.finish_and_clear();
+                if self.tty {
+                    self.state.lock().unwrap().counters.retain(|c| c.id != id);
                 }
             }
             Event::Message(m) => {
-                self.mp.println(m).ok();
+                if self.tty {
+                    self.state.lock().unwrap().pending.push(m);
+                } else {
+                    eprintln!("{m}");
+                }
             }
             Event::BatchItem { index, total, name } => {
                 self.batch(index, total, &name);
             }
         }
     }
+}
+
+fn draw_loop(state: Arc<Mutex<State>>, running: Arc<AtomicBool>) {
+    let t0 = Instant::now();
+    let frame_dt = Duration::from_micros(FRAME_US);
+    let mut next = t0 + frame_dt;
+    let mut drawn = false;
+    let stderr = std::io::stderr();
+
+    while running.load(Ordering::SeqCst) {
+        let t = t0.elapsed().as_secs_f32();
+        let mut buf = String::new();
+        {
+            let mut st = state.lock().unwrap();
+            // hold the first frame briefly so instant (cached) items don't flash
+            if !drawn && st.counters.is_empty() && t < 0.08 {
+                drop(st);
+                std::thread::sleep(Duration::from_millis(5));
+                continue;
+            }
+            if drawn {
+                buf.push_str(&format!("\x1b[{REGION_H}F")); // top of the loader
+            }
+            for m in st.pending.drain(..) {
+                buf.push_str("\x1b[2K");
+                buf.push_str(&m);
+                buf.push('\n');
+            }
+            compose(&st, t, &mut buf);
+        }
+        drawn = true;
+        {
+            let mut out = stderr.lock();
+            let _ = out.write_all(buf.as_bytes());
+            let _ = out.flush();
+        }
+
+        let now = Instant::now();
+        if next > now {
+            std::thread::sleep(next - now);
+        } else {
+            next = now; // don't burst to catch up after the first-frame hold
+        }
+        next += frame_dt;
+    }
+
+    // scroll out any last messages and take the loader down
+    let mut buf = String::new();
+    if drawn {
+        buf.push_str(&format!("\x1b[{REGION_H}F"));
+    }
+    for m in state.lock().unwrap().pending.drain(..) {
+        buf.push_str("\x1b[2K");
+        buf.push_str(&m);
+        buf.push('\n');
+    }
+    if drawn {
+        buf.push_str("\x1b[J");
+    }
+    if !buf.is_empty() {
+        let mut out = stderr.lock();
+        let _ = out.write_all(buf.as_bytes());
+        let _ = out.flush();
+    }
+}
+
+// The four loader lines: spinner cells, then title / current item / bars.
+// Every line is \x1b[2K-cleared before writing, so no padding is needed.
+fn compose(st: &State, t: f32, buf: &mut String) {
+    let spin = tetra::frame(t);
+    buf.push_str("\x1b[2K\n"); // blank line separating the loader from prior output
+    let texts: [String; tetra::H] = [
+        st.batch.as_deref().map(|s| truncate(s, BATCHW)).unwrap_or_default(),
+        String::new(),
+        st.counters.first().map(|c| counter_line(c, t)).unwrap_or_default(),
+        if st.counters.len() > 1 {
+            counter_line(st.counters.last().unwrap(), t)
+        } else {
+            String::new()
+        },
+    ];
+    for (line, text) in spin.iter().zip(texts.iter()) {
+        buf.push_str("\x1b[2K");
+        buf.push_str(line);
+        buf.push_str("  ");
+        buf.push_str(text);
+        buf.push('\n');
+    }
+}
+
+fn counter_line(c: &Counter, t: f32) -> String {
+    let label = truncate(&c.label, LABELW);
+    match c.total {
+        Some(total) if total > 0.0 => {
+            let frac = (c.count / total).clamp(0.0, 1.0) as f32;
+            format!("{label:<LABELW$} {} {:>3}%", bar(frac), (frac * 100.0) as u32)
+        }
+        _ => format!("{label:<LABELW$} {}", sweep(t)),
+    }
+}
+
+// Heavy rule with a half-cell head, empty missing.
+fn bar(frac: f32) -> String {
+    let n = (frac * BARW as f32) as usize;
+    let mut s = "━".repeat(n);
+    if n < BARW {
+        s.push('╸');
+        s.push_str(&" ".repeat(BARW - n - 1));
+    }
+    s
+}
+
+// Indeterminate counters: a 3-cell comet bouncing along the same rail.
+fn sweep(t: f32) -> String {
+    let span = (BARW - 3) as f32;
+    let phase = (t * 0.7).fract() * 2.0;
+    let p = if phase < 1.0 { phase } else { 2.0 - phase };
+    let p = (p * span) as usize;
+    let mut s = " ".repeat(p);
+    s.push_str("╺━╸");
+    s.push_str(&" ".repeat(BARW - p - 3));
+    s
+}
+
+// Middle truncation is not worth the fuss; keep the tail, which carries the
+// filename.
+fn truncate(s: &str, max: usize) -> String {
+    let n = s.chars().count();
+    if n <= max {
+        return s.to_string();
+    }
+    let tail: String = s.chars().skip(n - (max - 1)).collect();
+    format!("…{tail}")
 }

--- a/crates/prism-cli/src/progress.rs
+++ b/crates/prism-cli/src/progress.rs
@@ -43,9 +43,41 @@ pub struct LoaderObserver {
     thread: Mutex<Option<JoinHandle<()>>>,
 }
 
+// The Windows console interprets VT sequences only once
+// ENABLE_VIRTUAL_TERMINAL_PROCESSING is set (Windows Terminal and WSL windows
+// have it on already, legacy conhost does not). No console mode to speak of
+// elsewhere.
+#[cfg(windows)]
+fn enable_vt() -> bool {
+    type Handle = *mut core::ffi::c_void;
+    const STD_ERROR_HANDLE: u32 = -12i32 as u32;
+    const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
+    extern "system" {
+        fn GetStdHandle(n: u32) -> Handle;
+        fn GetConsoleMode(h: Handle, mode: *mut u32) -> i32;
+        fn SetConsoleMode(h: Handle, mode: u32) -> i32;
+    }
+    unsafe {
+        let h = GetStdHandle(STD_ERROR_HANDLE);
+        let mut mode = 0u32;
+        if GetConsoleMode(h, &mut mode) == 0 {
+            return false;
+        }
+        if mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0 {
+            return true;
+        }
+        SetConsoleMode(h, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0
+    }
+}
+
+#[cfg(not(windows))]
+fn enable_vt() -> bool {
+    true
+}
+
 impl LoaderObserver {
     pub fn new() -> Self {
-        let tty = std::io::stderr().is_terminal();
+        let tty = std::io::stderr().is_terminal() && enable_vt();
         let state = Arc::new(Mutex::new(State::default()));
         let running = Arc::new(AtomicBool::new(true));
         let thread = tty.then(|| {
@@ -140,7 +172,7 @@ fn draw_loop(state: Arc<Mutex<State>>, running: Arc<AtomicBool>) {
                 buf.push_str(&format!("\x1b[{REGION_H}F")); // top of the loader
             }
             for m in st.pending.drain(..) {
-                buf.push_str("\x1b[2K");
+                buf.push_str("\r\x1b[2K");
                 buf.push_str(&m);
                 buf.push('\n');
             }
@@ -168,7 +200,7 @@ fn draw_loop(state: Arc<Mutex<State>>, running: Arc<AtomicBool>) {
         buf.push_str(&format!("\x1b[{REGION_H}F"));
     }
     for m in state.lock().unwrap().pending.drain(..) {
-        buf.push_str("\x1b[2K");
+        buf.push_str("\r\x1b[2K");
         buf.push_str(&m);
         buf.push('\n');
     }
@@ -186,7 +218,7 @@ fn draw_loop(state: Arc<Mutex<State>>, running: Arc<AtomicBool>) {
 // Every line is \x1b[2K-cleared before writing, so no padding is needed.
 fn compose(st: &State, t: f32, buf: &mut String) {
     let spin = tetra::frame(t);
-    buf.push_str("\x1b[2K\n"); // blank line separating the loader from prior output
+    buf.push_str("\r\x1b[2K\n"); // blank line separating the loader from prior output
     let texts: [String; tetra::H] = [
         st.batch.as_deref().map(|s| truncate(s, BATCHW)).unwrap_or_default(),
         String::new(),
@@ -198,7 +230,7 @@ fn compose(st: &State, t: f32, buf: &mut String) {
         },
     ];
     for (line, text) in spin.iter().zip(texts.iter()) {
-        buf.push_str("\x1b[2K");
+        buf.push_str("\r\x1b[2K");
         buf.push_str(line);
         buf.push_str("  ");
         buf.push_str(text);

--- a/crates/prism-cli/src/progress.rs
+++ b/crates/prism-cli/src/progress.rs
@@ -5,6 +5,11 @@
 //! head, and a percentage. Indeterminate counters get a bouncing comet on
 //! the same rail. Falls back to plain line output when stderr is not a
 //! terminal.
+//!
+//! Consoles whose font lacks braille (legacy Windows conhost, WSL windows
+//! outside Windows Terminal) get an all-ASCII loader instead. The default is
+//! ASCII on Windows unless WT_SESSION marks a Windows Terminal session, and
+//! PRISM_ASCII=1 or =0 forces the choice on any platform.
 
 use std::io::{IsTerminal, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -21,6 +26,14 @@ const BARW: usize = 30; // bar columns
 const LABELW: usize = 14; // label column width; longer labels truncate
 const BATCHW: usize = 58; // truncation budget for the item line
 const FRAME_US: u64 = 16_667; // 60fps
+
+// Render with ASCII-safe glyphs only (see the module docs). Set once at
+// observer creation, read wherever glyphs are chosen.
+static ASCII_MODE: AtomicBool = AtomicBool::new(false);
+
+fn ascii_mode() -> bool {
+    ASCII_MODE.load(Ordering::Relaxed)
+}
 
 struct Counter {
     id: u64,
@@ -77,6 +90,12 @@ fn enable_vt() -> bool {
 
 impl LoaderObserver {
     pub fn new() -> Self {
+        let ascii = match std::env::var("PRISM_ASCII").ok().as_deref() {
+            Some("1") => true,
+            Some("0") => false,
+            _ => cfg!(windows) && std::env::var_os("WT_SESSION").is_none(),
+        };
+        ASCII_MODE.store(ascii, Ordering::Relaxed);
         let tty = std::io::stderr().is_terminal() && enable_vt();
         let state = Arc::new(Mutex::new(State::default()));
         let running = Arc::new(AtomicBool::new(true));
@@ -217,7 +236,7 @@ fn draw_loop(state: Arc<Mutex<State>>, running: Arc<AtomicBool>) {
 // The four loader lines: spinner cells, then title / current item / bars.
 // Every line is \x1b[2K-cleared before writing, so no padding is needed.
 fn compose(st: &State, t: f32, buf: &mut String) {
-    let spin = tetra::frame(t);
+    let spin = tetra::frame(t, ascii_mode());
     buf.push_str("\r\x1b[2K\n"); // blank line separating the loader from prior output
     let texts: [String; tetra::H] = [
         st.batch.as_deref().map(|s| truncate(s, BATCHW)).unwrap_or_default(),
@@ -249,12 +268,14 @@ fn counter_line(c: &Counter, t: f32) -> String {
     }
 }
 
-// Heavy rule with a half-cell head, empty missing.
+// Heavy rule with a half-cell head, empty missing. ASCII mode draws the
+// classic equals-and-chevron bar instead.
 fn bar(frac: f32) -> String {
     let n = (frac * BARW as f32) as usize;
-    let mut s = "━".repeat(n);
+    let (fill, head) = if ascii_mode() { ("=", '>') } else { ("━", '╸') };
+    let mut s = fill.repeat(n);
     if n < BARW {
-        s.push('╸');
+        s.push(head);
         s.push_str(&" ".repeat(BARW - n - 1));
     }
     s
@@ -267,7 +288,7 @@ fn sweep(t: f32) -> String {
     let p = if phase < 1.0 { phase } else { 2.0 - phase };
     let p = (p * span) as usize;
     let mut s = " ".repeat(p);
-    s.push_str("╺━╸");
+    s.push_str(if ascii_mode() { "<=>" } else { "╺━╸" });
     s.push_str(&" ".repeat(BARW - p - 3));
     s
 }
@@ -279,6 +300,11 @@ fn truncate(s: &str, max: usize) -> String {
     if n <= max {
         return s.to_string();
     }
-    let tail: String = s.chars().skip(n - (max - 1)).collect();
-    format!("…{tail}")
+    if ascii_mode() {
+        let tail: String = s.chars().skip(n - (max - 2)).collect();
+        format!("..{tail}")
+    } else {
+        let tail: String = s.chars().skip(n - (max - 1)).collect();
+        format!("…{tail}")
+    }
 }

--- a/crates/prism-cli/src/tetra.rs
+++ b/crates/prism-cli/src/tetra.rs
@@ -95,27 +95,68 @@ fn face_visibility(v: &[[f32; 3]; 4]) -> [bool; 4] {
 }
 
 /// The four spinner lines at time `t` seconds: the tumble pose advances on
-/// all three axes at different velocities. `ascii` swaps the wireframe for a
-/// plain rotating spinner, for consoles whose font has no braille block.
+/// all three axes at different velocities. `ascii` draws the tetrahedron
+/// with plain ASCII strokes, for consoles whose font has no braille block.
 pub(crate) fn frame(t: f32, ascii: bool) -> [String; 4] {
     if ascii {
-        return spinner_ascii(t);
+        return render_ascii(t);
     }
     render_wire(0.85 + t * 0.9, 1.0 + t * 2.0, 0.3 + t * 0.55, 7.2, 8.0)
 }
 
-// The wireframe is illegible at 14x4 in bare ASCII, so the fallback is the
-// classic four-phase spinner, on the same row as the first progress bar.
-fn spinner_ascii(t: f32) -> [String; 4] {
-    const PHASES: [char; 4] = ['|', '/', '-', '\\'];
-    let ch = PHASES[(t * 8.0) as usize % PHASES.len()];
-    std::array::from_fn(|r| {
-        let mut line = " ".repeat(W);
-        if r == 2 {
-            line.replace_range(6..7, &ch.to_string());
+// ASCII tetrahedron. One character per cell picked from the owning edge's
+// overall screen slope, so every edge draws as a consistent stroke. The pose
+// spins about the vertical axis with a slight fixed tilt instead of
+// tumbling: 14x4 characters cannot keep arbitrary poses readable, a
+// triangle silhouette with sweeping inner edges stays one.
+fn render_ascii(t: f32) -> [String; 4] {
+    let v = rotated_vertices(0.18, 1.0 + t * 2.2, 0.0);
+    let visible = face_visibility(&v);
+
+    const SX: f32 = 3.6; // cols per world unit
+    const SY: f32 = 2.0; // rows per world unit, near half of SX for 1:2 cells
+    const CC: f32 = W as f32 / 2.0; // center col
+    const CR: f32 = 2.3; // center row
+
+    let mut grid = [[' '; W]; H];
+    for &(ia, ib, fa, fb) in EDGES.iter() {
+        if !visible[fa] && !visible[fb] {
+            continue;
         }
-        line
-    })
+        let pr = |p: [f32; 3]| {
+            let f = CAM / (CAM - p[2]);
+            (p[0] * f * SX + CC, -p[1] * f * SY + CR)
+        };
+        let (x0, y0) = pr(v[ia]);
+        let (x1, y1) = pr(v[ib]);
+        // slope in visual units: a row is twice as tall as a col is wide
+        let (vdx, vdy) = (x1 - x0, (y1 - y0) * 2.0);
+        let steep = vdy.abs() / vdx.abs().max(1e-6);
+        const M: usize = 64;
+        for m in 0..=M {
+            let s = m as f32 / M as f32;
+            let (x, y) = (x0 + (x1 - x0) * s, y0 + (y1 - y0) * s);
+            let (c, r) = (x.floor() as i32, y.floor() as i32);
+            if c < 0 || c >= W as i32 || r < 0 || r >= H as i32 {
+                continue;
+            }
+            let ch = if steep > 2.4 {
+                '|'
+            } else if steep < 0.45 {
+                if y - y.floor() > 0.6 {
+                    '_'
+                } else {
+                    '-'
+                }
+            } else if vdx * vdy > 0.0 {
+                '\\'
+            } else {
+                '/'
+            };
+            grid[r as usize][c as usize] = ch;
+        }
+    }
+    std::array::from_fn(|r| grid[r].iter().collect())
 }
 
 // s: dots per world unit (braille dot pitch is square, so one scale for both

--- a/crates/prism-cli/src/tetra.rs
+++ b/crates/prism-cli/src/tetra.rs
@@ -104,11 +104,12 @@ pub(crate) fn frame(t: f32, ascii: bool) -> [String; 4] {
     render_wire(0.85 + t * 0.9, 1.0 + t * 2.0, 0.3 + t * 0.55, 7.2, 8.0)
 }
 
-// ASCII tetrahedron. One character per cell picked from the owning edge's
-// overall screen slope, so every edge draws as a consistent stroke. The pose
-// spins about the vertical axis with a slight fixed tilt instead of
-// tumbling: 14x4 characters cannot keep arbitrary poses readable, a
-// triangle silhouette with sweeping inner edges stays one.
+// ASCII tetrahedron: every cell an edge passes through is a '#'. Uniform
+// cells keep the shape connected where slope-matched strokes ('/', '|', '\')
+// fall apart at this resolution. The pose spins about the vertical axis with
+// a slight fixed tilt instead of tumbling: 14x4 characters cannot keep
+// arbitrary poses readable, a triangle silhouette with sweeping inner edges
+// stays one.
 fn render_ascii(t: f32) -> [String; 4] {
     let v = rotated_vertices(0.18, 1.0 + t * 2.2, 0.0);
     let visible = face_visibility(&v);
@@ -129,9 +130,6 @@ fn render_ascii(t: f32) -> [String; 4] {
         };
         let (x0, y0) = pr(v[ia]);
         let (x1, y1) = pr(v[ib]);
-        // slope in visual units: a row is twice as tall as a col is wide
-        let (vdx, vdy) = (x1 - x0, (y1 - y0) * 2.0);
-        let steep = vdy.abs() / vdx.abs().max(1e-6);
         const M: usize = 64;
         for m in 0..=M {
             let s = m as f32 / M as f32;
@@ -140,20 +138,7 @@ fn render_ascii(t: f32) -> [String; 4] {
             if c < 0 || c >= W as i32 || r < 0 || r >= H as i32 {
                 continue;
             }
-            let ch = if steep > 2.4 {
-                '|'
-            } else if steep < 0.45 {
-                if y - y.floor() > 0.6 {
-                    '_'
-                } else {
-                    '-'
-                }
-            } else if vdx * vdy > 0.0 {
-                '\\'
-            } else {
-                '/'
-            };
-            grid[r as usize][c as usize] = ch;
+            grid[r as usize][c as usize] = '#';
         }
     }
     std::array::from_fn(|r| grid[r].iter().collect())

--- a/crates/prism-cli/src/tetra.rs
+++ b/crates/prism-cli/src/tetra.rs
@@ -95,92 +95,26 @@ fn face_visibility(v: &[[f32; 3]; 4]) -> [bool; 4] {
 }
 
 /// The four spinner lines at time `t` seconds: the tumble pose advances on
-/// all three axes at different velocities. `ascii` draws with line-printer
-/// strokes instead of braille, for consoles whose font has no braille block.
+/// all three axes at different velocities. `ascii` swaps the wireframe for a
+/// plain rotating spinner, for consoles whose font has no braille block.
 pub(crate) fn frame(t: f32, ascii: bool) -> [String; 4] {
-    let (rx, ry, rz) = (0.85 + t * 0.9, 1.0 + t * 2.0, 0.3 + t * 0.55);
     if ascii {
-        render_ascii(rx, ry, rz, 7.2, 8.0)
-    } else {
-        render_wire(rx, ry, rz, 7.2, 8.0)
+        return spinner_ascii(t);
     }
+    render_wire(0.85 + t * 0.9, 1.0 + t * 2.0, 0.3 + t * 0.55, 7.2, 8.0)
 }
 
-// ASCII wireframe: one character per cell, picked from the local stroke
-// direction of the edges crossing it. '|' for steep runs, '/' and '\' for
-// diagonals, and '"' '-' '_' for shallow runs by height within the cell.
-fn render_ascii(rx: f32, ry: f32, rz: f32, s: f32, rc: f32) -> [String; 4] {
-    let v = rotated_vertices(rx, ry, rz);
-    let visible = face_visibility(&v);
-
-    #[derive(Clone, Copy, Default)]
-    struct Acc {
-        n: f32,
-        ax: f32,
-        ay: f32,
-        diag: f32,
-        sub: f32,
-    }
-    let mut cells = [[Acc::default(); W]; H];
-    for &(ia, ib, fa, fb) in EDGES.iter() {
-        if !visible[fa] && !visible[fb] {
-            continue;
-        }
-        let pr = |p: [f32; 3]| {
-            let f = CAM / (CAM - p[2]);
-            (p[0] * f * s + DW as f32 * 0.5, -p[1] * f * s + rc)
-        };
-        let (x0, y0) = pr(v[ia]);
-        let (x1, y1) = pr(v[ib]);
-        let (dx, dy) = (x1 - x0, y1 - y0);
-        let len = (dx * dx + dy * dy).sqrt().max(1e-6);
-        let (ux, uy) = (dx / len, dy / len);
-        const M: usize = 96;
-        for m in 0..=M {
-            let t = m as f32 / M as f32;
-            let (fx, fy) = (x0 + dx * t, y0 + dy * t);
-            if fx < 0.0 || fy < 0.0 {
-                continue;
-            }
-            let (c, r) = ((fx / 2.0) as usize, (fy / 4.0) as usize);
-            if c >= W || r >= H {
-                continue;
-            }
-            let a = &mut cells[r][c];
-            a.n += 1.0;
-            a.ax += ux.abs();
-            a.ay += uy.abs();
-            a.diag += (ux * uy).signum();
-            a.sub += fy - (r as f32) * 4.0;
-        }
-    }
-
+// The wireframe is illegible at 14x4 in bare ASCII, so the fallback is the
+// classic four-phase spinner, on the same row as the first progress bar.
+fn spinner_ascii(t: f32) -> [String; 4] {
+    const PHASES: [char; 4] = ['|', '/', '-', '\\'];
+    let ch = PHASES[(t * 8.0) as usize % PHASES.len()];
     std::array::from_fn(|r| {
-        (0..W)
-            .map(|c| {
-                let a = cells[r][c];
-                if a.n == 0.0 {
-                    return ' ';
-                }
-                let (ax, ay) = (a.ax / a.n, a.ay / a.n);
-                if ay > 2.0 * ax {
-                    '|'
-                } else if ax > 2.0 * ay {
-                    let sub = a.sub / a.n; // 0..4 within the cell, y down
-                    if sub < 1.2 {
-                        '"'
-                    } else if sub < 2.6 {
-                        '-'
-                    } else {
-                        '_'
-                    }
-                } else if a.diag > 0.0 {
-                    '\\'
-                } else {
-                    '/'
-                }
-            })
-            .collect()
+        let mut line = " ".repeat(W);
+        if r == 2 {
+            line.replace_range(6..7, &ch.to_string());
+        }
+        line
     })
 }
 

--- a/crates/prism-cli/src/tetra.rs
+++ b/crates/prism-cli/src/tetra.rs
@@ -1,0 +1,153 @@
+//! Braille-wireframe tetrahedron spinner for the 4-line loader.
+//!
+//! Each terminal cell is a 2x4 braille dot grid, so 4 lines give a 28x16 dot
+//! canvas with square dot pitch. Hidden lines are culled via the convex-solid
+//! rule (an edge is visible iff either adjacent face is front-facing).
+
+use std::f32::consts::TAU;
+
+pub(crate) const W: usize = 14; // spinner cells per line
+pub(crate) const H: usize = 4;
+const DW: usize = W * 2; // braille dot columns
+const DH: usize = H * 4; // braille dot rows
+const CAM: f32 = 7.0; // camera distance for perspective
+
+// Regular tetrahedron, apex up, centroid at the origin, all 6 edges sqrt(3):
+// base triangle of circumradius 1 at y = -sqrt(2)/4, apex at y = 3*sqrt(2)/4.
+const APEX_Y: f32 = 1.060_660_2;
+const BASE_Y: f32 = -0.353_553_4;
+
+// Four triangular faces; order matches the EDGES adjacency below.
+const FACES: [(usize, usize, usize); 4] = [
+    (1, 2, 3), // base
+    (0, 1, 2), // sides
+    (0, 2, 3),
+    (0, 3, 1),
+];
+
+// Each edge with its two adjacent faces (indices into FACES).
+const EDGES: [(usize, usize, usize, usize); 6] = [
+    (1, 2, 0, 1),
+    (2, 3, 0, 2),
+    (3, 1, 0, 3),
+    (0, 1, 1, 3),
+    (0, 2, 1, 2),
+    (0, 3, 2, 3),
+];
+
+fn rotate(p: [f32; 3], rx: f32, ry: f32, rz: f32) -> [f32; 3] {
+    let (sx, cx) = rx.sin_cos();
+    let (sy, cy) = ry.sin_cos();
+    let (sz, cz) = rz.sin_cos();
+    // yaw (y axis), then pitch (x axis), then roll (z axis)
+    let (x, y, z) = (p[0] * cy + p[2] * sy, p[1], -p[0] * sy + p[2] * cy);
+    let (x, y, z) = (x, y * cx - z * sx, y * sx + z * cx);
+    let (x, y, z) = (x * cz - y * sz, x * sz + y * cz, z);
+    [x, y, z]
+}
+
+// Vert 0 is the apex; 1-3 the base triangle.
+fn rotated_vertices(rx: f32, ry: f32, rz: f32) -> [[f32; 3]; 4] {
+    let mut v = [[0.0f32; 3]; 4];
+    v[0] = rotate([0.0, APEX_Y, 0.0], rx, ry, rz);
+    for k in 0..3 {
+        let a = k as f32 * TAU / 3.0;
+        v[k + 1] = rotate([a.sin(), BASE_Y, a.cos()], rx, ry, rz);
+    }
+    v
+}
+
+fn sub3(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+fn dot(a: [f32; 3], b: [f32; 3]) -> f32 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+// A face is visible when its outward normal points toward the camera.
+fn face_visibility(v: &[[f32; 3]; 4]) -> [bool; 4] {
+    let mut visible = [false; 4];
+    for (fi, &(ia, ib, ic)) in FACES.iter().enumerate() {
+        let (a, b, c) = (v[ia], v[ib], v[ic]);
+        let e1 = sub3(b, a);
+        let e2 = sub3(c, a);
+        let mut n = cross(e1, e2);
+        let center = [
+            a[0] + (e1[0] + e2[0]) / 3.0,
+            a[1] + (e1[1] + e2[1]) / 3.0,
+            a[2] + (e1[2] + e2[2]) / 3.0,
+        ];
+        if dot(n, center) < 0.0 {
+            n = [-n[0], -n[1], -n[2]];
+        }
+        visible[fi] = dot(n, [-center[0], -center[1], CAM - center[2]]) > 0.0;
+    }
+    visible
+}
+
+/// The four spinner lines at time `t` seconds: the tumble pose advances on
+/// all three axes at different velocities.
+pub(crate) fn frame(t: f32) -> [String; 4] {
+    render_wire(0.85 + t * 0.9, 1.0 + t * 2.0, 0.3 + t * 0.55, 7.2, 8.0)
+}
+
+// s: dots per world unit (braille dot pitch is square, so one scale for both
+// axes). rc: dot row of the object center.
+fn render_wire(rx: f32, ry: f32, rz: f32, s: f32, rc: f32) -> [String; 4] {
+    let v = rotated_vertices(rx, ry, rz);
+    let visible = face_visibility(&v);
+
+    let mut dots = [[false; DW]; DH];
+    for &(ia, ib, fa, fb) in EDGES.iter() {
+        if !visible[fa] && !visible[fb] {
+            continue;
+        }
+        const M: usize = 96;
+        for m in 0..=M {
+            let t = m as f32 / M as f32;
+            let p = [
+                v[ia][0] + (v[ib][0] - v[ia][0]) * t,
+                v[ia][1] + (v[ib][1] - v[ia][1]) * t,
+                v[ia][2] + (v[ib][2] - v[ia][2]) * t,
+            ];
+            let f = CAM / (CAM - p[2]);
+            let sc = (p[0] * f * s + DW as f32 * 0.5).floor() as i32;
+            let sr = (-p[1] * f * s + rc).floor() as i32;
+            if sc < 0 || sc >= DW as i32 || sr < 0 || sr >= DH as i32 {
+                continue;
+            }
+            dots[sr as usize][sc as usize] = true;
+        }
+    }
+
+    // pack 2x4 dot blocks into braille characters
+    const BITS: [[u32; 2]; 4] = [[0x01, 0x08], [0x02, 0x10], [0x04, 0x20], [0x40, 0x80]];
+    std::array::from_fn(|r| {
+        let mut line = String::with_capacity(W * 4);
+        for c in 0..W {
+            let mut bits = 0u32;
+            for dy in 0..4 {
+                for dx in 0..2 {
+                    if dots[r * 4 + dy][c * 2 + dx] {
+                        bits |= BITS[dy][dx];
+                    }
+                }
+            }
+            line.push(if bits == 0 {
+                ' '
+            } else {
+                char::from_u32(0x2800 + bits).unwrap()
+            });
+        }
+        line
+    })
+}

--- a/crates/prism-cli/src/tetra.rs
+++ b/crates/prism-cli/src/tetra.rs
@@ -104,12 +104,13 @@ pub(crate) fn frame(t: f32, ascii: bool) -> [String; 4] {
     render_wire(0.85 + t * 0.9, 1.0 + t * 2.0, 0.3 + t * 0.55, 7.2, 8.0)
 }
 
-// ASCII tetrahedron: every cell an edge passes through is a '#'. Uniform
-// cells keep the shape connected where slope-matched strokes ('/', '|', '\')
-// fall apart at this resolution. The pose spins about the vertical axis with
-// a slight fixed tilt instead of tumbling: 14x4 characters cannot keep
-// arbitrary poses readable, a triangle silhouette with sweeping inner edges
-// stays one.
+// ASCII tetrahedron in sharp glyphs graded by depth: '#' near, '%' mid, '*'
+// far, so edges receding from the camera visibly thin out. All three are
+// full-cell characters, which keeps the shape connected where slope-matched
+// strokes ('/', '|', '\') fall apart at this resolution. The pose spins
+// about the vertical axis with a slight fixed tilt instead of tumbling:
+// 14x4 characters cannot keep arbitrary poses readable, a triangle
+// silhouette with sweeping inner edges stays one.
 fn render_ascii(t: f32) -> [String; 4] {
     let v = rotated_vertices(0.18, 1.0 + t * 2.2, 0.0);
     let visible = face_visibility(&v);
@@ -118,8 +119,10 @@ fn render_ascii(t: f32) -> [String; 4] {
     const SY: f32 = 2.0; // rows per world unit, near half of SX for 1:2 cells
     const CC: f32 = W as f32 / 2.0; // center col
     const CR: f32 = 2.3; // center row
+    const GLYPH: [char; 4] = [' ', '*', '%', '#'];
 
-    let mut grid = [[' '; W]; H];
+    // per cell, the densest rank of any sample landing there: near edges win
+    let mut grid = [[0u8; W]; H];
     for &(ia, ib, fa, fb) in EDGES.iter() {
         if !visible[fa] && !visible[fb] {
             continue;
@@ -138,10 +141,19 @@ fn render_ascii(t: f32) -> [String; 4] {
             if c < 0 || c >= W as i32 || r < 0 || r >= H as i32 {
                 continue;
             }
-            grid[r as usize][c as usize] = '#';
+            let z = v[ia][2] + (v[ib][2] - v[ia][2]) * s;
+            let rank = if z > 0.35 {
+                3
+            } else if z > -0.35 {
+                2
+            } else {
+                1
+            };
+            let cell = &mut grid[r as usize][c as usize];
+            *cell = (*cell).max(rank);
         }
     }
-    std::array::from_fn(|r| grid[r].iter().collect())
+    std::array::from_fn(|r| grid[r].iter().map(|&g| GLYPH[g as usize]).collect())
 }
 
 // s: dots per world unit (braille dot pitch is square, so one scale for both

--- a/crates/prism-cli/src/tetra.rs
+++ b/crates/prism-cli/src/tetra.rs
@@ -95,9 +95,93 @@ fn face_visibility(v: &[[f32; 3]; 4]) -> [bool; 4] {
 }
 
 /// The four spinner lines at time `t` seconds: the tumble pose advances on
-/// all three axes at different velocities.
-pub(crate) fn frame(t: f32) -> [String; 4] {
-    render_wire(0.85 + t * 0.9, 1.0 + t * 2.0, 0.3 + t * 0.55, 7.2, 8.0)
+/// all three axes at different velocities. `ascii` draws with line-printer
+/// strokes instead of braille, for consoles whose font has no braille block.
+pub(crate) fn frame(t: f32, ascii: bool) -> [String; 4] {
+    let (rx, ry, rz) = (0.85 + t * 0.9, 1.0 + t * 2.0, 0.3 + t * 0.55);
+    if ascii {
+        render_ascii(rx, ry, rz, 7.2, 8.0)
+    } else {
+        render_wire(rx, ry, rz, 7.2, 8.0)
+    }
+}
+
+// ASCII wireframe: one character per cell, picked from the local stroke
+// direction of the edges crossing it. '|' for steep runs, '/' and '\' for
+// diagonals, and '"' '-' '_' for shallow runs by height within the cell.
+fn render_ascii(rx: f32, ry: f32, rz: f32, s: f32, rc: f32) -> [String; 4] {
+    let v = rotated_vertices(rx, ry, rz);
+    let visible = face_visibility(&v);
+
+    #[derive(Clone, Copy, Default)]
+    struct Acc {
+        n: f32,
+        ax: f32,
+        ay: f32,
+        diag: f32,
+        sub: f32,
+    }
+    let mut cells = [[Acc::default(); W]; H];
+    for &(ia, ib, fa, fb) in EDGES.iter() {
+        if !visible[fa] && !visible[fb] {
+            continue;
+        }
+        let pr = |p: [f32; 3]| {
+            let f = CAM / (CAM - p[2]);
+            (p[0] * f * s + DW as f32 * 0.5, -p[1] * f * s + rc)
+        };
+        let (x0, y0) = pr(v[ia]);
+        let (x1, y1) = pr(v[ib]);
+        let (dx, dy) = (x1 - x0, y1 - y0);
+        let len = (dx * dx + dy * dy).sqrt().max(1e-6);
+        let (ux, uy) = (dx / len, dy / len);
+        const M: usize = 96;
+        for m in 0..=M {
+            let t = m as f32 / M as f32;
+            let (fx, fy) = (x0 + dx * t, y0 + dy * t);
+            if fx < 0.0 || fy < 0.0 {
+                continue;
+            }
+            let (c, r) = ((fx / 2.0) as usize, (fy / 4.0) as usize);
+            if c >= W || r >= H {
+                continue;
+            }
+            let a = &mut cells[r][c];
+            a.n += 1.0;
+            a.ax += ux.abs();
+            a.ay += uy.abs();
+            a.diag += (ux * uy).signum();
+            a.sub += fy - (r as f32) * 4.0;
+        }
+    }
+
+    std::array::from_fn(|r| {
+        (0..W)
+            .map(|c| {
+                let a = cells[r][c];
+                if a.n == 0.0 {
+                    return ' ';
+                }
+                let (ax, ay) = (a.ax / a.n, a.ay / a.n);
+                if ay > 2.0 * ax {
+                    '|'
+                } else if ax > 2.0 * ay {
+                    let sub = a.sub / a.n; // 0..4 within the cell, y down
+                    if sub < 1.2 {
+                        '"'
+                    } else if sub < 2.6 {
+                        '-'
+                    } else {
+                        '_'
+                    }
+                } else if a.diag > 0.0 {
+                    '\\'
+                } else {
+                    '/'
+                }
+            })
+            .collect()
+    })
 }
 
 // s: dots per world unit (braille dot pitch is square, so one scale for both

--- a/crates/prism-cli/src/tetra.rs
+++ b/crates/prism-cli/src/tetra.rs
@@ -121,8 +121,24 @@ fn render_ascii(t: f32) -> [String; 4] {
     const CR: f32 = 2.3; // center row
     const GLYPH: [char; 4] = [' ', '*', '%', '#'];
 
-    // per cell, the densest rank of any sample landing there: near edges win
+    // per cell, the densest rank of any edge crossing it: near edges win.
+    // Edges step along their major axis, one cell per step, so every stroke
+    // stays a single cell wide.
     let mut grid = [[0u8; W]; H];
+    let mut mark = |c: i32, r: i32, z: f32| {
+        if c < 0 || c >= W as i32 || r < 0 || r >= H as i32 {
+            return;
+        }
+        let rank: u8 = if z > 0.35 {
+            3
+        } else if z > -0.35 {
+            2
+        } else {
+            1
+        };
+        let cell = &mut grid[r as usize][c as usize];
+        *cell = (*cell).max(rank);
+    };
     for &(ia, ib, fa, fb) in EDGES.iter() {
         if !visible[fa] && !visible[fb] {
             continue;
@@ -133,24 +149,23 @@ fn render_ascii(t: f32) -> [String; 4] {
         };
         let (x0, y0) = pr(v[ia]);
         let (x1, y1) = pr(v[ib]);
-        const M: usize = 64;
-        for m in 0..=M {
-            let s = m as f32 / M as f32;
-            let (x, y) = (x0 + (x1 - x0) * s, y0 + (y1 - y0) * s);
-            let (c, r) = (x.floor() as i32, y.floor() as i32);
-            if c < 0 || c >= W as i32 || r < 0 || r >= H as i32 {
-                continue;
+        let (z0, z1) = (v[ia][2], v[ib][2]);
+        let (dx, dy) = (x1 - x0, y1 - y0);
+        if dx == 0.0 && dy == 0.0 {
+            continue;
+        }
+        if dy.abs() >= dx.abs() {
+            let (lo, hi) = (y0.min(y1).floor() as i32, y0.max(y1).floor() as i32);
+            for r in lo..=hi {
+                let t = ((r as f32 + 0.5 - y0) / dy).clamp(0.0, 1.0);
+                mark((x0 + dx * t).floor() as i32, r, z0 + (z1 - z0) * t);
             }
-            let z = v[ia][2] + (v[ib][2] - v[ia][2]) * s;
-            let rank = if z > 0.35 {
-                3
-            } else if z > -0.35 {
-                2
-            } else {
-                1
-            };
-            let cell = &mut grid[r as usize][c as usize];
-            *cell = (*cell).max(rank);
+        } else {
+            let (lo, hi) = (x0.min(x1).floor() as i32, x0.max(x1).floor() as i32);
+            for c in lo..=hi {
+                let t = ((c as f32 + 0.5 - x0) / dx).clamp(0.0, 1.0);
+                mark(c, (y0 + dy * t).floor() as i32, z0 + (z1 - z0) * t);
+            }
         }
     }
     std::array::from_fn(|r| grid[r].iter().map(|&g| GLYPH[g as usize]).collect())

--- a/crates/prism-core/src/fingerprint.rs
+++ b/crates/prism-core/src/fingerprint.rs
@@ -45,7 +45,7 @@ pub fn hash_image(path: &str, observer: &Arc<dyn ProgressObserver>) -> Result<Im
     const ID: u64 = 0;
     observer.on_event(Event::CounterOpen {
         id: ID,
-        label: format!("Hashing image {name}"),
+        label: "Hashing".into(),
         unit: "B".into(),
         total: Some(size as f64),
     });
@@ -79,7 +79,7 @@ fn hash_dir(root: &std::path::Path, observer: &Arc<dyn ProgressObserver>) -> Res
     const ID: u64 = 0;
     observer.on_event(Event::CounterOpen {
         id: ID,
-        label: format!("Hashing image {name}"),
+        label: "Hashing".into(),
         unit: "B".into(),
         total: Some(total as f64),
     });


### PR DESCRIPTION
Replaces indicatif in the CLI with a self-drawn loader on stderr: a tumbling braille wireframe tetrahedron beside the item being processed and up to two progress rows, each a label column, a heavy rule bar, and a percentage. Status messages scroll out above the region, labels truncate so lines never wrap, and when stderr is not a terminal it falls back to the old plain line output.

The core hashing counter is now labeled just Hashing since every front-end already shows which file it is on, so the GUIs pick that up too. A loader_demo example drives the loader with fake events for quick visual checks. Legacy Windows conhost would need a SetConsoleMode VT enable that indicatif used to do, left for a follow-up (WSL and Windows Terminal are fine).