### PR TITLE
Raise asset size and decode caps

### DIFF
--- a/crates/prism-core/src/schema.rs
+++ b/crates/prism-core/src/schema.rs
@@ -18,9 +18,11 @@ pub const FINGERPRINT_PROFILE: &str = "v1";
 /// 5 = PDF and PostScript (.eps/.ps/.ai) as `kind: "document"`; 6 = videos
 /// ship whole up to DVD-VOB scale (previously capped with everything else at
 /// 20MB); 7 = archives (zip/7z/rar/tar/cab/…) extracted as if directories,
-/// their members' assets riding under `<archive path>/...`. A record below
-/// the current value gets its assets re-extracted on the next analyze.
-pub const ASSET_PROFILE: u32 = 7;
+/// their members' assets riding under `<archive path>/...`; 8 = the shared
+/// asset cap raised from 20 to 64 MiB (files between the two previously fell
+/// back to head snippets). A record below the current value gets its assets
+/// re-extracted on the next analyze.
+pub const ASSET_PROFILE: u32 = 8;
 
 /// A fully analyzed disc image / container — image-independent and self-describing.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/prism-core/src/tga.rs
+++ b/crates/prism-core/src/tga.rs
@@ -8,7 +8,7 @@
 /// Refuse to decode absurd dimensions (decode allocates width*height*4 up
 /// front, and headers are attacker-controlled bytes). Matches the web
 /// converter's cap (web/src/lib/imgpng.ts).
-const MAX_PIXELS: u32 = 16_000_000;
+const MAX_PIXELS: u32 = 32_000_000;
 
 struct Decoded {
     width: usize,

--- a/ps2exe-adapter/prism_adapter/viewable.py
+++ b/ps2exe-adapter/prism_adapter/viewable.py
@@ -7,7 +7,8 @@ can't script against the web origin.
 """
 
 # Hard cap on extracted asset size. Files past this fall back to a head snippet.
-MAX_ASSET_SIZE = 20 * 1024 * 1024
+# Sized for press/artwork discs, whose uncompressed TGA/BMP scans run ~30 MiB.
+MAX_ASSET_SIZE = 64 * 1024 * 1024
 
 # Videos get a larger allowance: DVD-Video discs split a title into .VOB files
 # of up to 1 GiB each, and demoting those to head snippets would drop the only

--- a/web/src/app/api/asset/[sha256]/png/route.ts
+++ b/web/src/app/api/asset/[sha256]/png/route.ts
@@ -16,8 +16,9 @@ export const runtime = "nodejs";
 const CACHE = "public, max-age=31536000, immutable";
 
 // Bound what the in-process decoder will chew on (decoded size is capped
-// separately by the converters' MAX_PIXELS).
-const MAX_CONVERT_BYTES = 32_000_000;
+// separately by the converters' MAX_PIXELS). Matches the adapter's
+// MAX_ASSET_SIZE so any stored image asset is convertible.
+const MAX_CONVERT_BYTES = 64 * 1024 * 1024;
 
 export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
   const { sha256 } = await ctx.params;

--- a/web/src/lib/imgpng.ts
+++ b/web/src/lib/imgpng.ts
@@ -24,8 +24,9 @@ export function toPng(mime: string, bytes: Buffer): Buffer {
 }
 
 // Refuse to decode absurd dimensions (decode allocates width*height*4 up
-// front, and headers are attacker-controlled bytes).
-const MAX_PIXELS = 16_000_000;
+// front, and headers are attacker-controlled bytes). Sized to admit hi-res
+// print artwork scans (5760x3600 and up).
+const MAX_PIXELS = 32_000_000;
 
 // The standard BGRA channel masks — what every mainstream tool writes when it
 // uses BI_BITFIELDS on 24/32bpp instead of plain BI_RGB.

--- a/web/src/lib/submission-assets.ts
+++ b/web/src/lib/submission-assets.ts
@@ -8,7 +8,7 @@ import { isSha256 } from "./validate";
 
 /** Per-blob hard caps — mirror max_size() in the adapter's viewable.py:
  *  videos ship whole up to DVD-VOB scale, everything else stays small. */
-export const MAX_ASSET_BLOB_BYTES = 20 * 1024 * 1024;
+export const MAX_ASSET_BLOB_BYTES = 64 * 1024 * 1024;
 export const MAX_VIDEO_BLOB_BYTES = 1280 * 1024 * 1024;
 
 function maxBlobBytes(kind: unknown): number {


### PR DESCRIPTION
Hi-res artwork discs carry image files past the current limits, so most of their assets ship as hex stubs or fail PNG conversion. This raises the extraction cap from 20 to 64 MiB and the BMP/TGA/TIFF decode cap from 16M to 32M pixels.

The submission upload cap and the Rust TGA decoder move in lockstep with their web mirrors. Already stored oversized images convert after deploy, snipped files need re-extraction with the updated adapter.