### PR TITLE
Fix staircased CLI output on Windows

### DIFF
--- a/crates/prism-cli/src/lib.rs
+++ b/crates/prism-cli/src/lib.rs
@@ -370,7 +370,11 @@ fn execute(cli: Cli, fallback_adapter: Option<AdapterCommand>) -> Result<()> {
                 }
             }
             observer.finish();
-            // The end-of-run summary: what this whole invocation accomplished.
+            // The end-of-run summary: what this whole invocation accomplished,
+            // set off from the scrolled per-blob lines by a blank line.
+            if crate::out::stderr_tty() {
+                errln!();
+            }
             let mut summary = format!(
                 "submitted {pushed} of {total} build{}",
                 if total == 1 { "" } else { "s" }

--- a/crates/prism-cli/src/lib.rs
+++ b/crates/prism-cli/src/lib.rs
@@ -194,13 +194,19 @@ pub fn run(args: Vec<String>, fallback_adapter: Option<AdapterCommand>) -> i32 {
             return e.exit_code();
         }
     };
-    match execute(cli, fallback_adapter) {
+    let code = match execute(cli, fallback_adapter) {
         Ok(()) => 0,
         Err(e) => {
             errln!("error: {e:#}");
             1
         }
+    };
+    // A parting blank line puts the shell prompt on a fresh column-zero row,
+    // whatever column the run left the cursor in.
+    if crate::out::stderr_tty() {
+        errln!();
     }
+    code
 }
 
 fn execute(cli: Cli, fallback_adapter: Option<AdapterCommand>) -> Result<()> {
@@ -340,20 +346,52 @@ fn execute(cli: Cli, fallback_adapter: Option<AdapterCommand>) -> Result<()> {
             let token = moderation_token.as_deref().filter(|t| !t.is_empty());
             let total = targets.len();
             let mut failed = 0usize;
+            let (mut pushed, mut blobs, mut bytes) = (0usize, 0usize, 0u64);
+            let (mut unavailable, mut accepted) = (0usize, 0usize);
             // One loader across all targets: batch shows "[n/N] name" beside the
             // spinner, and every submit-phase line scrolls out above it (the
             // loader's frames carry the explicit `\r`s a Windows console needs).
             let observer = Arc::new(LoaderObserver::new());
             for (i, target) in targets.iter().enumerate() {
                 observer.batch(i as u64, total as u64, target);
-                if let Err(e) =
-                    submit_one(&analyzer, &reader, &client, target, &nickname, token, force, &observer)
+                match submit_one(&analyzer, &reader, &client, target, &nickname, token, force, &observer)
                 {
-                    failed += 1;
-                    observer.on_event(Event::Message(format!("error: {target}: {e:#}")));
+                    Ok(o) => {
+                        pushed += 1;
+                        blobs += o.uploaded;
+                        bytes += o.bytes;
+                        unavailable += o.unavailable;
+                        accepted += usize::from(o.accepted);
+                    }
+                    Err(e) => {
+                        failed += 1;
+                        observer.on_event(Event::Message(format!("error: {target}: {e:#}")));
+                    }
                 }
             }
             observer.finish();
+            // The end-of-run summary: what this whole invocation accomplished.
+            let mut summary = format!(
+                "submitted {pushed} of {total} build{}",
+                if total == 1 { "" } else { "s" }
+            );
+            if blobs > 0 {
+                summary.push_str(&format!(
+                    ", uploaded {blobs} asset blob{} ({})",
+                    if blobs == 1 { "" } else { "s" },
+                    summary::human_size(bytes),
+                ));
+            }
+            if unavailable > 0 {
+                summary.push_str(&format!(
+                    ", {unavailable} blob{} not in local store",
+                    if unavailable == 1 { "" } else { "s" }
+                ));
+            }
+            if accepted > 0 {
+                summary.push_str(&format!(", accepted {accepted}"));
+            }
+            errln!("{summary}");
             if failed > 0 {
                 bail!("{failed} of {total} submissions failed");
             }
@@ -515,7 +553,7 @@ fn submit_one(
     moderation_token: Option<&str>,
     force: bool,
     observer: &Arc<LoaderObserver>,
-) -> Result<()> {
+) -> Result<service::SubmitOutcome> {
     let analysis = resolve_target(analyzer, target, force, observer)?;
     let json = render::to_json(&analysis.record)?;
     observer.on_event(Event::Message(format!(

--- a/crates/prism-cli/src/lib.rs
+++ b/crates/prism-cli/src/lib.rs
@@ -4,6 +4,7 @@
 //! the local library, inspect a build's views, extract assets, and talk to the
 //! web service (Find Similar / Submit).
 
+mod out;
 pub mod progress;
 mod service;
 mod tetra;
@@ -17,8 +18,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 use prism_core::adapter::AdapterCommand;
 use prism_core::db::{LibraryRow, LibrarySort};
 use prism_core::summary::{self, Section};
-use prism_core::{render, Analysis, Analyzer, Config, Node, Reader};
+use prism_core::{render, Analysis, Analyzer, Config, Event, Node, ProgressObserver, Reader};
 
+use crate::out::{errln, out, outln};
 use crate::progress::LoaderObserver;
 
 #[derive(Parser)]
@@ -195,7 +197,7 @@ pub fn run(args: Vec<String>, fallback_adapter: Option<AdapterCommand>) -> i32 {
     match execute(cli, fallback_adapter) {
         Ok(()) => 0,
         Err(e) => {
-            eprintln!("error: {e:#}");
+            errln!("error: {e:#}");
             1
         }
     }
@@ -214,24 +216,24 @@ fn execute(cli: Cli, fallback_adapter: Option<AdapterCommand>) -> Result<()> {
 
     match cli.command {
         Command::Stats => {
-            println!("builds in library: {}", analyzer.library_size()?);
+            outln!("builds in library: {}", analyzer.library_size()?);
         }
         Command::Export { out } => match &out {
             Some(p) if p.extension().and_then(|e| e.to_str()) == Some("zip") => {
                 let n = analyzer
                     .export_bundle(p)
                     .with_context(|| format!("writing bundle {}", p.display()))?;
-                eprintln!("exported {n} builds -> {}", p.display());
+                errln!("exported {n} builds -> {}", p.display());
             }
             Some(p) => {
                 let f = std::fs::File::create(p)
                     .with_context(|| format!("creating {}", p.display()))?;
                 let n = analyzer.export_jsonl(std::io::BufWriter::new(f))?;
-                eprintln!("exported {n} builds -> {}", p.display());
+                errln!("exported {n} builds -> {}", p.display());
             }
             None => {
                 let n = analyzer.export_jsonl(std::io::stdout().lock())?;
-                eprintln!("exported {n} builds");
+                errln!("exported {n} builds");
             }
         },
         Command::Analyze { files, format, out, force } => {
@@ -269,7 +271,7 @@ fn execute(cli: Cli, fallback_adapter: Option<AdapterCommand>) -> Result<()> {
         }
         Command::Systems => {
             for s in analyzer.open_reader()?.list_systems()? {
-                println!("{s}");
+                outln!("{s}");
             }
         }
         Command::Recent { limit } => {
@@ -288,19 +290,23 @@ fn execute(cli: Cli, fallback_adapter: Option<AdapterCommand>) -> Result<()> {
                     print_sections(&sections);
                 }
                 View::Tree => print_tree(&analysis.record.contents, 0),
-                View::Xml => print!("{}", render::to_dat_xml(&analysis.record)),
-                View::Json => print!("{}", render::to_json(&analysis.record)?),
+                View::Xml => out!("{}", render::to_dat_xml(&analysis.record)),
+                View::Json => out!("{}", render::to_json(&analysis.record)?),
             }
         }
         Command::Extract { sha, out, filter } => {
             extract(&analyzer, &sha, &out, filter.as_deref())?;
         }
         Command::Similar { target } => {
-            let analysis = resolve_target(&analyzer, &target, false)?;
+            let observer = Arc::new(LoaderObserver::new());
+            observer.batch(0, 1, &target);
+            let analysis = resolve_target(&analyzer, &target, false, &observer)?;
             let json = render::to_json(&analysis.record)?;
             let client = service::Client::new(&cli.web_url)?;
-            eprintln!("querying similar builds…");
-            print!("{}", client.similarity(&json)?);
+            observer.batch(0, 1, "querying similar builds…");
+            let similar = client.similarity(&json)?;
+            observer.finish();
+            out!("{similar}");
         }
         Command::Submit { targets, nickname, recursive, force, moderation_token } => {
             if nickname.trim().is_empty() {
@@ -334,16 +340,20 @@ fn execute(cli: Cli, fallback_adapter: Option<AdapterCommand>) -> Result<()> {
             let token = moderation_token.as_deref().filter(|t| !t.is_empty());
             let total = targets.len();
             let mut failed = 0usize;
+            // One loader across all targets: batch shows "[n/N] name" beside the
+            // spinner, and every submit-phase line scrolls out above it (the
+            // loader's frames carry the explicit `\r`s a Windows console needs).
+            let observer = Arc::new(LoaderObserver::new());
             for (i, target) in targets.iter().enumerate() {
-                if total > 1 {
-                    eprintln!("[{}/{total}] {target}", i + 1);
-                }
-                if let Err(e) = submit_one(&analyzer, &reader, &client, target, &nickname, token, force)
+                observer.batch(i as u64, total as u64, target);
+                if let Err(e) =
+                    submit_one(&analyzer, &reader, &client, target, &nickname, token, force, &observer)
                 {
                     failed += 1;
-                    eprintln!("error: {target}: {e:#}");
+                    observer.on_event(Event::Message(format!("error: {target}: {e:#}")));
                 }
             }
+            observer.finish();
             if failed > 0 {
                 bail!("{failed} of {total} submissions failed");
             }
@@ -387,14 +397,14 @@ fn analyze(
                 };
                 std::fs::write(&path, rendered)
                     .with_context(|| format!("writing {}", path.display()))?;
-                eprintln!(
+                errln!(
                     "{} {} -> {}",
                     if analysis.from_cache { "[cached]" } else { "[analyzed]" },
                     analysis.record.image.sha256,
                     path.display()
                 );
             }
-            None => print!("{rendered}"),
+            None => out!("{rendered}"),
         }
     }
     Ok(())
@@ -424,7 +434,7 @@ fn expand_inputs(paths: &[String]) -> Vec<String> {
 fn import(analyzer: &Analyzer, paths: &[String]) -> Result<()> {
     let files = expand_inputs(paths);
     if files.is_empty() {
-        eprintln!("no files found to import");
+        errln!("no files found to import");
         return Ok(());
     }
     let total = files.len() as u64;
@@ -438,11 +448,11 @@ fn import(analyzer: &Analyzer, paths: &[String]) -> Result<()> {
             Ok(_) => imported += 1,
             Err(e) => {
                 skipped += 1;
-                eprintln!("  skipped {path}: {e}");
+                errln!("  skipped {path}: {e}");
             }
         }
     }
-    println!("imported {imported}, skipped {skipped} unsupported");
+    outln!("imported {imported}, skipped {skipped} unsupported");
     Ok(())
 }
 
@@ -475,19 +485,21 @@ fn load_build(reader: &Reader, sha: &str) -> Result<Analysis> {
 
 /// A submit/similar target: an existing path is analyzed (cache hit when
 /// already imported; `force` re-parses from scratch); anything else is
-/// treated as a library sha256/prefix.
-fn resolve_target(analyzer: &Analyzer, target: &str, force: bool) -> Result<Analysis> {
+/// treated as a library sha256/prefix. The caller owns the loader (and has
+/// set its batch label), so it keeps spinning through the service phase.
+fn resolve_target(
+    analyzer: &Analyzer,
+    target: &str,
+    force: bool,
+    observer: &Arc<LoaderObserver>,
+) -> Result<Analysis> {
     if Path::new(target).exists() {
-        let observer = Arc::new(LoaderObserver::new());
-        observer.batch(0, 1, target);
-        let analysis = if force {
+        if force {
             analyzer.reanalyze(target, observer.clone())
         } else {
             analyzer.analyze(target, observer.clone())
         }
-        .with_context(|| format!("analyzing {target}"))?;
-        observer.finish();
-        Ok(analysis)
+        .with_context(|| format!("analyzing {target}"))
     } else {
         load_build(&analyzer.open_reader()?, target)
     }
@@ -502,15 +514,16 @@ fn submit_one(
     nickname: &str,
     moderation_token: Option<&str>,
     force: bool,
+    observer: &Arc<LoaderObserver>,
 ) -> Result<()> {
-    let analysis = resolve_target(analyzer, target, force)?;
+    let analysis = resolve_target(analyzer, target, force, observer)?;
     let json = render::to_json(&analysis.record)?;
-    eprintln!(
+    observer.on_event(Event::Message(format!(
         "{} {} — {}",
         if analysis.from_cache { "[cached]" } else { "[analyzed]" },
         analysis.record.image.sha256,
         analysis.record.info.system,
-    );
+    )));
     // Resolve which of the build's asset blobs exist locally (sha256 → path);
     // the client uploads whichever the server lacks.
     let mut local: HashMap<String, PathBuf> = HashMap::new();
@@ -519,7 +532,7 @@ fn submit_one(
             local.insert(a.sha256.clone(), p);
         }
     }
-    client.submit(&analysis.record.image.sha256, &json, nickname, &local, moderation_token)
+    client.submit(&analysis.record.image.sha256, &json, nickname, &local, moderation_token, observer.as_ref())
 }
 
 fn extract(analyzer: &Analyzer, sha: &str, out: &Path, filter: Option<&str>) -> Result<()> {
@@ -552,7 +565,7 @@ fn extract(analyzer: &Analyzer, sha: &str, out: &Path, filter: Option<&str>) -> 
         }
         std::fs::copy(&blob, &dest)
             .with_context(|| format!("writing {}", dest.display()))?;
-        println!("{}", dest.display());
+        outln!("{}", dest.display());
         extracted += 1;
     }
     let note = if missing > 0 {
@@ -560,7 +573,7 @@ fn extract(analyzer: &Analyzer, sha: &str, out: &Path, filter: Option<&str>) -> 
     } else {
         String::new()
     };
-    eprintln!("extracted {extracted} assets{note}");
+    errln!("extracted {extracted} assets{note}");
     Ok(())
 }
 
@@ -588,12 +601,12 @@ fn safe_component(comp: &str) -> String {
 fn print_sections(sections: &[Section]) {
     for (i, sec) in sections.iter().enumerate() {
         if i > 0 {
-            println!();
+            outln!();
         }
-        println!("{}", sec.title);
+        outln!("{}", sec.title);
         let width = sec.rows.iter().map(|(k, _)| k.chars().count()).max().unwrap_or(0);
         for (key, value) in &sec.rows {
-            println!("  {key:<width$}  {value}");
+            outln!("  {key:<width$}  {value}");
         }
     }
 }
@@ -603,7 +616,7 @@ fn print_tree(nodes: &[Node], depth: usize) {
         let indent = "  ".repeat(depth);
         match node {
             Node::Dir { name, children, .. } => {
-                println!("{indent}{name}/");
+                outln!("{indent}{name}/");
                 print_tree(children, depth + 1);
             }
             Node::File { name, size, unreadable, .. } => {
@@ -614,7 +627,7 @@ fn print_tree(nodes: &[Node], depth: usize) {
                 if *unreadable {
                     line.push_str("  [unreadable]");
                 }
-                println!("{line}");
+                outln!("{line}");
             }
         }
     }
@@ -622,17 +635,17 @@ fn print_tree(nodes: &[Node], depth: usize) {
 
 fn print_rows(rows: &[LibraryRow]) {
     if rows.is_empty() {
-        eprintln!("(no builds)");
+        errln!("(no builds)");
         return;
     }
     let name_w = rows.iter().map(|r| r.name.chars().count()).max().unwrap_or(0).clamp(4, 60);
     let sys_w = rows.iter().map(|r| r.system.chars().count()).max().unwrap_or(0).max(6);
-    println!(
+    outln!(
         "{:<name_w$}  {:<sys_w$}  {:>6}  {:>9}  {:<10}  {}",
         "NAME", "SYSTEM", "FILES", "SIZE", "ANALYZED", "SHA256"
     );
     for r in rows {
-        println!(
+        outln!(
             "{:<name_w$}  {:<sys_w$}  {:>6}  {:>9}  {:<10}  {}",
             truncate(&r.name, name_w),
             r.system,

--- a/crates/prism-cli/src/out.rs
+++ b/crates/prism-cli/src/out.rs
@@ -1,0 +1,63 @@
+//! Console-safe line output: `outln!`/`errln!`/`out!` mirror `println!`/
+//! `eprintln!`/`print!`, but on a Windows console they end lines with `\r\n`
+//! and convert embedded `\n` too. A Windows console can run with newline
+//! auto-return disabled (WSL interop's conhost does, for VT passthrough), and
+//! there a bare `\n` moves down without returning the carriage, stair-stepping
+//! every plain line (the loader is immune: its frames start with `\r`).
+//! Redirected streams keep plain `\n`, so piped output is byte-identical.
+
+use std::fmt;
+use std::io::{IsTerminal, Write};
+use std::sync::OnceLock;
+
+fn stdout_crlf() -> bool {
+    static V: OnceLock<bool> = OnceLock::new();
+    cfg!(windows) && *V.get_or_init(|| std::io::stdout().is_terminal())
+}
+
+fn stderr_crlf() -> bool {
+    static V: OnceLock<bool> = OnceLock::new();
+    cfg!(windows) && *V.get_or_init(|| std::io::stderr().is_terminal())
+}
+
+fn emit(w: &mut impl Write, args: fmt::Arguments, crlf: bool, newline: bool) {
+    if crlf {
+        let mut s = args.to_string().replace('\n', "\r\n");
+        if newline {
+            s.push_str("\r\n");
+        }
+        let _ = w.write_all(s.as_bytes());
+    } else if newline {
+        let _ = writeln!(w, "{args}");
+    } else {
+        let _ = write!(w, "{args}");
+    }
+}
+
+pub fn out_line(args: fmt::Arguments) {
+    emit(&mut std::io::stdout().lock(), args, stdout_crlf(), true);
+}
+
+pub fn out_raw(args: fmt::Arguments) {
+    emit(&mut std::io::stdout().lock(), args, stdout_crlf(), false);
+}
+
+pub fn err_line(args: fmt::Arguments) {
+    emit(&mut std::io::stderr().lock(), args, stderr_crlf(), true);
+}
+
+macro_rules! outln {
+    () => { $crate::out::out_line(format_args!("")) };
+    ($($arg:tt)*) => { $crate::out::out_line(format_args!($($arg)*)) };
+}
+
+macro_rules! out {
+    ($($arg:tt)*) => { $crate::out::out_raw(format_args!($($arg)*)) };
+}
+
+macro_rules! errln {
+    () => { $crate::out::err_line(format_args!("")) };
+    ($($arg:tt)*) => { $crate::out::err_line(format_args!($($arg)*)) };
+}
+
+pub(crate) use {errln, out, outln};

--- a/crates/prism-cli/src/out.rs
+++ b/crates/prism-cli/src/out.rs
@@ -15,9 +15,13 @@ fn stdout_crlf() -> bool {
     cfg!(windows) && *V.get_or_init(|| std::io::stdout().is_terminal())
 }
 
-fn stderr_crlf() -> bool {
+pub fn stderr_tty() -> bool {
     static V: OnceLock<bool> = OnceLock::new();
-    cfg!(windows) && *V.get_or_init(|| std::io::stderr().is_terminal())
+    *V.get_or_init(|| std::io::stderr().is_terminal())
+}
+
+fn stderr_crlf() -> bool {
+    cfg!(windows) && stderr_tty()
 }
 
 fn emit(w: &mut impl Write, args: fmt::Arguments, crlf: bool, newline: bool) {

--- a/crates/prism-cli/src/progress.rs
+++ b/crates/prism-cli/src/progress.rs
@@ -1,10 +1,10 @@
 //! Renders core progress events as a 4-line loader on stderr: a tumbling
-//! braille tetrahedron beside the item being worked on, a blank line, and up
-//! to two progress rows (the first counter still open and the most recently
-//! opened one), each as a label column, a heavy-rule bar with a half-cell
-//! head, and a percentage. Indeterminate counters get a bouncing comet on
-//! the same rail. Falls back to plain line output when stderr is not a
-//! terminal.
+//! braille tetrahedron beside the item being worked on, a transient
+//! per-item status line, and up to two progress rows (the first counter
+//! still open and the most recently opened one), each as a label column, a
+//! heavy-rule bar with a half-cell head, and a percentage or item count.
+//! Indeterminate counters get a bouncing comet on the same rail. Falls
+//! back to plain line output when stderr is not a terminal.
 //!
 //! Windows console fonts are not reliable braille renderers, so on Windows
 //! and inside WSL the loader is all-ASCII. PRISM_ASCII=1 or =0 forces the
@@ -57,6 +57,9 @@ struct Counter {
 #[derive(Default)]
 struct State {
     batch: Option<String>,
+    /// Latest per-item status, drawn inside the loader region and replaced
+    /// by the next one (unlike `pending`, it never reaches the scrollback).
+    transient: Option<String>,
     counters: Vec<Counter>,
     pending: Vec<String>, // messages to scroll out above the loader
 }
@@ -125,9 +128,21 @@ impl LoaderObserver {
             } else {
                 name.to_string()
             };
-            self.state.lock().unwrap().batch = Some(label);
+            let mut st = self.state.lock().unwrap();
+            st.batch = Some(label);
+            st.transient = None; // a new item starts with a clean status line
         } else if total > 1 {
             errln!("[{}/{}] {}", index + 1, total, name);
+        }
+    }
+
+    /// Show a per-item status inside the loader region, replacing the
+    /// previous one. Plain mode logs it as an ordinary line instead.
+    pub fn transient(&self, text: String) {
+        if self.tty {
+            self.state.lock().unwrap().transient = Some(text);
+        } else {
+            errln!("{text}");
         }
     }
 
@@ -252,7 +267,7 @@ fn compose(st: &State, t: f32, buf: &mut String) {
     buf.push_str("\r\x1b[2K\n"); // blank line separating the loader from prior output
     let texts: [String; tetra::H] = [
         st.batch.as_deref().map(|s| truncate(s, BATCHW)).unwrap_or_default(),
-        String::new(),
+        st.transient.as_deref().map(|s| truncate(s, BATCHW)).unwrap_or_default(),
         st.counters.first().map(|c| counter_line(c, t)).unwrap_or_default(),
         if st.counters.len() > 1 {
             counter_line(st.counters.last().unwrap(), t)

--- a/crates/prism-cli/src/progress.rs
+++ b/crates/prism-cli/src/progress.rs
@@ -24,6 +24,7 @@ use crate::tetra;
 const REGION_H: usize = tetra::H + 1; // loader lines: one blank, then the spinner rows
 const BARW: usize = 30; // bar columns
 const LABELW: usize = 14; // label column width; longer labels truncate
+const TAILW: usize = 9; // progress figure column, right-aligned ("9999/9999", " 100%")
 const BATCHW: usize = 58; // truncation budget for the item line
 const FRAME_US: u64 = 16_667; // 60fps
 
@@ -306,11 +307,11 @@ fn counter_line(c: &Counter, t: f32) -> String {
         Some(total) if total > 0.0 => {
             let frac = (c.count / total).clamp(0.0, 1.0) as f32;
             let tail = if c.unit == "B" {
-                format!("{:>3}%", (frac * 100.0) as u32)
+                format!("{}%", (frac * 100.0) as u32)
             } else {
                 format!("{}/{}", c.count.min(total) as u64, total as u64)
             };
-            format!("{label:<LABELW$} {} {tail}", bar(frac))
+            format!("{label:<LABELW$} {} {tail:>TAILW$}", bar(frac))
         }
         _ => format!("{label:<LABELW$} {}", sweep(t)),
     }

--- a/crates/prism-cli/src/progress.rs
+++ b/crates/prism-cli/src/progress.rs
@@ -58,6 +58,9 @@ struct Counter {
 struct State {
     batch: Option<String>,
     counters: Vec<Counter>,
+    /// The last secondary counter to finish, shown full on the second row
+    /// while newer counters have nothing to show yet.
+    done: Option<Counter>,
     pending: Vec<String>, // messages to scroll out above the loader
 }
 
@@ -125,7 +128,9 @@ impl LoaderObserver {
             } else {
                 name.to_string()
             };
-            self.state.lock().unwrap().batch = Some(label);
+            let mut st = self.state.lock().unwrap();
+            st.batch = Some(label);
+            st.done = None; // a finished bar never outlives its batch item
         } else if total > 1 {
             errln!("[{}/{}] {}", index + 1, total, name);
         }
@@ -172,7 +177,17 @@ impl ProgressObserver for LoaderObserver {
             }
             Event::CounterClose { id } => {
                 if self.tty {
-                    self.state.lock().unwrap().counters.retain(|c| c.id != id);
+                    let mut st = self.state.lock().unwrap();
+                    if let Some(pos) = st.counters.iter().position(|c| c.id == id) {
+                        let c = st.counters.remove(pos);
+                        // A finished secondary counter lingers on the second
+                        // row, pinned at full, until something overtakes it.
+                        if pos > 0 {
+                            if let Some(total) = c.total.filter(|t| *t > 0.0) {
+                                st.done = Some(Counter { count: total, ..c });
+                            }
+                        }
+                    }
                 }
             }
             Event::Message(m) => {
@@ -258,15 +273,21 @@ fn draw_loop(state: Arc<Mutex<State>>, running: Arc<AtomicBool>) {
 fn compose(st: &State, t: f32, buf: &mut String) {
     let spin = tetra::frame(t, ascii_mode());
     buf.push_str("\r\x1b[2K\n"); // blank line separating the loader from prior output
+    // Second row: the newest secondary counter once it has progress to show,
+    // otherwise the last one to finish (pinned at full), so with many quick
+    // items the row tails completions instead of idling at zero.
+    let second = match st.counters.last() {
+        Some(last) if st.counters.len() > 1 && (last.count > 0.0 || st.done.is_none()) => {
+            Some(counter_line(last, t))
+        }
+        Some(_) => st.done.as_ref().map(|c| counter_line(c, t)),
+        None => None,
+    };
     let texts: [String; tetra::H] = [
         st.batch.as_deref().map(|s| truncate(s, BATCHW)).unwrap_or_default(),
         String::new(),
         st.counters.first().map(|c| counter_line(c, t)).unwrap_or_default(),
-        if st.counters.len() > 1 {
-            counter_line(st.counters.last().unwrap(), t)
-        } else {
-            String::new()
-        },
+        second.unwrap_or_default(),
     ];
     for (line, text) in spin.iter().zip(texts.iter()) {
         buf.push_str("\r\x1b[2K");

--- a/crates/prism-cli/src/progress.rs
+++ b/crates/prism-cli/src/progress.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 
 use prism_core::{Event, ProgressObserver};
 
+use crate::out::errln;
 use crate::tetra;
 
 const REGION_H: usize = tetra::H + 1; // loader lines: one blank, then the spinner rows
@@ -125,7 +126,7 @@ impl LoaderObserver {
             };
             self.state.lock().unwrap().batch = Some(label);
         } else if total > 1 {
-            eprintln!("[{}/{}] {}", index + 1, total, name);
+            errln!("[{}/{}] {}", index + 1, total, name);
         }
     }
 
@@ -169,7 +170,7 @@ impl ProgressObserver for LoaderObserver {
                 if self.tty {
                     self.state.lock().unwrap().pending.push(m);
                 } else {
-                    eprintln!("{m}");
+                    errln!("{m}");
                 }
             }
             Event::BatchItem { index, total, name } => {

--- a/crates/prism-cli/src/progress.rs
+++ b/crates/prism-cli/src/progress.rs
@@ -49,6 +49,7 @@ fn wsl() -> bool {
 struct Counter {
     id: u64,
     label: String,
+    unit: String,
     total: Option<f64>,
     count: f64,
 }
@@ -147,10 +148,10 @@ impl Drop for LoaderObserver {
 impl ProgressObserver for LoaderObserver {
     fn on_event(&self, ev: Event) {
         match ev {
-            Event::CounterOpen { id, label, unit: _, total } => {
+            Event::CounterOpen { id, label, unit, total } => {
                 if self.tty {
                     let mut st = self.state.lock().unwrap();
-                    st.counters.push(Counter { id, label, total, count: 0.0 });
+                    st.counters.push(Counter { id, label, unit, total, count: 0.0 });
                 }
             }
             Event::Progress { id, count } => {
@@ -268,12 +269,19 @@ fn compose(st: &State, t: f32, buf: &mut String) {
     }
 }
 
+// Byte counters read best as a percentage, item counters (files, blobs) as
+// the k/n they actually are.
 fn counter_line(c: &Counter, t: f32) -> String {
     let label = truncate(&c.label, LABELW);
     match c.total {
         Some(total) if total > 0.0 => {
             let frac = (c.count / total).clamp(0.0, 1.0) as f32;
-            format!("{label:<LABELW$} {} {:>3}%", bar(frac), (frac * 100.0) as u32)
+            let tail = if c.unit == "B" {
+                format!("{:>3}%", (frac * 100.0) as u32)
+            } else {
+                format!("{}/{}", c.count.min(total) as u64, total as u64)
+            };
+            format!("{label:<LABELW$} {} {tail}", bar(frac))
         }
         _ => format!("{label:<LABELW$} {}", sweep(t)),
     }

--- a/crates/prism-cli/src/progress.rs
+++ b/crates/prism-cli/src/progress.rs
@@ -287,14 +287,18 @@ fn counter_line(c: &Counter, t: f32) -> String {
     }
 }
 
-// Heavy rule with a half-cell head, empty missing. ASCII mode draws the
-// classic equals-and-chevron bar instead.
+// Heavy rule with a half-cell head, empty missing. ASCII mode draws a plain
+// equals rule with no head.
 fn bar(frac: f32) -> String {
     let n = (frac * BARW as f32) as usize;
-    let (fill, head) = if ascii_mode() { ("=", '>') } else { ("━", '╸') };
-    let mut s = fill.repeat(n);
+    if ascii_mode() {
+        let mut s = "=".repeat(n);
+        s.push_str(&" ".repeat(BARW - n));
+        return s;
+    }
+    let mut s = "━".repeat(n);
     if n < BARW {
-        s.push(head);
+        s.push('╸');
         s.push_str(&" ".repeat(BARW - n - 1));
     }
     s
@@ -307,7 +311,7 @@ fn sweep(t: f32) -> String {
     let p = if phase < 1.0 { phase } else { 2.0 - phase };
     let p = (p * span) as usize;
     let mut s = " ".repeat(p);
-    s.push_str(if ascii_mode() { "<=>" } else { "╺━╸" });
+    s.push_str(if ascii_mode() { "===" } else { "╺━╸" });
     s.push_str(&" ".repeat(BARW - p - 3));
     s
 }

--- a/crates/prism-cli/src/progress.rs
+++ b/crates/prism-cli/src/progress.rs
@@ -1,10 +1,10 @@
 //! Renders core progress events as a 4-line loader on stderr: a tumbling
-//! braille tetrahedron beside the item being worked on, a transient
-//! per-item status line, and up to two progress rows (the first counter
-//! still open and the most recently opened one), each as a label column, a
-//! heavy-rule bar with a half-cell head, and a percentage or item count.
-//! Indeterminate counters get a bouncing comet on the same rail. Falls
-//! back to plain line output when stderr is not a terminal.
+//! braille tetrahedron beside the item being worked on, a blank line, and
+//! up to two progress rows (the first counter still open and the most
+//! recently opened one), each as a label column, a heavy-rule bar with a
+//! half-cell head, and a percentage or item count. Indeterminate counters
+//! get a bouncing comet on the same rail. Falls back to plain line output
+//! when stderr is not a terminal.
 //!
 //! Windows console fonts are not reliable braille renderers, so on Windows
 //! and inside WSL the loader is all-ASCII. PRISM_ASCII=1 or =0 forces the
@@ -57,9 +57,6 @@ struct Counter {
 #[derive(Default)]
 struct State {
     batch: Option<String>,
-    /// Latest per-item status, drawn inside the loader region and replaced
-    /// by the next one (unlike `pending`, it never reaches the scrollback).
-    transient: Option<String>,
     counters: Vec<Counter>,
     pending: Vec<String>, // messages to scroll out above the loader
 }
@@ -128,20 +125,16 @@ impl LoaderObserver {
             } else {
                 name.to_string()
             };
-            let mut st = self.state.lock().unwrap();
-            st.batch = Some(label);
-            st.transient = None; // a new item starts with a clean status line
+            self.state.lock().unwrap().batch = Some(label);
         } else if total > 1 {
             errln!("[{}/{}] {}", index + 1, total, name);
         }
     }
 
-    /// Show a per-item status inside the loader region, replacing the
-    /// previous one. Plain mode logs it as an ordinary line instead.
-    pub fn transient(&self, text: String) {
-        if self.tty {
-            self.state.lock().unwrap().transient = Some(text);
-        } else {
+    /// Log a line in plain mode only. The tty loader carries the same
+    /// information in its counter rows, so it stays quiet there.
+    pub fn plain(&self, text: String) {
+        if !self.tty {
             errln!("{text}");
         }
     }
@@ -267,7 +260,7 @@ fn compose(st: &State, t: f32, buf: &mut String) {
     buf.push_str("\r\x1b[2K\n"); // blank line separating the loader from prior output
     let texts: [String; tetra::H] = [
         st.batch.as_deref().map(|s| truncate(s, BATCHW)).unwrap_or_default(),
-        st.transient.as_deref().map(|s| truncate(s, BATCHW)).unwrap_or_default(),
+        String::new(),
         st.counters.first().map(|c| counter_line(c, t)).unwrap_or_default(),
         if st.counters.len() > 1 {
             counter_line(st.counters.last().unwrap(), t)

--- a/crates/prism-cli/src/service.rs
+++ b/crates/prism-cli/src/service.rs
@@ -192,10 +192,25 @@ impl Client {
         std::thread::scope(|s| {
             for _ in 0..PARALLEL_UPLOADS.min(total) {
                 s.spawn(|| loop {
-                    let Some(sha) = todo.get(next.fetch_add(1, Ordering::Relaxed)) else { break };
+                    let i = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(sha) = todo.get(i) else { break };
+                    // Each blob gets its own byte counter, so the loader's
+                    // second bar row tracks the most recently started blob.
+                    let id = UPLOAD_ID - 1 - i as u64;
+                    let size = std::fs::metadata(&local[*sha]).map(|m| m.len()).unwrap_or(0);
+                    obs.on_event(Event::CounterOpen {
+                        id,
+                        label: format!("{}…", &sha[..12.min(sha.len())]),
+                        unit: "B".into(),
+                        total: Some(size as f64),
+                    });
+                    let sent = std::cell::Cell::new(0u64);
                     let ok = self.upload_asset_chunked(&assets_url, sha, &local[*sha], &|delta| {
                         bytes_done.fetch_add(delta as u64, Ordering::Relaxed);
+                        sent.set(sent.get() + delta as u64);
+                        obs.on_event(Event::Progress { id, count: sent.get() as f64 });
                     });
+                    obs.on_event(Event::CounterClose { id });
                     if ok {
                         ok_count.fetch_add(1, Ordering::Relaxed);
                     }
@@ -206,10 +221,10 @@ impl Client {
                         &sha[..12.min(sha.len())],
                         if ok { "uploaded" } else { "FAILED" }
                     );
-                    // Successes tick by inside the loader; failures must
-                    // survive in the scrollback.
+                    // Completions tick by in the counter rows; plain mode logs
+                    // each, and failures must survive in the scrollback.
                     if ok {
-                        obs.transient(line);
+                        obs.plain(line);
                     } else {
                         obs.on_event(Event::Message(line));
                     }

--- a/crates/prism-cli/src/service.rs
+++ b/crates/prism-cli/src/service.rs
@@ -5,17 +5,22 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
+use prism_core::{Event, ProgressObserver};
 
 /// Upload chunk size — small enough to clear typical proxy body-size limits.
 const UPLOAD_CHUNK: usize = 4 * 1024 * 1024;
 
 /// How many asset blobs to upload at once.
 const PARALLEL_UPLOADS: usize = 32;
+
+/// Counter id for the upload progress bar. The adapter's counters are all
+/// closed by the time the service phase starts, so any id would do.
+const UPLOAD_ID: u64 = u64::MAX;
 
 /// Give up after this many consecutive rate-limit waits on one chunk.
 const MAX_THROTTLE_RETRIES: u32 = 30;
@@ -86,6 +91,7 @@ impl Client {
         nickname: &str,
         local: &HashMap<String, PathBuf>,
         moderation_token: Option<&str>,
+        obs: &dyn ProgressObserver,
     ) -> Result<()> {
         let record: serde_json::Value =
             serde_json::from_str(record_json).context("parsing record JSON")?;
@@ -104,12 +110,12 @@ impl Client {
             .ok()
             .and_then(|v| v.get("status").and_then(|s| s.as_str()).map(String::from))
             .unwrap_or_else(|| "queued".into());
-        println!("submitted — {status}");
+        obs.on_event(Event::Message(format!("submitted — {status}")));
 
-        self.upload_missing_assets(build_sha, local)?;
+        self.upload_missing_assets(build_sha, local, obs)?;
 
         if let Some(token) = moderation_token {
-            self.accept(build_sha, token)?;
+            self.accept(build_sha, token, obs)?;
         }
         Ok(())
     }
@@ -117,7 +123,12 @@ impl Client {
     /// Ask the server which of the submitted build's asset blobs it lacks,
     /// then PUT each one we hold locally, a few at once. Errors if any upload
     /// fails — the record submission itself has already succeeded by then.
-    fn upload_missing_assets(&self, build_sha: &str, local: &HashMap<String, PathBuf>) -> Result<()> {
+    fn upload_missing_assets(
+        &self,
+        build_sha: &str,
+        local: &HashMap<String, PathBuf>,
+        obs: &dyn ProgressObserver,
+    ) -> Result<()> {
         if local.is_empty() {
             return Ok(()); // nothing extracted locally — nothing to offer
         }
@@ -135,18 +146,32 @@ impl Client {
             })
             .unwrap_or_default();
         if missing.is_empty() {
-            println!("assets already on server");
+            obs.on_event(Event::Message("assets already on server".into()));
             return Ok(());
         }
         let todo: Vec<&String> = missing.iter().filter(|sha| local.contains_key(*sha)).collect();
         let unavailable = missing.len() - todo.len();
         if todo.is_empty() {
-            println!("{unavailable} missing asset blobs are not in the local store");
+            obs.on_event(Event::Message(format!(
+                "{unavailable} missing asset blobs are not in the local store"
+            )));
             return Ok(());
         }
         // Workers pull the next blob off a shared counter; each blob is its own
-        // resumable PUT (chunks of one blob never interleave).
+        // resumable PUT (chunks of one blob never interleave). One byte-level
+        // counter spans all blobs, advanced as chunks are accepted.
         let total = todo.len();
+        let total_bytes: u64 = todo
+            .iter()
+            .map(|sha| std::fs::metadata(&local[*sha]).map(|m| m.len()).unwrap_or(0))
+            .sum();
+        obs.on_event(Event::CounterOpen {
+            id: UPLOAD_ID,
+            label: "Uploading".into(),
+            unit: "B".into(),
+            total: Some(total_bytes as f64),
+        });
+        let bytes_done = AtomicU64::new(0);
         let next = AtomicUsize::new(0);
         let completed = AtomicUsize::new(0);
         let ok_count = AtomicUsize::new(0);
@@ -154,26 +179,30 @@ impl Client {
             for _ in 0..PARALLEL_UPLOADS.min(total) {
                 s.spawn(|| loop {
                     let Some(sha) = todo.get(next.fetch_add(1, Ordering::Relaxed)) else { break };
-                    let ok = self.upload_asset_chunked(&assets_url, sha, &local[*sha]);
+                    let ok = self.upload_asset_chunked(&assets_url, sha, &local[*sha], &|delta| {
+                        let done = bytes_done.fetch_add(delta as u64, Ordering::Relaxed) + delta as u64;
+                        obs.on_event(Event::Progress { id: UPLOAD_ID, count: done as f64 });
+                    });
                     if ok {
                         ok_count.fetch_add(1, Ordering::Relaxed);
                     }
                     let n = completed.fetch_add(1, Ordering::Relaxed) + 1;
-                    eprintln!(
+                    obs.on_event(Event::Message(format!(
                         "  [{n}/{total}] {}… {}",
                         &sha[..12.min(sha.len())],
                         if ok { "uploaded" } else { "FAILED" }
-                    );
+                    )));
                 });
             }
         });
+        obs.on_event(Event::CounterClose { id: UPLOAD_ID });
         let uploaded = ok_count.into_inner();
         let failed = total - uploaded;
         let mut note = format!("uploaded {uploaded} asset blob{}", if uploaded == 1 { "" } else { "s" });
         if unavailable > 0 {
             note.push_str(&format!(", {unavailable} not in local store"));
         }
-        println!("{note}");
+        obs.on_event(Event::Message(note));
         if failed > 0 {
             bail!("{failed} asset upload{} failed (submission is queued; retry to resume)",
                 if failed == 1 { "" } else { "s" });
@@ -183,10 +212,19 @@ impl Client {
 
     /// PUT one asset blob in resumable chunks: each request appends at
     /// `offset`, a 409 answers with the server's staged offset to resume from,
-    /// and the final chunk returns `stored` (or `exists`).
-    fn upload_asset_chunked(&self, assets_url: &str, sha: &str, path: &Path) -> bool {
+    /// and the final chunk returns `stored` (or `exists`). `report` receives
+    /// newly-confirmed byte counts, monotonic per blob (a 409 resume can move
+    /// the offset either way, only fresh high-water marks are reported).
+    fn upload_asset_chunked(
+        &self,
+        assets_url: &str,
+        sha: &str,
+        path: &Path,
+        report: &dyn Fn(usize),
+    ) -> bool {
         let Ok(bytes) = std::fs::read(path) else { return false };
         let mut offset: usize = 0;
+        let mut reported: usize = 0;
         let mut last_staged: Option<usize> = None;
         let mut throttled = 0u32;
         while offset < bytes.len() {
@@ -205,13 +243,22 @@ impl Client {
                 c if (200..300).contains(&c) => {
                     let v = serde_json::from_str::<serde_json::Value>(&body).unwrap_or_default();
                     match v.get("status").and_then(|s| s.as_str()) {
-                        Some("stored") | Some("exists") => return true,
+                        Some("stored") | Some("exists") => {
+                            if bytes.len() > reported {
+                                report(bytes.len() - reported);
+                            }
+                            return true;
+                        }
                         _ => {
                             offset = v
                                 .get("offset")
                                 .and_then(|o| o.as_u64())
                                 .map(|o| o as usize)
                                 .unwrap_or(end);
+                            if offset > reported {
+                                report(offset - reported);
+                                reported = offset;
+                            }
                             last_staged = None;
                             throttled = 0;
                         }
@@ -244,6 +291,10 @@ impl Client {
                     }
                     last_staged = Some(staged);
                     offset = staged;
+                    if staged > reported {
+                        report(staged - reported);
+                        reported = staged;
+                    }
                 }
                 _ => return false,
             }
@@ -253,7 +304,7 @@ impl Client {
 
     /// Accept the just-submitted build with the moderation token, so the
     /// record (and its refreshed assets) replaces the live build immediately.
-    fn accept(&self, build_sha: &str, token: &str) -> Result<()> {
+    fn accept(&self, build_sha: &str, token: &str, obs: &dyn ProgressObserver) -> Result<()> {
         let url = format!("{}/api/submissions/{build_sha}", self.base);
         let (code, body) = self.request(
             "POST",
@@ -263,7 +314,7 @@ impl Client {
         )?;
         match code {
             c if (200..300).contains(&c) => {
-                println!("accepted — live build updated");
+                obs.on_event(Event::Message("accepted — live build updated".into()));
                 Ok(())
             }
             401 => bail!("accept failed: moderation token rejected (submission stays queued)"),

--- a/crates/prism-cli/src/service.rs
+++ b/crates/prism-cli/src/service.rs
@@ -12,6 +12,8 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use prism_core::{Event, ProgressObserver};
 
+use crate::progress::LoaderObserver;
+
 /// Upload chunk size — small enough to clear typical proxy body-size limits.
 const UPLOAD_CHUNK: usize = 4 * 1024 * 1024;
 
@@ -103,7 +105,7 @@ impl Client {
         nickname: &str,
         local: &HashMap<String, PathBuf>,
         moderation_token: Option<&str>,
-        obs: &dyn ProgressObserver,
+        obs: &LoaderObserver,
     ) -> Result<SubmitOutcome> {
         let record: serde_json::Value =
             serde_json::from_str(record_json).context("parsing record JSON")?;
@@ -142,7 +144,7 @@ impl Client {
         &self,
         build_sha: &str,
         local: &HashMap<String, PathBuf>,
-        obs: &dyn ProgressObserver,
+        obs: &LoaderObserver,
     ) -> Result<(usize, usize, u64)> {
         if local.is_empty() {
             return Ok((0, 0, 0)); // nothing extracted locally — nothing to offer
@@ -199,11 +201,18 @@ impl Client {
                     }
                     let n = completed.fetch_add(1, Ordering::Relaxed) + 1;
                     obs.on_event(Event::Progress { id: UPLOAD_ID, count: n as f64 });
-                    obs.on_event(Event::Message(format!(
+                    let line = format!(
                         "  [{n}/{total}] {}… {}",
                         &sha[..12.min(sha.len())],
                         if ok { "uploaded" } else { "FAILED" }
-                    )));
+                    );
+                    // Successes tick by inside the loader; failures must
+                    // survive in the scrollback.
+                    if ok {
+                        obs.transient(line);
+                    } else {
+                        obs.on_event(Event::Message(line));
+                    }
                 });
             }
         });
@@ -316,7 +325,7 @@ impl Client {
 
     /// Accept the just-submitted build with the moderation token, so the
     /// record (and its refreshed assets) replaces the live build immediately.
-    fn accept(&self, build_sha: &str, token: &str, obs: &dyn ProgressObserver) -> Result<()> {
+    fn accept(&self, build_sha: &str, token: &str, obs: &LoaderObserver) -> Result<()> {
         let url = format!("{}/api/submissions/{build_sha}", self.base);
         let (code, body) = self.request(
             "POST",

--- a/crates/prism-cli/src/service.rs
+++ b/crates/prism-cli/src/service.rs
@@ -30,6 +30,18 @@ pub struct Client {
     base: String,
 }
 
+/// What one submission accomplished, for the caller's end-of-run summary.
+pub struct SubmitOutcome {
+    /// Asset blobs newly confirmed on the server.
+    pub uploaded: usize,
+    /// Blobs the server wants that the local store does not hold.
+    pub unavailable: usize,
+    /// Bytes confirmed server-side across the uploaded blobs.
+    pub bytes: u64,
+    /// Whether the submission was moderation-accepted into the live build.
+    pub accepted: bool,
+}
+
 impl Client {
     pub fn new(web_url: &str) -> Result<Self> {
         let tls = native_tls::TlsConnector::new().context("initializing TLS")?;
@@ -92,7 +104,7 @@ impl Client {
         local: &HashMap<String, PathBuf>,
         moderation_token: Option<&str>,
         obs: &dyn ProgressObserver,
-    ) -> Result<()> {
+    ) -> Result<SubmitOutcome> {
         let record: serde_json::Value =
             serde_json::from_str(record_json).context("parsing record JSON")?;
         let body = serde_json::json!({ "nickname": nickname, "record": record });
@@ -112,25 +124,28 @@ impl Client {
             .unwrap_or_else(|| "queued".into());
         obs.on_event(Event::Message(format!("submitted — {status}")));
 
-        self.upload_missing_assets(build_sha, local, obs)?;
+        let (uploaded, unavailable, bytes) = self.upload_missing_assets(build_sha, local, obs)?;
 
+        let mut accepted = false;
         if let Some(token) = moderation_token {
             self.accept(build_sha, token, obs)?;
+            accepted = true;
         }
-        Ok(())
+        Ok(SubmitOutcome { uploaded, unavailable, bytes, accepted })
     }
 
     /// Ask the server which of the submitted build's asset blobs it lacks,
     /// then PUT each one we hold locally, a few at once. Errors if any upload
     /// fails — the record submission itself has already succeeded by then.
+    /// Returns (uploaded blobs, blobs not held locally, bytes confirmed).
     fn upload_missing_assets(
         &self,
         build_sha: &str,
         local: &HashMap<String, PathBuf>,
         obs: &dyn ProgressObserver,
-    ) -> Result<()> {
+    ) -> Result<(usize, usize, u64)> {
         if local.is_empty() {
-            return Ok(()); // nothing extracted locally — nothing to offer
+            return Ok((0, 0, 0)); // nothing extracted locally — nothing to offer
         }
         let assets_url = format!("{}/api/submissions/{build_sha}/assets", self.base);
         let (code, body) = self.request("GET", &assets_url, &[], None)?;
@@ -147,7 +162,7 @@ impl Client {
             .unwrap_or_default();
         if missing.is_empty() {
             obs.on_event(Event::Message("assets already on server".into()));
-            return Ok(());
+            return Ok((0, 0, 0));
         }
         let todo: Vec<&String> = missing.iter().filter(|sha| local.contains_key(*sha)).collect();
         let unavailable = missing.len() - todo.len();
@@ -155,21 +170,18 @@ impl Client {
             obs.on_event(Event::Message(format!(
                 "{unavailable} missing asset blobs are not in the local store"
             )));
-            return Ok(());
+            return Ok((0, unavailable, 0));
         }
         // Workers pull the next blob off a shared counter; each blob is its own
-        // resumable PUT (chunks of one blob never interleave). One byte-level
-        // counter spans all blobs, advanced as chunks are accepted.
+        // resumable PUT (chunks of one blob never interleave). One counter
+        // spans all blobs, counted per completed blob (the loader shows a
+        // non-byte counter as k/n rather than a percentage).
         let total = todo.len();
-        let total_bytes: u64 = todo
-            .iter()
-            .map(|sha| std::fs::metadata(&local[*sha]).map(|m| m.len()).unwrap_or(0))
-            .sum();
         obs.on_event(Event::CounterOpen {
             id: UPLOAD_ID,
             label: "Uploading".into(),
-            unit: "B".into(),
-            total: Some(total_bytes as f64),
+            unit: "blobs".into(),
+            total: Some(total as f64),
         });
         let bytes_done = AtomicU64::new(0);
         let next = AtomicUsize::new(0);
@@ -180,13 +192,13 @@ impl Client {
                 s.spawn(|| loop {
                     let Some(sha) = todo.get(next.fetch_add(1, Ordering::Relaxed)) else { break };
                     let ok = self.upload_asset_chunked(&assets_url, sha, &local[*sha], &|delta| {
-                        let done = bytes_done.fetch_add(delta as u64, Ordering::Relaxed) + delta as u64;
-                        obs.on_event(Event::Progress { id: UPLOAD_ID, count: done as f64 });
+                        bytes_done.fetch_add(delta as u64, Ordering::Relaxed);
                     });
                     if ok {
                         ok_count.fetch_add(1, Ordering::Relaxed);
                     }
                     let n = completed.fetch_add(1, Ordering::Relaxed) + 1;
+                    obs.on_event(Event::Progress { id: UPLOAD_ID, count: n as f64 });
                     obs.on_event(Event::Message(format!(
                         "  [{n}/{total}] {}… {}",
                         &sha[..12.min(sha.len())],
@@ -207,7 +219,7 @@ impl Client {
             bail!("{failed} asset upload{} failed (submission is queued; retry to resume)",
                 if failed == 1 { "" } else { "s" });
         }
-        Ok(())
+        Ok((uploaded, unavailable, bytes_done.into_inner()))
     }
 
     /// PUT one asset blob in resumable chunks: each request appends at

--- a/crates/prism-cli/src/tetra.rs
+++ b/crates/prism-cli/src/tetra.rs
@@ -108,11 +108,17 @@ pub(crate) fn frame(t: f32, ascii: bool) -> [String; 4] {
 // far, so edges receding from the camera visibly thin out. All three are
 // full-cell characters, which keeps the shape connected where slope-matched
 // strokes ('/', '|', '\') fall apart at this resolution. The pose spins
-// about the vertical axis with a slight fixed tilt instead of tumbling:
+// about the vertical axis with a slight tilt instead of tumbling:
 // 14x4 characters cannot keep arbitrary poses readable, a triangle
-// silhouette with sweeping inner edges stays one.
+// silhouette with sweeping inner edges stays one. The tilt nutates a
+// little (slow pitch and roll wobble) so the apex, which sits on the
+// spin axis, does not render as a frozen pair of cells.
 fn render_ascii(t: f32) -> [String; 4] {
-    let v = rotated_vertices(0.18, 1.0 - t * 2.2, 0.0);
+    let v = rotated_vertices(
+        0.18 + 0.12 * (t * 1.3).sin(),
+        1.0 - t * 2.2,
+        0.22 * (t * 0.9).sin(),
+    );
     let visible = face_visibility(&v);
 
     const SX: f32 = 3.6; // cols per world unit

--- a/crates/prism-cli/src/tetra.rs
+++ b/crates/prism-cli/src/tetra.rs
@@ -104,15 +104,17 @@ pub(crate) fn frame(t: f32, ascii: bool) -> [String; 4] {
     render_wire(0.85 + t * 0.9, 1.0 + t * 2.0, 0.3 + t * 0.55, 7.2, 8.0)
 }
 
-// ASCII tetrahedron in sharp glyphs graded by depth: '#' near, '%' mid, '*'
-// far, so edges receding from the camera visibly thin out. All three are
-// full-cell characters, which keeps the shape connected where slope-matched
-// strokes ('/', '|', '\') fall apart at this resolution. The pose spins
-// about the vertical axis with a slight tilt instead of tumbling:
-// 14x4 characters cannot keep arbitrary poses readable, a triangle
-// silhouette with sweeping inner edges stays one. The tilt nutates a
-// little (slow pitch and roll wobble) so the apex, which sits on the
-// spin axis, does not render as a frozen pair of cells.
+// ASCII tetrahedron in thin strokes: each edge picks its glyph from its
+// projected slope ('|', '/', '\', '-'), so lines read as lines instead of
+// blocks. Slope alone fell apart here once, the fix is classifying in
+// visual pixel space (cells are about twice as tall as wide) and letting
+// shallow runs fall back to '-' rather than stacking slashes. Depth still
+// grades weight: far edges thin out to '.', the nearest horizontal gets
+// '='. The pose spins about the vertical axis with a slight tilt instead
+// of tumbling: 14x4 characters cannot keep arbitrary poses readable, a
+// triangle silhouette with sweeping inner edges stays one. The tilt
+// nutates a little (slow pitch and roll wobble) so the apex, which sits
+// on the spin axis, does not render as a frozen pair of cells.
 fn render_ascii(t: f32) -> [String; 4] {
     let v = rotated_vertices(
         0.18 + 0.12 * (t * 1.3).sin(),
@@ -125,25 +127,27 @@ fn render_ascii(t: f32) -> [String; 4] {
     const SY: f32 = 2.0; // rows per world unit, near half of SX for 1:2 cells
     const CC: f32 = W as f32 / 2.0; // center col
     const CR: f32 = 2.3; // center row
-    const GLYPH: [char; 4] = [' ', '*', '%', '#'];
 
-    // per cell, the densest rank of any edge crossing it: near edges win.
-    // Edges step along their major axis, one cell per step, so every stroke
-    // stays a single cell wide.
-    let mut grid = [[0u8; W]; H];
-    let mut mark = |c: i32, r: i32, z: f32| {
+    // per cell, the glyph of the nearest edge crossing it: higher rank wins,
+    // an equal-rank crossing keeps the first comer. Edges step along their
+    // major axis, one cell per step, so every stroke stays a single cell wide.
+    let mut grid = [[(0u8, ' '); W]; H];
+    let mut mark = |c: i32, r: i32, z: f32, dir: usize| {
         if c < 0 || c >= W as i32 || r < 0 || r >= H as i32 {
             return;
         }
-        let rank: u8 = if z > 0.35 {
-            3
+        // dir: 0 '|', 1 '/', 2 '\', 3 '-'
+        let (rank, glyph): (u8, char) = if z > 0.35 {
+            (3, ['|', '/', '\\', '='][dir])
         } else if z > -0.35 {
-            2
+            (2, ['|', '/', '\\', '-'][dir])
         } else {
-            1
+            (1, '.')
         };
         let cell = &mut grid[r as usize][c as usize];
-        *cell = (*cell).max(rank);
+        if rank > cell.0 {
+            *cell = (rank, glyph);
+        }
     };
     for &(ia, ib, fa, fb) in EDGES.iter() {
         if !visible[fa] && !visible[fb] {
@@ -160,21 +164,34 @@ fn render_ascii(t: f32) -> [String; 4] {
         if dx == 0.0 && dy == 0.0 {
             continue;
         }
+        // Classify the stroke by its on-screen slope, in pixels (rows are
+        // about twice as tall as columns are wide, so the cell slope
+        // doubles). A '/' or '\' glyph itself runs at pixel slope ~2.
+        let pixel_slope = 2.0 * dy / dx;
+        let dir = if pixel_slope.abs() > 4.5 || dx == 0.0 {
+            0
+        } else if pixel_slope.abs() < 0.9 {
+            3
+        } else if pixel_slope < 0.0 {
+            1
+        } else {
+            2
+        };
         if dy.abs() >= dx.abs() {
             let (lo, hi) = (y0.min(y1).floor() as i32, y0.max(y1).floor() as i32);
             for r in lo..=hi {
                 let t = ((r as f32 + 0.5 - y0) / dy).clamp(0.0, 1.0);
-                mark((x0 + dx * t).floor() as i32, r, z0 + (z1 - z0) * t);
+                mark((x0 + dx * t).floor() as i32, r, z0 + (z1 - z0) * t, dir);
             }
         } else {
             let (lo, hi) = (x0.min(x1).floor() as i32, x0.max(x1).floor() as i32);
             for c in lo..=hi {
                 let t = ((c as f32 + 0.5 - x0) / dx).clamp(0.0, 1.0);
-                mark(c, (y0 + dy * t).floor() as i32, z0 + (z1 - z0) * t);
+                mark(c, (y0 + dy * t).floor() as i32, z0 + (z1 - z0) * t, dir);
             }
         }
     }
-    std::array::from_fn(|r| grid[r].iter().map(|&g| GLYPH[g as usize]).collect())
+    std::array::from_fn(|r| grid[r].iter().map(|&(_, g)| g).collect())
 }
 
 // s: dots per world unit (braille dot pitch is square, so one scale for both

--- a/crates/prism-cli/src/tetra.rs
+++ b/crates/prism-cli/src/tetra.rs
@@ -112,7 +112,7 @@ pub(crate) fn frame(t: f32, ascii: bool) -> [String; 4] {
 // 14x4 characters cannot keep arbitrary poses readable, a triangle
 // silhouette with sweeping inner edges stays one.
 fn render_ascii(t: f32) -> [String; 4] {
-    let v = rotated_vertices(0.18, 1.0 + t * 2.2, 0.0);
+    let v = rotated_vertices(0.18, 1.0 - t * 2.2, 0.0);
     let visible = face_visibility(&v);
 
     const SX: f32 = 3.6; // cols per world unit


### PR DESCRIPTION
Under WSL the Windows exe writes to a conhost that has newline auto-return disabled, so every plain line printed during submit stair-stepped across the screen (the hashing loader was immune because its frames start with a carriage return). CLI prints now go through console-safe macros that end lines with CRLF on a Windows console, and the submit and similar phases keep the loader running, with status lines scrolling above the spinner and a byte-level upload progress bar.

Piped output is byte-identical to before, though submit status lines now land on stderr instead of stdout. Also flips the ASCII tetra spin direction.