### PR TITLE
Community media and notes

### DIFF
--- a/web/db/migrations/006-user-media.sql
+++ b/web/db/migrations/006-user-media.sql
@@ -1,0 +1,52 @@
+-- Community metadata: media uploads, notes, and completeness skip flags,
+-- contributed by logged-in wiki users on the build pages.
+--
+-- PROD-ONLY USER DATA. On the production server these tables hold
+-- contributions that exist nowhere else. Never drop, truncate, or reload
+-- them from a local dump; schema changes must stay additive. The deploy
+-- tooling preserves and restores them around any full DB reload.
+--
+-- build_skip is its own table (not columns on builds) on purpose: library
+-- reloads rewrite builds, and user state must never ride on a library table.
+--
+-- Idempotent, safe to re-run. Apply to every prism DB:
+--   psql -d <db> -f db/migrations/006-user-media.sql
+
+-- Uploaded media, one row per (build, kind, file). The bytes live in the
+-- blob store under the media/ namespace, content-addressed by sha256.
+CREATE TABLE IF NOT EXISTS build_media (
+    id            BIGSERIAL PRIMARY KEY,
+    build_sha256  TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE,
+    kind          TEXT NOT NULL CHECK (kind IN ('screenshot','video','physical')),
+    sha256        TEXT NOT NULL,          -- content hash = key under media/ in the blob store
+    poster_sha256 TEXT,                   -- video poster still, also under media/
+    filename      TEXT NOT NULL,
+    content_type  TEXT NOT NULL,          -- sniffed server-side, not the client's claim
+    size          BIGINT NOT NULL,
+    author        TEXT NOT NULL,          -- wiki username
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (build_sha256, kind, sha256)
+);
+CREATE INDEX IF NOT EXISTS idx_build_media_build ON build_media(build_sha256);
+CREATE INDEX IF NOT EXISTS idx_build_media_sha256 ON build_media(sha256);
+
+CREATE TABLE IF NOT EXISTS build_note (
+    id           BIGSERIAL PRIMARY KEY,
+    build_sha256 TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE,
+    body         TEXT NOT NULL,
+    author       TEXT NOT NULL,           -- wiki username
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    edited_at    TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS idx_build_note_build ON build_note(build_sha256);
+
+-- Per-build "this category does not apply" flags for the completeness
+-- columns on /builds (a build with 0 in a category shows orange unless the
+-- category is skipped here).
+CREATE TABLE IF NOT EXISTS build_skip (
+    build_sha256     TEXT PRIMARY KEY REFERENCES builds(sha256) ON DELETE CASCADE,
+    skip_notes       BOOLEAN NOT NULL DEFAULT FALSE,
+    skip_screenshots BOOLEAN NOT NULL DEFAULT FALSE,
+    skip_video       BOOLEAN NOT NULL DEFAULT FALSE,
+    skip_physical    BOOLEAN NOT NULL DEFAULT FALSE
+);

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -188,7 +188,54 @@ CREATE TABLE exe_fp (
 );
 CREATE INDEX idx_exe_imphash ON exe_fp(imphash);
 
+-- ── community metadata: media, notes, skip flags ─────────────────────────────
+-- PROD-ONLY USER DATA. On the production server these tables hold wiki-user
+-- contributions that exist nowhere else. Never drop, truncate, or reload them
+-- from a local dump; schema changes must stay additive (the deploy tooling
+-- preserves and restores them around any full DB reload). build_skip is its
+-- own table, not columns on builds, so library reloads can never carry it.
+
+-- Uploaded media, one row per (build, kind, file). The bytes live in the
+-- blob store under the media/ namespace, content-addressed by sha256.
+CREATE TABLE build_media (
+    id            BIGSERIAL PRIMARY KEY,
+    build_sha256  TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE,
+    kind          TEXT NOT NULL CHECK (kind IN ('screenshot','video','physical')),
+    sha256        TEXT NOT NULL,          -- content hash = key under media/ in the blob store
+    poster_sha256 TEXT,                   -- video poster still, also under media/
+    filename      TEXT NOT NULL,
+    content_type  TEXT NOT NULL,          -- sniffed server-side, not the client's claim
+    size          BIGINT NOT NULL,
+    author        TEXT NOT NULL,          -- wiki username
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (build_sha256, kind, sha256)
+);
+CREATE INDEX idx_build_media_build ON build_media(build_sha256);
+CREATE INDEX idx_build_media_sha256 ON build_media(sha256);
+
+CREATE TABLE build_note (
+    id           BIGSERIAL PRIMARY KEY,
+    build_sha256 TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE,
+    body         TEXT NOT NULL,
+    author       TEXT NOT NULL,           -- wiki username
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    edited_at    TIMESTAMPTZ
+);
+CREATE INDEX idx_build_note_build ON build_note(build_sha256);
+
+-- Per-build "this category does not apply" flags for the completeness
+-- columns on /builds (0 in a category shows orange unless skipped here).
+CREATE TABLE build_skip (
+    build_sha256     TEXT PRIMARY KEY REFERENCES builds(sha256) ON DELETE CASCADE,
+    skip_notes       BOOLEAN NOT NULL DEFAULT FALSE,
+    skip_screenshots BOOLEAN NOT NULL DEFAULT FALSE,
+    skip_video       BOOLEAN NOT NULL DEFAULT FALSE,
+    skip_physical    BOOLEAN NOT NULL DEFAULT FALSE
+);
+
 -- ── ops: similarity-check log + submission queue ─────────────────────────────
+-- submission_queue is PROD-ONLY USER DATA on the production server (pending
+-- and accepted user submissions): same never-wipe rules as above.
 CREATE TABLE similarity_log (
     id          BIGSERIAL PRIMARY KEY,
     sha256      TEXT NOT NULL,         -- queried build identity (may be unknown to corpus)

--- a/web/src/app/api/build/[sha256]/media/[id]/route.ts
+++ b/web/src/app/api/build/[sha256]/media/[id]/route.ts
@@ -1,0 +1,36 @@
+import type { NextRequest } from "next/server";
+import { getContributor, contributionTarget, revalidateBuildPages } from "@/lib/contrib";
+import { getPool } from "@/lib/db";
+import { deleteMedia, getMediaById } from "@/lib/media";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// DELETE /api/build/<sha256>/media/<id>: remove one media entry, by its own
+// author or a moderator. The blob stays in the store (content-addressed and
+// possibly shared); only the record goes.
+export async function DELETE(request: NextRequest, ctx: { params: Promise<{ sha256: string; id: string }> }) {
+  const { sha256, id } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+  const mediaId = Number(id);
+  if (!Number.isInteger(mediaId) || mediaId <= 0) {
+    return Response.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  const contributor = await getContributor(request);
+  if (!contributor) return Response.json({ error: "log in to the wiki first" }, { status: 401 });
+  const pool = getPool();
+  const target = await contributionTarget(pool, sha256);
+  if (!target) return Response.json({ error: "not found" }, { status: 404 });
+
+  const row = await getMediaById(pool, sha256, mediaId);
+  if (!row) return Response.json({ error: "not found" }, { status: 404 });
+  if (row.author !== contributor.name && !contributor.moderator) {
+    return Response.json({ error: "only the uploader or a moderator can remove this" }, { status: 403 });
+  }
+
+  await deleteMedia(pool, sha256, mediaId);
+  revalidateBuildPages(sha256, target.name);
+  return Response.json({ deleted: true });
+}

--- a/web/src/app/api/build/[sha256]/media/upload/[token]/route.ts
+++ b/web/src/app/api/build/[sha256]/media/upload/[token]/route.ts
@@ -1,0 +1,155 @@
+import fsp from "node:fs/promises";
+import type { NextRequest } from "next/server";
+import { storeBlobFromFile } from "@/lib/blobstore";
+import { getContributor, contributionTarget, revalidateBuildPages } from "@/lib/contrib";
+import { getPool } from "@/lib/db";
+import { extractStill } from "@/lib/ffmpeg";
+import {
+  MEDIA_NS,
+  dropMediaSession,
+  hashFile,
+  insertMedia,
+  isMediaToken,
+  mediaStagingPath,
+  mediaView,
+  readMediaSession,
+  sniffMedia,
+  updateMediaSession,
+} from "@/lib/media";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Client chunks stay well under proxy body limits; reject anything absurd.
+const MAX_CHUNK_BYTES = 32 * 1024 * 1024;
+
+// PUT /api/build/<sha256>/media/upload/<token>?offset=N: append one chunk to
+// an open upload session. The first chunk is sniffed (magic bytes decide the
+// stored content type; the client's claim is ignored) and must agree with the
+// session's kind. A stale offset answers 409 { offset } so the client can
+// resume. When the staged bytes reach the claimed size the file is hashed,
+// stored under the media/ namespace (with a poster still for videos), and
+// recorded; the response carries { done: true, media }.
+export async function PUT(
+  request: NextRequest,
+  ctx: { params: Promise<{ sha256: string; token: string }> }
+) {
+  const { sha256, token } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+  if (!isMediaToken(token)) return Response.json({ error: "invalid token" }, { status: 400 });
+
+  const contributor = await getContributor(request);
+  if (!contributor) {
+    return Response.json({ error: "log in to the wiki to contribute" }, { status: 401 });
+  }
+  const pool = getPool();
+  const target = await contributionTarget(pool, sha256);
+  if (!target) return Response.json({ error: "not found" }, { status: 404 });
+  if (!target.visible && !contributor.moderator) {
+    return Response.json({ error: "this build is not open for contributions" }, { status: 403 });
+  }
+
+  const session = await readMediaSession(token);
+  if (!session || session.build !== sha256) {
+    return Response.json({ error: "no such upload session" }, { status: 404 });
+  }
+  const staging = mediaStagingPath(token);
+  const st = await fsp.stat(staging).catch(() => null);
+  if (!st) return Response.json({ error: "no such upload session" }, { status: 404 });
+  let staged = st.size;
+  if (staged > session.size) {
+    await dropMediaSession(token);
+    return Response.json({ error: "corrupt upload session" }, { status: 400 });
+  }
+
+  if (staged < session.size) {
+    const offset = Number(request.nextUrl.searchParams.get("offset") ?? "0");
+    if (!Number.isInteger(offset) || offset < 0) {
+      return Response.json({ error: "invalid offset" }, { status: 400 });
+    }
+    if (offset !== staged) return Response.json({ offset: staged }, { status: 409 });
+
+    const declared = Number(request.headers.get("content-length") ?? "0");
+    if (declared > MAX_CHUNK_BYTES) {
+      return Response.json({ error: "chunk too large" }, { status: 413 });
+    }
+    const chunk = Buffer.from(await request.arrayBuffer());
+    if (!chunk.length) return Response.json({ error: "empty chunk" }, { status: 400 });
+    if (chunk.length > MAX_CHUNK_BYTES) {
+      return Response.json({ error: "chunk too large" }, { status: 413 });
+    }
+    if (staged + chunk.length > session.size) {
+      return Response.json({ error: "chunk exceeds the claimed size" }, { status: 400 });
+    }
+
+    if (staged === 0) {
+      const sniffed = sniffMedia(chunk);
+      if (!sniffed) {
+        await dropMediaSession(token);
+        return Response.json(
+          { error: "unsupported format (png, jpeg, gif, webp, mp4, or webm)" },
+          { status: 415 }
+        );
+      }
+      if (sniffed.video !== (session.kind === "video")) {
+        await dropMediaSession(token);
+        return Response.json(
+          {
+            error: sniffed.video
+              ? "that file is a video, upload it as the video kind"
+              : `${session.kind} uploads must be images`,
+          },
+          { status: 415 }
+        );
+      }
+      session.contentType = sniffed.contentType;
+      await updateMediaSession(token, session);
+    }
+
+    await fsp.appendFile(staging, chunk);
+    staged = (await fsp.stat(staging)).size;
+    if (staged < session.size) return Response.json({ done: false, offset: staged });
+    if (staged > session.size) {
+      await dropMediaSession(token);
+      return Response.json({ error: "corrupt upload session" }, { status: 400 });
+    }
+  }
+
+  // Complete (possibly a retry after a failed finalize): hash, store, record.
+  if (!session.contentType) {
+    await dropMediaSession(token);
+    return Response.json({ error: "corrupt upload session" }, { status: 400 });
+  }
+  const blobSha = await hashFile(staging);
+
+  let poster: string | null = null;
+  if (session.contentType.startsWith("video/")) {
+    const posterTmp = `${staging}.poster.jpg`;
+    try {
+      await extractStill(staging, posterTmp);
+      poster = await hashFile(posterTmp);
+      await storeBlobFromFile(poster, posterTmp, { ns: MEDIA_NS });
+    } catch {
+      // No usable ffmpeg or no decodable frame: the video plays without one.
+      await fsp.rm(posterTmp, { force: true });
+      poster = null;
+    }
+  }
+
+  await storeBlobFromFile(blobSha, staging, { ns: MEDIA_NS });
+  await dropMediaSession(token);
+
+  const row = await insertMedia(pool, {
+    build_sha256: sha256,
+    kind: session.kind,
+    sha256: blobSha,
+    poster_sha256: poster,
+    filename: session.filename,
+    content_type: session.contentType,
+    size: session.size,
+    author: session.author,
+  });
+  revalidateBuildPages(sha256, target.name);
+  return Response.json({ done: true, media: mediaView(row) });
+}

--- a/web/src/app/api/build/[sha256]/media/upload/route.ts
+++ b/web/src/app/api/build/[sha256]/media/upload/route.ts
@@ -1,0 +1,82 @@
+import type { NextRequest } from "next/server";
+import { getPool } from "@/lib/db";
+import { getContributor, contributionTarget } from "@/lib/contrib";
+import {
+  createMediaSession,
+  isMediaKind,
+  kindMaxBytes,
+  MAX_FILENAME_LEN,
+  newMediaToken,
+} from "@/lib/media";
+import { clientKey, rateLimitCheck } from "@/lib/ratelimit";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Uploads per contributor per hour. Generous for a photo session of one
+// build, tight enough to stop a script hosing the bucket.
+const CREATE_LIMIT = 60;
+const CREATE_WINDOW_MS = 3600_000;
+
+// POST /api/build/<sha256>/media/upload { kind, filename, size }: open a
+// chunked upload session for one media file, for any logged-in wiki user who
+// can see the build. Returns { token }; the client PUTs chunks to
+// ./upload/<token>?offset=N until the claimed size is reached, at which point
+// the server sniffs, stores, and records the file (see the token route).
+export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const contributor = await getContributor(request);
+  if (!contributor) {
+    return Response.json({ error: "log in to the wiki to contribute" }, { status: 401 });
+  }
+  const pool = getPool();
+  const target = await contributionTarget(pool, sha256);
+  if (!target) return Response.json({ error: "not found" }, { status: 404 });
+  if (!target.visible && !contributor.moderator) {
+    return Response.json({ error: "this build is not open for contributions" }, { status: 403 });
+  }
+
+  const rl = rateLimitCheck(`media:${contributor.name}:${clientKey(request)}`, CREATE_LIMIT, CREATE_WINDOW_MS);
+  if (!rl.ok) {
+    return Response.json(
+      { error: "too many uploads, slow down" },
+      { status: 429, headers: { "Retry-After": String(Math.ceil(rl.retryAfterMs / 1000)) } }
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  const kind = body.kind;
+  if (!isMediaKind(kind)) {
+    return Response.json({ error: "kind must be screenshot, video, or physical" }, { status: 400 });
+  }
+  const size = body.size;
+  if (typeof size !== "number" || !Number.isInteger(size) || size <= 0) {
+    return Response.json({ error: "size must be a positive integer" }, { status: 400 });
+  }
+  if (size > kindMaxBytes(kind)) {
+    return Response.json(
+      { error: `${kind} uploads are capped at ${Math.round(kindMaxBytes(kind) / 1024 / 1024)} MB` },
+      { status: 413 }
+    );
+  }
+  const rawName = typeof body.filename === "string" ? body.filename : "";
+  const filename =
+    rawName
+      .split(/[/\\]/)
+      .pop()!
+      .replace(/[\x00-\x1f\x7f]/g, "")
+      .trim()
+      .slice(0, MAX_FILENAME_LEN) || "upload";
+
+  const token = newMediaToken();
+  await createMediaSession(token, { build: sha256, kind, filename, size, author: contributor.name });
+  return Response.json({ token });
+}

--- a/web/src/app/api/build/[sha256]/notes/[id]/route.ts
+++ b/web/src/app/api/build/[sha256]/notes/[id]/route.ts
@@ -1,0 +1,71 @@
+import type { NextRequest } from "next/server";
+import { getContributor, contributionTarget, revalidateBuildPages, type Contributor } from "@/lib/contrib";
+import { getPool } from "@/lib/db";
+import { MAX_NOTE_LEN, deleteNote, getNoteById, updateNote, type BuildNoteRow } from "@/lib/media";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Author-or-moderator gate shared by edit and delete.
+async function resolveNote(
+  request: NextRequest,
+  ctx: { params: Promise<{ sha256: string; id: string }> }
+): Promise<
+  | { ok: true; sha256: string; noteId: number; note: BuildNoteRow; name: string; contributor: Contributor }
+  | { ok: false; response: Response }
+> {
+  const { sha256, id } = await ctx.params;
+  const fail = (error: string, status: number) => ({
+    ok: false as const,
+    response: Response.json({ error }, { status }),
+  });
+  if (!isSha256(sha256)) return fail("invalid sha256", 400);
+  const noteId = Number(id);
+  if (!Number.isInteger(noteId) || noteId <= 0) return fail("invalid id", 400);
+
+  const contributor = await getContributor(request);
+  if (!contributor) return fail("log in to the wiki first", 401);
+  const pool = getPool();
+  const target = await contributionTarget(pool, sha256);
+  if (!target) return fail("not found", 404);
+  const note = await getNoteById(pool, sha256, noteId);
+  if (!note) return fail("not found", 404);
+  if (note.author !== contributor.name && !contributor.moderator) {
+    return fail("only the author or a moderator can change this note", 403);
+  }
+  return { ok: true, sha256, noteId, note, name: target.name, contributor };
+}
+
+// PATCH /api/build/<sha256>/notes/<id> { body }: edit a note (author or
+// moderator), stamps edited_at.
+export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha256: string; id: string }> }) {
+  const r = await resolveNote(request, ctx);
+  if (!r.ok) return r.response;
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  const body = typeof parsed.body === "string" ? parsed.body.trim() : "";
+  if (!body) return Response.json({ error: "note body must be a non-empty string" }, { status: 400 });
+  if (body.length > MAX_NOTE_LEN) {
+    return Response.json({ error: `note exceeds ${MAX_NOTE_LEN} characters` }, { status: 400 });
+  }
+
+  const note = await updateNote(getPool(), r.sha256, r.noteId, body);
+  if (!note) return Response.json({ error: "not found" }, { status: 404 });
+  revalidateBuildPages(r.sha256, r.name);
+  return Response.json({ note });
+}
+
+// DELETE /api/build/<sha256>/notes/<id>: remove a note (author or moderator).
+export async function DELETE(request: NextRequest, ctx: { params: Promise<{ sha256: string; id: string }> }) {
+  const r = await resolveNote(request, ctx);
+  if (!r.ok) return r.response;
+  await deleteNote(getPool(), r.sha256, r.noteId);
+  revalidateBuildPages(r.sha256, r.name);
+  return Response.json({ deleted: true });
+}

--- a/web/src/app/api/build/[sha256]/notes/route.ts
+++ b/web/src/app/api/build/[sha256]/notes/route.ts
@@ -1,0 +1,54 @@
+import type { NextRequest } from "next/server";
+import { getContributor, contributionTarget, revalidateBuildPages } from "@/lib/contrib";
+import { getPool } from "@/lib/db";
+import { MAX_NOTE_LEN, insertNote } from "@/lib/media";
+import { clientKey, rateLimitCheck } from "@/lib/ratelimit";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const NOTE_LIMIT = 30;
+const NOTE_WINDOW_MS = 600_000;
+
+// POST /api/build/<sha256>/notes { body }: add one plain-text note, for any
+// logged-in wiki user who can see the build. Attributed to the wiki username.
+export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const contributor = await getContributor(request);
+  if (!contributor) {
+    return Response.json({ error: "log in to the wiki to contribute" }, { status: 401 });
+  }
+  const pool = getPool();
+  const target = await contributionTarget(pool, sha256);
+  if (!target) return Response.json({ error: "not found" }, { status: 404 });
+  if (!target.visible && !contributor.moderator) {
+    return Response.json({ error: "this build is not open for contributions" }, { status: 403 });
+  }
+
+  const rl = rateLimitCheck(`notes:${contributor.name}:${clientKey(request)}`, NOTE_LIMIT, NOTE_WINDOW_MS);
+  if (!rl.ok) {
+    return Response.json(
+      { error: "too many notes, slow down" },
+      { status: 429, headers: { "Retry-After": String(Math.ceil(rl.retryAfterMs / 1000)) } }
+    );
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  const body = typeof parsed.body === "string" ? parsed.body.trim() : "";
+  if (!body) return Response.json({ error: "note body must be a non-empty string" }, { status: 400 });
+  if (body.length > MAX_NOTE_LEN) {
+    return Response.json({ error: `note exceeds ${MAX_NOTE_LEN} characters` }, { status: 400 });
+  }
+
+  const note = await insertNote(pool, sha256, body, contributor.name);
+  revalidateBuildPages(sha256, target.name);
+  return Response.json({ note });
+}

--- a/web/src/app/api/build/[sha256]/skip/route.ts
+++ b/web/src/app/api/build/[sha256]/skip/route.ts
@@ -1,0 +1,56 @@
+import type { NextRequest } from "next/server";
+import { getModerator, moderationEnabled } from "@/lib/auth";
+import { contributionTarget, revalidateBuildPages } from "@/lib/contrib";
+import { getPool } from "@/lib/db";
+import { upsertSkip, type SkipFlags } from "@/lib/media";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// PATCH /api/build/<sha256>/skip { notes?, screenshots?, video?, physical? }:
+// moderator-only toggles marking a completeness category as not applicable
+// to this build (its 0 in the /builds columns stops rendering orange).
+// Omitted fields keep their stored value.
+export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  if (!(await getModerator(request))) {
+    return moderationEnabled()
+      ? Response.json({ error: "unauthorized" }, { status: 401 })
+      : Response.json({ error: "moderation disabled (set MODERATION_TOKEN or WIKI_API_URL)" }, { status: 403 });
+  }
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  const flags: Partial<SkipFlags> = {};
+  const FIELDS: Array<[string, keyof SkipFlags]> = [
+    ["notes", "skip_notes"],
+    ["screenshots", "skip_screenshots"],
+    ["video", "skip_video"],
+    ["physical", "skip_physical"],
+  ];
+  for (const [key, col] of FIELDS) {
+    const v = body[key];
+    if (v === undefined) continue;
+    if (typeof v !== "boolean") {
+      return Response.json({ error: `${key} must be a boolean` }, { status: 400 });
+    }
+    flags[col] = v;
+  }
+  if (!Object.keys(flags).length) {
+    return Response.json({ error: "nothing to update (notes, screenshots, video, physical)" }, { status: 400 });
+  }
+
+  const pool = getPool();
+  const target = await contributionTarget(pool, sha256);
+  if (!target) return Response.json({ error: "not found" }, { status: 404 });
+
+  const saved = await upsertSkip(pool, sha256, flags);
+  revalidateBuildPages(sha256, target.name);
+  return Response.json({ sha256, ...saved });
+}

--- a/web/src/app/api/media/[sha256]/route.ts
+++ b/web/src/app/api/media/[sha256]/route.ts
@@ -1,0 +1,63 @@
+import { Readable } from "node:stream";
+import type { NextRequest } from "next/server";
+import { blobSize, openBlobStream } from "@/lib/blobstore";
+import { getPool } from "@/lib/db";
+import { MEDIA_NS, mediaContentType } from "@/lib/media";
+import { parseRange } from "@/lib/range";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const CACHE = "public, max-age=31536000, immutable";
+const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+
+const EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+};
+
+// GET /api/media/<sha256>: stream one user-media blob (or a video poster)
+// out of the media/ namespace. In production the pages link the public bucket
+// gateway instead; this route is the fallback when no gateway is configured
+// (dev, or a fresh deployment). Content-addressed, so responses cache hard.
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const contentType = await mediaContentType(getPool(), sha256);
+  if (!contentType) return Response.json({ error: "not found" }, { status: 404 });
+
+  if (request.headers.get("if-none-match") === `"${sha256}-media"`) {
+    return new Response(null, { status: 304, headers: { "Cache-Control": CACHE, ETag: `"${sha256}-media"` } });
+  }
+
+  const size = await blobSize(sha256, MEDIA_NS);
+  if (size == null) return Response.json({ error: "blob missing from store" }, { status: 404 });
+
+  const headers: Record<string, string> = {
+    "Content-Type": contentType,
+    "Content-Disposition": `inline; filename="${sha256.slice(0, 12)}.${EXT[contentType] ?? "bin"}"`,
+    "Cache-Control": CACHE,
+    ETag: `"${sha256}-media"`,
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": CSP,
+    "Accept-Ranges": "bytes",
+  };
+
+  // Single-range support so <video> can seek.
+  const range = parseRange(request.headers.get("range"), size);
+  const stream = await openBlobStream(sha256, range ?? undefined, MEDIA_NS);
+  if (!stream) return Response.json({ error: "blob missing from store" }, { status: 404 });
+  if (range) {
+    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${size}`;
+    headers["Content-Length"] = String(range.end - range.start + 1);
+    return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
+  }
+  headers["Content-Length"] = String(size);
+  return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
+}

--- a/web/src/app/builds/BuildsBrowser.tsx
+++ b/web/src/app/builds/BuildsBrowser.tsx
@@ -124,7 +124,11 @@ export default function BuildsBrowser({ rows, total, systems, page, perPage, q, 
               <Th label="System" sortKey="system" sort={sort} dir={dir} onSort={toggleSort} />
               <Th label="Date" sortKey="build_date" sort={sort} dir={dir} onSort={toggleSort} />
               <Th label="Files" sortKey="file_count" sort={sort} dir={dir} onSort={toggleSort} align="right" />
-              <Th label="Size" sortKey="total_size" sort={sort} dir={dir} onSort={toggleSort} align="right" last />
+              <Th label="Size" sortKey="total_size" sort={sort} dir={dir} onSort={toggleSort} align="right" />
+              <Th label="Notes" sortKey="notes" sort={sort} dir={dir} onSort={toggleSort} align="right" />
+              <Th label="Screens" sortKey="screenshots" sort={sort} dir={dir} onSort={toggleSort} align="right" />
+              <Th label="Video" sortKey="video" sort={sort} dir={dir} onSort={toggleSort} align="right" />
+              <Th label="Physical" sortKey="physical" sort={sort} dir={dir} onSort={toggleSort} align="right" last />
             </tr>
           </thead>
           <tbody className="divide-y divide-neutral-100 dark:divide-neutral-900/60">
@@ -161,8 +165,28 @@ export default function BuildsBrowser({ rows, total, systems, page, perPage, q, 
                 <td className="h-full p-0">
                   <RowLink href={href} className="px-3 text-right tabular-nums text-neutral-500">{b.file_count}</RowLink>
                 </td>
-                <td className="h-full p-0 last:[&>a]:pr-0">
+                <td className="h-full p-0">
                   <RowLink href={href} className="px-3 text-right tabular-nums text-neutral-500">{humanSize(b.total_size)}</RowLink>
+                </td>
+                <td className="h-full p-0">
+                  <RowLink href={href} className="px-3 text-right tabular-nums">
+                    <Count value={b.notes} skipped={b.skip_notes} />
+                  </RowLink>
+                </td>
+                <td className="h-full p-0">
+                  <RowLink href={href} className="px-3 text-right tabular-nums">
+                    <Count value={b.screenshots} skipped={b.skip_screenshots} />
+                  </RowLink>
+                </td>
+                <td className="h-full p-0">
+                  <RowLink href={href} className="px-3 text-right tabular-nums">
+                    <Count value={b.videos} skipped={b.skip_video} />
+                  </RowLink>
+                </td>
+                <td className="h-full p-0 last:[&>a]:pr-0">
+                  <RowLink href={href} className="px-3 text-right tabular-nums">
+                    <Count value={b.physical} skipped={b.skip_physical} />
+                  </RowLink>
                 </td>
               </tr>
             );})}
@@ -193,6 +217,27 @@ export default function BuildsBrowser({ rows, total, systems, page, perPage, q, 
       )}
     </>
   );
+}
+
+// Community completeness cell: a missing category (0, not skipped) renders
+// orange so gaps jump out; a skipped category is explicitly not applicable.
+function Count({ value, skipped }: { value?: number; skipped?: boolean }) {
+  const v = value ?? 0;
+  if (skipped) {
+    return (
+      <span className="text-neutral-400" title="Marked not applicable">
+        skip
+      </span>
+    );
+  }
+  if (v === 0) {
+    return (
+      <span className="rounded bg-orange-100 px-1.5 py-0.5 font-medium text-orange-800 dark:bg-orange-900/40 dark:text-orange-300">
+        0
+      </span>
+    );
+  }
+  return <span className="text-neutral-500">{v}</span>;
 }
 
 function Th({

--- a/web/src/app/builds/[buildId]/MediaSection.tsx
+++ b/web/src/app/builds/[buildId]/MediaSection.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { BuildMediaView, MediaKind } from "@/lib/media";
+
+interface Viewer {
+  name?: string;
+  moderator: boolean;
+}
+
+interface Upload {
+  key: number;
+  label: string;
+  pct: number;
+  error?: string;
+}
+
+interface Props {
+  sha256: string;
+  items: BuildMediaView[];
+}
+
+const CHUNK = 8 * 1024 * 1024;
+
+const SECTIONS: Array<{ kind: MediaKind; title: string; accept: string; add: string; multiple: boolean }> = [
+  {
+    kind: "screenshot",
+    title: "Screenshots",
+    accept: "image/png,image/jpeg,image/webp,image/gif",
+    add: "Add screenshots",
+    multiple: true,
+  },
+  { kind: "video", title: "Video", accept: "video/mp4,video/webm", add: "Add video", multiple: false },
+  {
+    kind: "physical",
+    title: "Physical media",
+    accept: "image/png,image/jpeg,image/webp,image/gif",
+    add: "Add photos",
+    multiple: true,
+  },
+];
+
+// Community media gallery + uploader. Uploads go in 8MB chunks (the chunk
+// route resumes on 409), so even long captures pass the proxy body limit.
+// Gating here is cosmetic: the routes re-check the wiki session server-side.
+export default function MediaSection({ sha256, items }: Props) {
+  const router = useRouter();
+  const [viewer, setViewer] = useState<Viewer | null>(null);
+  const [uploads, setUploads] = useState<Upload[]>([]);
+  const [note, setNote] = useState("");
+  const nextKey = useRef(1);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/whoami", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((w) => !cancelled && setViewer({ name: w.name, moderator: !!w.moderator }))
+      .catch(() => !cancelled && setViewer({ moderator: false }));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const loggedIn = !!viewer?.name || !!viewer?.moderator;
+
+  const patchUpload = (key: number, patch: Partial<Upload>) =>
+    setUploads((u) => u.map((x) => (x.key === key ? { ...x, ...patch } : x)));
+
+  async function uploadFile(file: File, kind: MediaKind) {
+    const key = nextKey.current++;
+    setUploads((u) => [...u, { key, label: file.name, pct: 0 }]);
+    try {
+      const create = await fetch(`/api/build/${sha256}/media/upload`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind, filename: file.name, size: file.size }),
+      });
+      const cj = await create.json().catch(() => ({}));
+      if (!create.ok) throw new Error(cj.error ?? create.statusText);
+
+      let offset = 0;
+      let stalls = 0;
+      for (;;) {
+        const end = Math.min(offset + CHUNK, file.size);
+        const res = await fetch(`/api/build/${sha256}/media/upload/${cj.token}?offset=${offset}`, {
+          method: "PUT",
+          body: file.slice(offset, end),
+        });
+        const j = await res.json().catch(() => ({}));
+        if (res.status === 409 && typeof j.offset === "number") {
+          if (++stalls > 3 && j.offset <= offset) throw new Error("upload stalled");
+          offset = j.offset;
+          continue;
+        }
+        if (!res.ok) throw new Error(j.error ?? res.statusText);
+        if (j.done) break;
+        offset = typeof j.offset === "number" ? j.offset : end;
+        patchUpload(key, { pct: offset / file.size });
+      }
+      setUploads((u) => u.filter((x) => x.key !== key));
+      router.refresh();
+    } catch (e) {
+      patchUpload(key, { error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
+  async function remove(id: number) {
+    setNote("");
+    const res = await fetch(`/api/build/${sha256}/media/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      setNote(`Error: ${j.error ?? res.statusText}`);
+      return;
+    }
+    router.refresh();
+  }
+
+  const total = items.length;
+  return (
+    <section className="mt-8">
+      <h2 className="text-lg font-medium">
+        Media {total > 0 && <span className="text-sm font-normal text-neutral-400">({total})</span>}
+      </h2>
+      {!loggedIn && viewer && (
+        <p className="mt-1 text-xs text-neutral-500">Log in to the wiki to add screenshots, video, or photos.</p>
+      )}
+      <div className="mt-3 grid gap-8">
+        {SECTIONS.map((s) => {
+          const mine = items.filter((m) => m.kind === s.kind);
+          return (
+            <div key={s.kind}>
+              <div className="flex items-center gap-3">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-400">{s.title}</h3>
+                {loggedIn && (
+                  <AddButton
+                    label={s.add}
+                    accept={s.accept}
+                    multiple={s.multiple}
+                    onFiles={(files) => files.forEach((f) => uploadFile(f, s.kind))}
+                  />
+                )}
+              </div>
+              {mine.length === 0 ? (
+                <p className="mt-2 text-xs text-neutral-400">None yet.</p>
+              ) : s.kind === "video" ? (
+                <div className="mt-2 grid gap-4 sm:grid-cols-2">
+                  {mine.map((m) => (
+                    <figure key={m.id}>
+                      <video
+                        controls
+                        preload="none"
+                        poster={m.posterUrl ?? undefined}
+                        src={m.url}
+                        className="max-h-80 w-full rounded-md border border-neutral-200 bg-black dark:border-neutral-800"
+                      />
+                      <Caption item={m} viewer={viewer} onDelete={() => remove(m.id)} />
+                    </figure>
+                  ))}
+                </div>
+              ) : (
+                <div className="mt-2 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+                  {mine.map((m) => (
+                    <figure key={m.id}>
+                      <a href={m.url} target="_blank" rel="noreferrer">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={m.url}
+                          alt={m.filename}
+                          loading="lazy"
+                          className="h-36 w-full rounded-md border border-neutral-200 object-cover dark:border-neutral-800"
+                        />
+                      </a>
+                      <Caption item={m} viewer={viewer} onDelete={() => remove(m.id)} />
+                    </figure>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {uploads.length > 0 && (
+        <ul className="mt-4 grid gap-1 text-xs text-neutral-500">
+          {uploads.map((u) => (
+            <li key={u.key} className="flex items-center gap-2">
+              <span className="max-w-64 truncate">{u.label}</span>
+              {u.error ? (
+                <>
+                  <span className="text-red-500">{u.error}</span>
+                  <button
+                    onClick={() => setUploads((x) => x.filter((y) => y.key !== u.key))}
+                    className="text-neutral-400 hover:text-neutral-600"
+                  >
+                    dismiss
+                  </button>
+                </>
+              ) : (
+                <>
+                  <progress value={u.pct} max={1} className="h-1.5 w-40" />
+                  <span className="tabular-nums">{Math.round(u.pct * 100)}%</span>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      {note && <p className="mt-2 text-xs text-neutral-500">{note}</p>}
+    </section>
+  );
+}
+
+function AddButton({
+  label,
+  accept,
+  multiple,
+  onFiles,
+}: {
+  label: string;
+  accept: string;
+  multiple: boolean;
+  onFiles: (files: File[]) => void;
+}) {
+  const input = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <button
+        onClick={() => input.current?.click()}
+        className="rounded-md border border-neutral-300 px-2 py-0.5 text-xs font-medium hover:border-neutral-500 dark:border-neutral-700"
+      >
+        {label}
+      </button>
+      <input
+        ref={input}
+        type="file"
+        accept={accept}
+        multiple={multiple}
+        className="hidden"
+        onChange={(e) => {
+          onFiles(Array.from(e.target.files ?? []));
+          e.target.value = "";
+        }}
+      />
+    </>
+  );
+}
+
+function Caption({
+  item,
+  viewer,
+  onDelete,
+}: {
+  item: BuildMediaView;
+  viewer: Viewer | null;
+  onDelete: () => void;
+}) {
+  const canDelete = !!viewer && (viewer.moderator || (!!viewer.name && viewer.name === item.author));
+  return (
+    <figcaption className="mt-1 flex items-baseline gap-2 text-xs text-neutral-500">
+      <span className="min-w-0 truncate" title={item.filename}>
+        {item.author}
+      </span>
+      <span className="shrink-0 text-neutral-400">{item.created_at.slice(0, 10)}</span>
+      {canDelete && (
+        <button onClick={onDelete} title="Remove" className="shrink-0 text-neutral-400 hover:text-red-500">
+          ×
+        </button>
+      )}
+    </figcaption>
+  );
+}

--- a/web/src/app/builds/[buildId]/ModeratorTools.tsx
+++ b/web/src/app/builds/[buildId]/ModeratorTools.tsx
@@ -20,6 +20,8 @@ interface Props {
   privateFlag: boolean;
   /** Whether the build's lot is private (hides every build in it). */
   lotPrivate: boolean;
+  /** Completeness categories marked not-applicable for this build. */
+  skips: { skip_notes: boolean; skip_screenshots: boolean; skip_video: boolean; skip_physical: boolean };
 }
 
 // Rename + lot assignment, shown when a moderation token is saved (the
@@ -27,7 +29,7 @@ interface Props {
 // belongs to a moderator group. Purely cosmetic gating — the PATCH route
 // re-checks credentials server-side. The parent keys this component on
 // name+lot, so a router.refresh() after a save remounts it with fresh values.
-export default function ModeratorTools({ sha256, name, lot, lots, privateFlag, lotPrivate }: Props) {
+export default function ModeratorTools({ sha256, name, lot, lots, privateFlag, lotPrivate, skips }: Props) {
   const router = useRouter();
   const token = useSyncExternalStore(noSubscribe, clientToken, serverToken);
   const [wikiModerator, setWikiModerator] = useState(false);
@@ -50,11 +52,16 @@ export default function ModeratorTools({ sha256, name, lot, lots, privateFlag, l
 
   if (!token && !wikiModerator) return null;
 
-  async function save(patch: { name?: string; lot?: string | null; private?: boolean; lotPrivate?: boolean }) {
+  async function saveTo(
+    path: string,
+    patch:
+      | { name?: string; lot?: string | null; private?: boolean; lotPrivate?: boolean }
+      | { notes?: boolean; screenshots?: boolean; video?: boolean; physical?: boolean }
+  ) {
     setBusy(true);
     setNote("");
     try {
-      const res = await fetch(`/api/build/${sha256}`, {
+      const res = await fetch(path, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
@@ -75,6 +82,11 @@ export default function ModeratorTools({ sha256, name, lot, lots, privateFlag, l
       setBusy(false);
     }
   }
+
+  const save = (patch: { name?: string; lot?: string | null; private?: boolean; lotPrivate?: boolean }) =>
+    saveTo(`/api/build/${sha256}`, patch);
+  const saveSkip = (patch: { notes?: boolean; screenshots?: boolean; video?: boolean; physical?: boolean }) =>
+    saveTo(`/api/build/${sha256}/skip`, patch);
 
   const nameDirty = nameInput.trim() !== "" && nameInput.trim() !== name;
   const lotDirty = (lotInput.trim() || null) !== lot;
@@ -148,6 +160,49 @@ export default function ModeratorTools({ sha256, name, lot, lots, privateFlag, l
                 onChange={(e) => save({ lotPrivate: e.target.checked })}
               />
               Private lot
+            </label>
+          </div>
+        </div>
+        {/* "Not applicable" markers for the completeness columns on /builds:
+            a skipped category's 0 stops rendering orange there. */}
+        <div className="flex flex-col gap-1">
+          <span className="text-xs text-neutral-500">Skip (not applicable)</span>
+          <div className="flex h-9 items-center gap-5">
+            <label className="flex items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={skips.skip_notes}
+                disabled={busy}
+                onChange={(e) => saveSkip({ notes: e.target.checked })}
+              />
+              Notes
+            </label>
+            <label className="flex items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={skips.skip_screenshots}
+                disabled={busy}
+                onChange={(e) => saveSkip({ screenshots: e.target.checked })}
+              />
+              Screenshots
+            </label>
+            <label className="flex items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={skips.skip_video}
+                disabled={busy}
+                onChange={(e) => saveSkip({ video: e.target.checked })}
+              />
+              Video
+            </label>
+            <label className="flex items-center gap-1.5">
+              <input
+                type="checkbox"
+                checked={skips.skip_physical}
+                disabled={busy}
+                onChange={(e) => saveSkip({ physical: e.target.checked })}
+              />
+              Physical
             </label>
           </div>
         </div>

--- a/web/src/app/builds/[buildId]/NotesSection.tsx
+++ b/web/src/app/builds/[buildId]/NotesSection.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { BuildNoteRow } from "@/lib/media";
+
+interface Viewer {
+  name?: string;
+  moderator: boolean;
+}
+
+interface Props {
+  sha256: string;
+  notes: BuildNoteRow[];
+}
+
+// Community notes: plain text, attributed, editable by their author or a
+// moderator. Gating here is cosmetic: the routes re-check server-side.
+export default function NotesSection({ sha256, notes }: Props) {
+  const router = useRouter();
+  const [viewer, setViewer] = useState<Viewer | null>(null);
+  const [draft, setDraft] = useState("");
+  const [editing, setEditing] = useState<number | null>(null);
+  const [editDraft, setEditDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/whoami", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((w) => !cancelled && setViewer({ name: w.name, moderator: !!w.moderator }))
+      .catch(() => !cancelled && setViewer({ moderator: false }));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const loggedIn = !!viewer?.name || !!viewer?.moderator;
+
+  async function call(path: string, init: RequestInit): Promise<boolean> {
+    setBusy(true);
+    setNote("");
+    try {
+      const res = await fetch(path, init);
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        setNote(`Error: ${j.error ?? res.statusText}`);
+        return false;
+      }
+      router.refresh();
+      return true;
+    } catch (e) {
+      setNote(`Failed: ${e}`);
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const add = async () => {
+    if (!draft.trim()) return;
+    if (
+      await call(`/api/build/${sha256}/notes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body: draft.trim() }),
+      })
+    ) {
+      setDraft("");
+    }
+  };
+
+  const saveEdit = async (id: number) => {
+    if (!editDraft.trim()) return;
+    if (
+      await call(`/api/build/${sha256}/notes/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body: editDraft.trim() }),
+      })
+    ) {
+      setEditing(null);
+    }
+  };
+
+  return (
+    <section className="mt-8">
+      <h2 className="text-lg font-medium">
+        Notes {notes.length > 0 && <span className="text-sm font-normal text-neutral-400">({notes.length})</span>}
+      </h2>
+      {notes.length === 0 && <p className="mt-2 text-xs text-neutral-400">None yet.</p>}
+      <ul className="mt-3 grid max-w-3xl gap-3">
+        {notes.map((n) => {
+          const canEdit = !!viewer && (viewer.moderator || (!!viewer.name && viewer.name === n.author));
+          return (
+            <li key={n.id} className="rounded-md border border-neutral-200 px-4 py-3 text-sm dark:border-neutral-800">
+              {editing === n.id ? (
+                <div className="grid gap-2">
+                  <textarea
+                    value={editDraft}
+                    onChange={(e) => setEditDraft(e.target.value)}
+                    rows={3}
+                    className="w-full rounded-md border border-neutral-300 bg-transparent px-3 py-2 outline-none focus:border-neutral-500 dark:border-neutral-700"
+                  />
+                  <div className="flex gap-2 text-xs">
+                    <button
+                      onClick={() => saveEdit(n.id)}
+                      disabled={busy || !editDraft.trim()}
+                      className="rounded-md border border-neutral-300 px-2 py-1 font-medium hover:border-neutral-500 disabled:opacity-40 dark:border-neutral-700"
+                    >
+                      Save
+                    </button>
+                    <button onClick={() => setEditing(null)} className="text-neutral-500 hover:underline">
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <p className="whitespace-pre-wrap break-words">{n.body}</p>
+                  <p className="mt-2 flex items-baseline gap-2 text-xs text-neutral-500">
+                    <span className="font-medium">{n.author}</span>
+                    <span className="text-neutral-400">{n.created_at.slice(0, 10)}</span>
+                    {n.edited_at && <span className="text-neutral-400">(edited)</span>}
+                    {canEdit && (
+                      <>
+                        <button
+                          onClick={() => {
+                            setEditing(n.id);
+                            setEditDraft(n.body);
+                          }}
+                          className="text-neutral-400 hover:underline"
+                        >
+                          edit
+                        </button>
+                        <button
+                          onClick={() => call(`/api/build/${sha256}/notes/${n.id}`, { method: "DELETE" })}
+                          disabled={busy}
+                          className="text-neutral-400 hover:text-red-500"
+                        >
+                          delete
+                        </button>
+                      </>
+                    )}
+                  </p>
+                </>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+      {loggedIn ? (
+        <div className="mt-4 grid max-w-3xl gap-2">
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={3}
+            placeholder="Add a note about this build…"
+            className="w-full rounded-md border border-neutral-300 bg-transparent px-3 py-2 text-sm outline-none placeholder:text-neutral-400 focus:border-neutral-500 dark:border-neutral-700"
+          />
+          <div>
+            <button
+              onClick={add}
+              disabled={busy || !draft.trim()}
+              className="rounded-md border border-neutral-300 px-3 py-1 text-sm font-medium hover:border-neutral-500 disabled:opacity-40 dark:border-neutral-700"
+            >
+              Add note
+            </button>
+          </div>
+        </div>
+      ) : (
+        viewer && <p className="mt-2 text-xs text-neutral-500">Log in to the wiki to add a note.</p>
+      )}
+      {note && <p className="mt-2 text-xs text-neutral-500">{note}</p>}
+    </section>
+  );
+}

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -8,6 +8,7 @@ import { buildTree, initialExpanded, pruneToExpanded, treeCounts } from "@/lib/f
 import { getBuild, getBuildAssets, getBuildMeta, getBuildRepos, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, listLots, isLotPrivate, resolveBuild } from "@/lib/queries";
 import { shortOid } from "@/lib/repo-manifest";
 import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
+import { getBuildMedia, getBuildNotes, getBuildSkip, mediaView } from "@/lib/media";
 import { buildDescription, displayTitle } from "@/lib/meta";
 import { canonicalBuildId, parseBuildParam } from "@/lib/slug";
 import type { BuildRecord } from "@/lib/types";
@@ -15,7 +16,9 @@ import SimilarBuilds from "./SimilarBuilds";
 import FileTree from "./FileTree";
 import AssetGallery from "./AssetGallery";
 import AssetViewerHost from "./AssetViewerHost";
+import MediaSection from "./MediaSection";
 import ModeratorTools from "./ModeratorTools";
+import NotesSection from "./NotesSection";
 
 // The assets section previews at most this many items per kind; the rest live
 // on /builds/<id>/assets.
@@ -139,13 +142,16 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
   const q = deriveQueryFeatures(build.record);
   // Pull a wide candidate set per tier so the fused top-50 is well-populated.
   // Text neighbors use this build's already-stored embedding — no re-embedding per load.
-  const [similar, textNeighbors, assets, lots, repos, lotPrivate] = await Promise.all([
+  const [similar, textNeighbors, assets, lots, repos, lotPrivate, media, notes, skips] = await Promise.all([
     findSimilar(pool, q, 100),
     findByEmbeddingOf(pool, sha256, 100),
     getBuildAssets(pool, sha256),
     listLots(pool),
     getBuildRepos(pool, sha256),
     build.lot ? isLotPrivate(pool, build.lot) : Promise.resolve(false),
+    getBuildMedia(pool, sha256),
+    getBuildNotes(pool, sha256),
+    getBuildSkip(pool, sha256),
   ]);
   const fused = fuseSimilar(similar, textNeighbors);
 
@@ -208,13 +214,14 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
       </dl>
 
       <ModeratorTools
-        key={`${build.name}\0${build.lot ?? ""}\0${build.private}\0${lotPrivate}`}
+        key={`${build.name}\0${build.lot ?? ""}\0${build.private}\0${lotPrivate}\0${JSON.stringify(skips)}`}
         sha256={build.sha256}
         name={build.name}
         lot={build.lot}
         lots={lots}
         privateFlag={build.private}
         lotPrivate={lotPrivate}
+        skips={skips}
       />
 
       {meta.length > 0 && (
@@ -273,6 +280,10 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
           <AssetGallery buildHref={href} assets={previewAssets} totals={assetTotals(assets)} excerpts={excerpts} />
         </section>
       )}
+
+      <MediaSection sha256={sha256} items={media.map(mediaView)} />
+
+      <NotesSection sha256={sha256} notes={notes} />
 
       <section className="mt-8">
         <h2 className="text-lg font-medium">

--- a/web/src/app/builds/page.tsx
+++ b/web/src/app/builds/page.tsx
@@ -15,7 +15,17 @@ export const metadata: Metadata = {
 
 const PER_PAGE = 100;
 
-const SORT_KEYS: BuildSortKey[] = ["name", "system", "build_date", "file_count", "total_size"];
+const SORT_KEYS: BuildSortKey[] = [
+  "name",
+  "system",
+  "build_date",
+  "file_count",
+  "total_size",
+  "notes",
+  "screenshots",
+  "video",
+  "physical",
+];
 
 // Search/filter/sort/pagination all resolve in SQL — the old version shipped
 // every build (a 6MB payload at 16k builds) and filtered client-side.

--- a/web/src/lib/blobstore.ts
+++ b/web/src/lib/blobstore.ts
@@ -42,9 +42,12 @@ export function assetStoreDir(): string {
   return process.env.ASSET_STORE_DIR || path.join(process.cwd(), "asset-store");
 }
 
-/** Local path of one blob. Caller must have validated `sha256` (isSha256). */
-export function assetBlobPath(sha256: string): string {
-  return path.join(assetStoreDir(), sha256.slice(0, 2), sha256);
+/** Local path of one blob. Caller must have validated `sha256` (isSha256).
+ *  `ns` selects a store namespace ("" = assets, "media/" = user media); a
+ *  namespace name can't collide with the two-hex-char blob dirs. */
+export function assetBlobPath(sha256: string, ns = ""): string {
+  const parts = ns ? [ns.replace(/\/+$/, "")] : [];
+  return path.join(assetStoreDir(), ...parts, sha256.slice(0, 2), sha256);
 }
 
 /** Staging file for a blob's chunked upload (`.staging` can't collide with the
@@ -72,8 +75,8 @@ function s3Prefix(): string {
   return process.env.ASSET_S3_PREFIX || "";
 }
 
-function s3Key(sha256: string): string {
-  return `${s3Prefix()}${sha256.slice(0, 2)}/${sha256}`;
+function s3Key(sha256: string, ns = ""): string {
+  return `${s3Prefix()}${ns}${sha256.slice(0, 2)}/${sha256}`;
 }
 
 // One client per process; the config is env-fixed for the process lifetime.
@@ -121,10 +124,10 @@ function httpStatus(err: unknown): number | undefined {
 }
 
 /** Byte size of a blob, or null when it is missing from the store. */
-export async function blobSize(sha256: string): Promise<number | null> {
+export async function blobSize(sha256: string, ns = ""): Promise<number | null> {
   if (s3Enabled()) {
     try {
-      const r = await s3().send(new HeadObjectCommand({ Bucket: s3Bucket(), Key: s3Key(sha256) }));
+      const r = await s3().send(new HeadObjectCommand({ Bucket: s3Bucket(), Key: s3Key(sha256, ns) }));
       return r.ContentLength ?? null;
     } catch (err) {
       if (isMissing(err)) return null;
@@ -132,14 +135,14 @@ export async function blobSize(sha256: string): Promise<number | null> {
     }
   }
   try {
-    return (await fsp.stat(assetBlobPath(sha256))).size;
+    return (await fsp.stat(assetBlobPath(sha256, ns))).size;
   } catch {
     return null;
   }
 }
 
-export async function blobExists(sha256: string): Promise<boolean> {
-  return (await blobSize(sha256)) !== null;
+export async function blobExists(sha256: string, ns = ""): Promise<boolean> {
+  return (await blobSize(sha256, ns)) !== null;
 }
 
 // Bounds concurrent requests in missingBlobs (and nothing else): high enough
@@ -207,14 +210,15 @@ export async function missingBlobs(shas: string[]): Promise<string[]> {
  *  is missing from the store. */
 export async function openBlobStream(
   sha256: string,
-  range?: { start: number; end: number }
+  range?: { start: number; end: number },
+  ns = ""
 ): Promise<Readable | null> {
   if (s3Enabled()) {
     try {
       const r = await s3().send(
         new GetObjectCommand({
           Bucket: s3Bucket(),
-          Key: s3Key(sha256),
+          Key: s3Key(sha256, ns),
           ...(range ? { Range: `bytes=${range.start}-${range.end}` } : {}),
         })
       );
@@ -226,7 +230,7 @@ export async function openBlobStream(
   }
   // open() first so a missing blob is a null, not a later stream error event.
   try {
-    const fh = await fsp.open(assetBlobPath(sha256), "r");
+    const fh = await fsp.open(assetBlobPath(sha256, ns), "r");
     return fh.createReadStream(range ? { start: range.start, end: range.end } : {});
   } catch {
     return null;
@@ -293,13 +297,14 @@ export async function readBlobHead(sha256: string, maxBytes = 2048): Promise<Buf
 export async function storeBlobFromFile(
   sha256: string,
   src: string,
-  opts?: { keepSource?: boolean }
+  opts?: { keepSource?: boolean; ns?: string }
 ): Promise<"stored" | "exists"> {
+  const ns = opts?.ns ?? "";
   const cleanup = async () => {
     if (!opts?.keepSource) await fsp.rm(src, { force: true });
   };
   if (s3Enabled()) {
-    if (await blobExists(sha256)) {
+    if (await blobExists(sha256, ns)) {
       await cleanup();
       return "exists";
     }
@@ -307,12 +312,12 @@ export async function storeBlobFromFile(
     // per-part retries.
     await new Upload({
       client: s3(),
-      params: { Bucket: s3Bucket(), Key: s3Key(sha256), Body: fs.createReadStream(src) },
+      params: { Bucket: s3Bucket(), Key: s3Key(sha256, ns), Body: fs.createReadStream(src) },
     }).done();
     await cleanup();
     return "stored";
   }
-  const dest = assetBlobPath(sha256);
+  const dest = assetBlobPath(sha256, ns);
   if (fs.existsSync(dest)) {
     await cleanup();
     return "exists";

--- a/web/src/lib/contrib.ts
+++ b/web/src/lib/contrib.ts
@@ -1,0 +1,55 @@
+// Contributor auth for the community-metadata routes (media, notes). Any
+// logged-in wiki user may contribute to a build they can see; moderators
+// (wiki group or shared token) can also touch private builds and other
+// people's contributions.
+
+import { revalidatePath } from "next/cache";
+import type { NextRequest } from "next/server";
+import type { Pool } from "pg";
+import { getModerator } from "./auth";
+import { buildHref } from "./slug";
+import { wikiUserFromCookies } from "./wiki-auth";
+
+export interface Contributor {
+  /** Wiki username ("token" under shared-secret moderation). */
+  name: string;
+  moderator: boolean;
+}
+
+/** The contributor behind a request, or null (anonymous/invalid session).
+ *  Cookie-authenticated mutations must prove same-origin, exactly like the
+ *  moderation routes: cookies are ambient, custom headers are not. */
+export async function getContributor(request: NextRequest): Promise<Contributor | null> {
+  const mod = await getModerator(request);
+  if (mod) return { name: mod.name, moderator: true };
+  const user = await wikiUserFromCookies(request.headers.get("cookie"));
+  if (!user) return null;
+  const m = request.method.toUpperCase();
+  if (m !== "GET" && m !== "HEAD" && request.headers.get("sec-fetch-site") !== "same-origin") {
+    return null;
+  }
+  return { name: user.name, moderator: false };
+}
+
+export interface ContributionTarget {
+  name: string;
+  visible: boolean;
+}
+
+/** The build a contribution targets: its display name (for revalidation) and
+ *  whether the public can see it, or null when it doesn't exist. Writes to a
+ *  hidden build require a moderator. */
+export async function contributionTarget(pool: Pool, sha256: string): Promise<ContributionTarget | null> {
+  const r = await pool.query(
+    `SELECT name, NOT (private OR EXISTS (SELECT 1 FROM private_lots _pl WHERE _pl.lot = builds.lot)) AS visible
+     FROM builds WHERE sha256=$1`,
+    [sha256]
+  );
+  return (r.rows[0] as ContributionTarget) ?? null;
+}
+
+/** Surface a contribution on the ISR-cached build page right away. */
+export function revalidateBuildPages(sha256: string, name: string): void {
+  revalidatePath(buildHref(sha256, name));
+  revalidatePath(`/builds/${sha256}`);
+}

--- a/web/src/lib/ffmpeg.ts
+++ b/web/src/lib/ffmpeg.ts
@@ -349,41 +349,47 @@ export async function ensureThumb(sha256: string): Promise<string> {
 }
 
 async function thumb(sha256: string, out: string): Promise<string> {
-  await mkdir(dirname(out), { recursive: true });
-  const result = await withBlobFile(sha256, async (input) => {
-    // A quarter in (bounded) skips studio logos and fade-ins; the thumbnail
-    // filter then picks the most representative of the next frames, dodging
-    // black frames around the seek point. Falls back to the very start for
-    // clips too short to seek into.
-    const durationUs = await probeDurationUs(input);
-    const seekSec = durationUs ? Math.min(Math.max((durationUs / 1e6) * 0.25, 1), 45) : 3;
-    const tmp = `${out}.${randomBytes(4).toString("hex")}.part`;
-    const argsAt = (seek: number) => [
-      "-hide_banner", "-loglevel", "error", "-y",
-      ...(seek > 0 ? ["-ss", String(seek)] : []),
-      "-i", input,
-      "-map", "0:v:0", "-dn", "-sn", "-an",
-      "-vf", "yadif=deint=interlaced,thumbnail=48,scale=trunc(min(iw\\,512)/2)*2:-2",
-      "-frames:v", "1", "-c:v", "mjpeg", "-q:v", "4", "-f", "image2",
-      tmp,
-    ];
-    try {
-      for (const seek of seekSec > 0 ? [seekSec, 0] : [0]) {
-        try {
-          await execFileP(FFMPEG_BIN, argsAt(seek), { timeout: THUMB_TIMEOUT_MS, maxBuffer: 4_000_000 });
-          if ((await stat(tmp)).size > 0) {
-            await rename(tmp, out);
-            return out;
-          }
-        } catch {
-          // Retry from the start (a clip shorter than the seek), then give up.
-        }
-      }
-      throw new Error("no frame extracted");
-    } finally {
-      await rm(tmp, { force: true });
-    }
-  });
+  const result = await withBlobFile(sha256, (input) => extractStill(input, out));
   if (result === null) throw new Error("blob missing from store");
   return result;
+}
+
+/** Extract one representative poster still (JPEG) from a local video file
+ *  into `out`. Shared by the asset thumb cache (via the blob store) and the
+ *  media-upload poster path (which still has the uploaded file on disk).
+ *  Throws when ffmpeg is missing or can't find a frame. */
+export async function extractStill(input: string, out: string): Promise<string> {
+  await mkdir(dirname(out), { recursive: true });
+  // A quarter in (bounded) skips studio logos and fade-ins; the thumbnail
+  // filter then picks the most representative of the next frames, dodging
+  // black frames around the seek point. Falls back to the very start for
+  // clips too short to seek into.
+  const durationUs = await probeDurationUs(input);
+  const seekSec = durationUs ? Math.min(Math.max((durationUs / 1e6) * 0.25, 1), 45) : 3;
+  const tmp = `${out}.${randomBytes(4).toString("hex")}.part`;
+  const argsAt = (seek: number) => [
+    "-hide_banner", "-loglevel", "error", "-y",
+    ...(seek > 0 ? ["-ss", String(seek)] : []),
+    "-i", input,
+    "-map", "0:v:0", "-dn", "-sn", "-an",
+    "-vf", "yadif=deint=interlaced,thumbnail=48,scale=trunc(min(iw\\,512)/2)*2:-2",
+    "-frames:v", "1", "-c:v", "mjpeg", "-q:v", "4", "-f", "image2",
+    tmp,
+  ];
+  try {
+    for (const seek of seekSec > 0 ? [seekSec, 0] : [0]) {
+      try {
+        await execFileP(FFMPEG_BIN, argsAt(seek), { timeout: THUMB_TIMEOUT_MS, maxBuffer: 4_000_000 });
+        if ((await stat(tmp)).size > 0) {
+          await rename(tmp, out);
+          return out;
+        }
+      } catch {
+        // Retry from the start (a clip shorter than the seek), then give up.
+      }
+    }
+    throw new Error("no frame extracted");
+  } finally {
+    await rm(tmp, { force: true });
+  }
 }

--- a/web/src/lib/media.ts
+++ b/web/src/lib/media.ts
@@ -1,0 +1,346 @@
+// Community metadata: user-uploaded media (screenshots, videos, physical
+// media photos), plain-text notes, and per-build completeness skip flags.
+// Media bytes live in the blob store under the media/ namespace,
+// content-addressed like assets, but a separate part of the bucket so asset
+// tooling can never touch user uploads. Uploads arrive in chunks (staged
+// under .staging/ next to the asset staging) because the production app sits
+// behind a proxy with a per-request body limit.
+
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { createHash, randomBytes } from "node:crypto";
+import type { Pool } from "pg";
+import { assetStoreDir } from "./blobstore";
+
+/** Store namespace for user media (see blobstore key layout). */
+export const MEDIA_NS = "media/";
+
+export const MEDIA_KINDS = ["screenshot", "video", "physical"] as const;
+export type MediaKind = (typeof MEDIA_KINDS)[number];
+
+export function isMediaKind(v: unknown): v is MediaKind {
+  return typeof v === "string" && (MEDIA_KINDS as readonly string[]).includes(v);
+}
+
+/** Upload size caps. Images stay modest; videos get room for real captures. */
+export const IMAGE_MAX_BYTES = 25 * 1024 * 1024;
+export const VIDEO_MAX_BYTES = 512 * 1024 * 1024;
+
+export function kindMaxBytes(kind: MediaKind): number {
+  return kind === "video" ? VIDEO_MAX_BYTES : IMAGE_MAX_BYTES;
+}
+
+/** Longest accepted original filename (display only; bytes are content-addressed). */
+export const MAX_FILENAME_LEN = 200;
+
+/** Note body cap (plain text). */
+export const MAX_NOTE_LEN = 10_000;
+
+/** Sniff the accepted media container formats from a file's leading bytes.
+ *  The stored content_type is always this verdict, never the client's claim.
+ *  Returns null for everything else (SVG stays out on purpose, it can script). */
+export function sniffMedia(head: Buffer): { contentType: string; video: boolean } | null {
+  if (head.length >= 12) {
+    if (head[0] === 0x89 && head[1] === 0x50 && head[2] === 0x4e && head[3] === 0x47) {
+      return { contentType: "image/png", video: false };
+    }
+    if (head[0] === 0xff && head[1] === 0xd8 && head[2] === 0xff) {
+      return { contentType: "image/jpeg", video: false };
+    }
+    if (head.toString("latin1", 0, 4) === "GIF8") {
+      return { contentType: "image/gif", video: false };
+    }
+    if (head.toString("latin1", 0, 4) === "RIFF" && head.toString("latin1", 8, 12) === "WEBP") {
+      return { contentType: "image/webp", video: false };
+    }
+    if (head.toString("latin1", 4, 8) === "ftyp") {
+      return { contentType: "video/mp4", video: true };
+    }
+    if (head[0] === 0x1a && head[1] === 0x45 && head[2] === 0xdf && head[3] === 0xa3) {
+      // Matroska EBML, served as WebM (browsers demux both).
+      return { contentType: "video/webm", video: true };
+    }
+  }
+  return null;
+}
+
+/** Public URL for one media blob: the bucket gateway when configured (same
+ *  contract as publicAssetUrl, keys under media/), else the app route. */
+export function mediaUrl(sha256: string, contentType: string): string {
+  const base = process.env.ASSET_PUBLIC_BASE;
+  if (base && /^(image|video)\/[\w.+-]+$/.test(contentType) && contentType !== "image/svg+xml") {
+    return `${base.replace(/\/+$/, "")}/media/${sha256.slice(0, 2)}/${sha256}`;
+  }
+  return `/api/media/${sha256}`;
+}
+
+// ── chunked upload sessions ──────────────────────────────────────────────────
+// A session is two files under the store's .staging dir: the growing payload
+// and a JSON sidecar with what finalize needs. No DB row until the bytes are
+// complete and sniffed, so abandoned uploads leave nothing behind but staging
+// files (reaped after a day).
+
+export interface MediaSession {
+  build: string;
+  kind: MediaKind;
+  filename: string;
+  size: number;
+  author: string;
+  /** Sniffed at the first chunk; absent until then. */
+  contentType?: string;
+}
+
+const SESSION_TTL_MS = 24 * 3600_000;
+
+export function isMediaToken(v: string): boolean {
+  return /^[0-9a-f]{32}$/.test(v);
+}
+
+export function newMediaToken(): string {
+  return randomBytes(16).toString("hex");
+}
+
+export function mediaStagingPath(token: string): string {
+  return path.join(assetStoreDir(), ".staging", `media-${token}.part`);
+}
+
+function mediaSessionPath(token: string): string {
+  return path.join(assetStoreDir(), ".staging", `media-${token}.json`);
+}
+
+export async function createMediaSession(token: string, session: MediaSession): Promise<void> {
+  const dir = path.join(assetStoreDir(), ".staging");
+  await fsp.mkdir(dir, { recursive: true });
+  await reapStaleSessions(dir).catch(() => {});
+  await fsp.writeFile(mediaSessionPath(token), JSON.stringify(session));
+  await fsp.writeFile(mediaStagingPath(token), Buffer.alloc(0));
+}
+
+export async function readMediaSession(token: string): Promise<MediaSession | null> {
+  try {
+    return JSON.parse(await fsp.readFile(mediaSessionPath(token), "utf8")) as MediaSession;
+  } catch {
+    return null;
+  }
+}
+
+export async function updateMediaSession(token: string, session: MediaSession): Promise<void> {
+  await fsp.writeFile(mediaSessionPath(token), JSON.stringify(session));
+}
+
+export async function dropMediaSession(token: string): Promise<void> {
+  await fsp.rm(mediaSessionPath(token), { force: true });
+  await fsp.rm(mediaStagingPath(token), { force: true });
+}
+
+async function reapStaleSessions(dir: string): Promise<void> {
+  const cutoff = Date.now() - SESSION_TTL_MS;
+  for (const name of await fsp.readdir(dir)) {
+    if (!name.startsWith("media-")) continue;
+    const p = path.join(dir, name);
+    try {
+      if ((await fsp.stat(p)).mtimeMs < cutoff) await fsp.rm(p, { force: true });
+    } catch {
+      // Raced with another reaper or an active finalize; leave it.
+    }
+  }
+}
+
+/** Streaming sha256 of a staged file. */
+export function hashFile(p: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const h = createHash("sha256");
+    fs.createReadStream(p)
+      .on("data", (c) => h.update(c))
+      .on("end", () => resolve(h.digest("hex")))
+      .on("error", reject);
+  });
+}
+
+// ── rows ─────────────────────────────────────────────────────────────────────
+
+export interface BuildMediaRow {
+  id: number;
+  build_sha256: string;
+  kind: MediaKind;
+  sha256: string;
+  poster_sha256: string | null;
+  filename: string;
+  content_type: string;
+  size: number;
+  author: string;
+  created_at: string;
+}
+
+/** A media row plus its serving URLs, as the media APIs and pages hand out. */
+export interface BuildMediaView extends BuildMediaRow {
+  url: string;
+  posterUrl: string | null;
+}
+
+export function mediaView(m: BuildMediaRow): BuildMediaView {
+  return {
+    ...m,
+    url: mediaUrl(m.sha256, m.content_type),
+    posterUrl: m.poster_sha256 ? mediaUrl(m.poster_sha256, "image/jpeg") : null,
+  };
+}
+
+export interface BuildNoteRow {
+  id: number;
+  build_sha256: string;
+  body: string;
+  author: string;
+  created_at: string;
+  edited_at: string | null;
+}
+
+export interface SkipFlags {
+  skip_notes: boolean;
+  skip_screenshots: boolean;
+  skip_video: boolean;
+  skip_physical: boolean;
+}
+
+export const NO_SKIPS: SkipFlags = {
+  skip_notes: false,
+  skip_screenshots: false,
+  skip_video: false,
+  skip_physical: false,
+};
+
+const MEDIA_COLS =
+  "id::int AS id, build_sha256, kind, sha256, poster_sha256, filename, content_type, size::float8 AS size, author, created_at::text AS created_at";
+
+const NOTE_COLS = "id::int AS id, build_sha256, body, author, created_at::text AS created_at, edited_at::text AS edited_at";
+
+export async function getBuildMedia(pool: Pool, buildSha: string): Promise<BuildMediaRow[]> {
+  const r = await pool.query(
+    `SELECT ${MEDIA_COLS} FROM build_media WHERE build_sha256=$1 ORDER BY created_at, id`,
+    [buildSha]
+  );
+  return r.rows as BuildMediaRow[];
+}
+
+export async function getMediaById(pool: Pool, buildSha: string, id: number): Promise<BuildMediaRow | null> {
+  const r = await pool.query(`SELECT ${MEDIA_COLS} FROM build_media WHERE build_sha256=$1 AND id=$2`, [
+    buildSha,
+    id,
+  ]);
+  return (r.rows[0] as BuildMediaRow) ?? null;
+}
+
+/** Insert one media row; on a duplicate (same build, kind, file) returns the
+ *  existing row instead. */
+export async function insertMedia(
+  pool: Pool,
+  m: {
+    build_sha256: string;
+    kind: MediaKind;
+    sha256: string;
+    poster_sha256: string | null;
+    filename: string;
+    content_type: string;
+    size: number;
+    author: string;
+  }
+): Promise<BuildMediaRow> {
+  const r = await pool.query(
+    `INSERT INTO build_media (build_sha256, kind, sha256, poster_sha256, filename, content_type, size, author)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+     ON CONFLICT (build_sha256, kind, sha256) DO NOTHING
+     RETURNING ${MEDIA_COLS}`,
+    [m.build_sha256, m.kind, m.sha256, m.poster_sha256, m.filename, m.content_type, m.size, m.author]
+  );
+  if (r.rows[0]) return r.rows[0] as BuildMediaRow;
+  const existing = await pool.query(
+    `SELECT ${MEDIA_COLS} FROM build_media WHERE build_sha256=$1 AND kind=$2 AND sha256=$3`,
+    [m.build_sha256, m.kind, m.sha256]
+  );
+  return existing.rows[0] as BuildMediaRow;
+}
+
+export async function deleteMedia(pool: Pool, buildSha: string, id: number): Promise<boolean> {
+  const r = await pool.query("DELETE FROM build_media WHERE build_sha256=$1 AND id=$2", [buildSha, id]);
+  return !!r.rowCount;
+}
+
+/** Look up the served content type of a media blob (or a video's poster). */
+export async function mediaContentType(pool: Pool, sha256: string): Promise<string | null> {
+  const r = await pool.query(
+    `SELECT content_type FROM build_media WHERE sha256=$1
+     UNION ALL
+     SELECT 'image/jpeg' FROM build_media WHERE poster_sha256=$1
+     LIMIT 1`,
+    [sha256]
+  );
+  return (r.rows[0]?.content_type as string) ?? null;
+}
+
+export async function getBuildNotes(pool: Pool, buildSha: string): Promise<BuildNoteRow[]> {
+  const r = await pool.query(
+    `SELECT ${NOTE_COLS} FROM build_note WHERE build_sha256=$1 ORDER BY created_at, id`,
+    [buildSha]
+  );
+  return r.rows as BuildNoteRow[];
+}
+
+export async function getNoteById(pool: Pool, buildSha: string, id: number): Promise<BuildNoteRow | null> {
+  const r = await pool.query(`SELECT ${NOTE_COLS} FROM build_note WHERE build_sha256=$1 AND id=$2`, [
+    buildSha,
+    id,
+  ]);
+  return (r.rows[0] as BuildNoteRow) ?? null;
+}
+
+export async function insertNote(pool: Pool, buildSha: string, body: string, author: string): Promise<BuildNoteRow> {
+  const r = await pool.query(
+    `INSERT INTO build_note (build_sha256, body, author) VALUES ($1,$2,$3) RETURNING ${NOTE_COLS}`,
+    [buildSha, body, author]
+  );
+  return r.rows[0] as BuildNoteRow;
+}
+
+export async function updateNote(pool: Pool, buildSha: string, id: number, body: string): Promise<BuildNoteRow | null> {
+  const r = await pool.query(
+    `UPDATE build_note SET body=$3, edited_at=now() WHERE build_sha256=$1 AND id=$2 RETURNING ${NOTE_COLS}`,
+    [buildSha, id, body]
+  );
+  return (r.rows[0] as BuildNoteRow) ?? null;
+}
+
+export async function deleteNote(pool: Pool, buildSha: string, id: number): Promise<boolean> {
+  const r = await pool.query("DELETE FROM build_note WHERE build_sha256=$1 AND id=$2", [buildSha, id]);
+  return !!r.rowCount;
+}
+
+export async function getBuildSkip(pool: Pool, buildSha: string): Promise<SkipFlags> {
+  const r = await pool.query(
+    "SELECT skip_notes, skip_screenshots, skip_video, skip_physical FROM build_skip WHERE build_sha256=$1",
+    [buildSha]
+  );
+  return (r.rows[0] as SkipFlags) ?? NO_SKIPS;
+}
+
+/** Upsert the skip flags; omitted fields keep their stored value. */
+export async function upsertSkip(pool: Pool, buildSha: string, flags: Partial<SkipFlags>): Promise<SkipFlags> {
+  const r = await pool.query(
+    `INSERT INTO build_skip (build_sha256, skip_notes, skip_screenshots, skip_video, skip_physical)
+     VALUES ($1, COALESCE($2, FALSE), COALESCE($3, FALSE), COALESCE($4, FALSE), COALESCE($5, FALSE))
+     ON CONFLICT (build_sha256) DO UPDATE SET
+       skip_notes       = COALESCE($2, build_skip.skip_notes),
+       skip_screenshots = COALESCE($3, build_skip.skip_screenshots),
+       skip_video       = COALESCE($4, build_skip.skip_video),
+       skip_physical    = COALESCE($5, build_skip.skip_physical)
+     RETURNING skip_notes, skip_screenshots, skip_video, skip_physical`,
+    [
+      buildSha,
+      flags.skip_notes ?? null,
+      flags.skip_screenshots ?? null,
+      flags.skip_video ?? null,
+      flags.skip_physical ?? null,
+    ]
+  );
+  return r.rows[0] as SkipFlags;
+}

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -499,9 +499,28 @@ export interface BuildListItem {
   /** Hidden from non-moderators (own flag or private lot). Only meaningful
    *  when the list was fetched with includePrivate. */
   private?: boolean;
+  /** Community completeness counts + skip flags (listBuildsPage only; a 0
+   *  renders orange in the browser unless the category is skipped). */
+  notes?: number;
+  screenshots?: number;
+  videos?: number;
+  physical?: number;
+  skip_notes?: boolean;
+  skip_screenshots?: boolean;
+  skip_video?: boolean;
+  skip_physical?: boolean;
 }
 
-export type BuildSortKey = "name" | "system" | "build_date" | "file_count" | "total_size";
+export type BuildSortKey =
+  | "name"
+  | "system"
+  | "build_date"
+  | "file_count"
+  | "total_size"
+  | "notes"
+  | "screenshots"
+  | "video"
+  | "physical";
 
 export interface BuildsPageOpts {
   q?: string;
@@ -524,13 +543,18 @@ export interface BuildsPageResult {
 }
 
 // Whitelist of sortable columns — `sort` is interpolated into ORDER BY, so it
-// must map through this table, never straight from user input.
+// must map through this table, never straight from user input. The community
+// count keys name select-list aliases (Postgres resolves them in ORDER BY).
 const BUILD_SORT: Record<BuildSortKey, string> = {
   name: "lower(name)",
   system: "system",
   build_date: "build_date",
   file_count: "file_count",
   total_size: "total_size",
+  notes: "notes",
+  screenshots: "screenshots",
+  video: "videos",
+  physical: "physical",
 };
 
 /// One page of the /builds index, filtered and sorted in SQL. Replaces the
@@ -566,11 +590,30 @@ export async function listBuildsPage(pool: Pool, opts: BuildsPageOpts = {}): Pro
   const limit = Math.min(Math.max(opts.limit ?? 100, 1), 500);
   const offset = Math.max(opts.offset ?? 0, 0);
 
+  // The community joins aggregate small user tables (media/notes stay orders
+  // of magnitude below builds), so they don't disturb the <500ms page budget.
   const [rows, count, systems] = await Promise.all([
     pool.query(
       `SELECT sha256, name, system, file_count, total_size, ingested_at, build_date, lot,
-              (private OR EXISTS (SELECT 1 FROM private_lots _pl WHERE _pl.lot = builds.lot)) AS private
-       FROM builds ${where} ORDER BY ${order}
+              (private OR EXISTS (SELECT 1 FROM private_lots _pl WHERE _pl.lot = builds.lot)) AS private,
+              COALESCE(_n.notes, 0)::int        AS notes,
+              COALESCE(_m.screenshots, 0)::int  AS screenshots,
+              COALESCE(_m.videos, 0)::int       AS videos,
+              COALESCE(_m.physical, 0)::int     AS physical,
+              COALESCE(_s.skip_notes, FALSE)       AS skip_notes,
+              COALESCE(_s.skip_screenshots, FALSE) AS skip_screenshots,
+              COALESCE(_s.skip_video, FALSE)       AS skip_video,
+              COALESCE(_s.skip_physical, FALSE)    AS skip_physical
+       FROM builds
+       LEFT JOIN (SELECT build_sha256,
+                         count(*) FILTER (WHERE kind='screenshot') AS screenshots,
+                         count(*) FILTER (WHERE kind='video')      AS videos,
+                         count(*) FILTER (WHERE kind='physical')   AS physical
+                  FROM build_media GROUP BY build_sha256) _m ON _m.build_sha256 = builds.sha256
+       LEFT JOIN (SELECT build_sha256, count(*) AS notes
+                  FROM build_note GROUP BY build_sha256) _n ON _n.build_sha256 = builds.sha256
+       LEFT JOIN build_skip _s ON _s.build_sha256 = builds.sha256
+       ${where} ORDER BY ${order}
        LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
       [...params, limit, offset]
     ),


### PR DESCRIPTION
Logged-in wiki users can now attach screenshots, video captures, and physical media photos to a build, plus plain-text notes, all attributed to the wiki username. Uploads land in a new media/ namespace of the blob store via a chunked, resumable endpoint, with server-side format sniffing and ffmpeg poster stills for videos.

The builds browser gains sortable notes, screenshots, video, and physical columns: a 0 renders orange unless a moderator marks the category not applicable on the build page. New tables (build_media, build_note, build_skip) ship in migration 006 and hold prod-only user data, additive migrations only.