### PR TITLE
AVI asset support

### DIFF
--- a/crates/prism-core/src/schema.rs
+++ b/crates/prism-core/src/schema.rs
@@ -20,9 +20,10 @@ pub const FINGERPRINT_PROFILE: &str = "v1";
 /// 20MB); 7 = archives (zip/7z/rar/tar/cab/…) extracted as if directories,
 /// their members' assets riding under `<archive path>/...`; 8 = the shared
 /// asset cap raised from 20 to 64 MiB (files between the two previously fell
-/// back to head snippets). A record below the current value gets its assets
-/// re-extracted on the next analyze.
-pub const ASSET_PROFILE: u32 = 8;
+/// back to head snippets); 9 = AVI classified as video (previously a head
+/// snippet). A record below the current value gets its assets re-extracted
+/// on the next analyze.
+pub const ASSET_PROFILE: u32 = 9;
 
 /// A fully analyzed disc image / container — image-independent and self-describing.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/ps2exe-adapter/prism_adapter/viewable.py
+++ b/ps2exe-adapter/prism_adapter/viewable.py
@@ -66,6 +66,9 @@ _VIDEO = {
     "m1v": "video/mpeg",
     "m2v": "video/mpeg",
     "vob": "video/mpeg",
+    # AVI (RIFF container) — the PC-era press/demo disc staple. Also not
+    # browser-playable; takes the same transcode path as MPEG.
+    "avi": "video/x-msvideo",
 }
 
 # Print-format documents. Browsers render PDF natively; PostScript (.eps, .ps,
@@ -175,6 +178,7 @@ _MAGIC = {
     # Program streams (.mpg, DVD .vob) open on a pack start code, elementary
     # video streams (.m1v/.m2v) on a sequence header.
     "video/mpeg": lambda h: h.startswith((b"\x00\x00\x01\xba", b"\x00\x00\x01\xb3")),
+    "video/x-msvideo": lambda h: h[:4] == b"RIFF" and h[8:12] == b"AVI ",
     "application/pdf": lambda h: h.startswith(b"%PDF-"),
     # ASCII PostScript/EPS, or the DOS EPS binary wrapper around one.
     "application/postscript": lambda h: h.startswith((b"%!PS", b"\xc5\xd0\xd3\xc6")),

--- a/ps2exe-adapter/tests/test_viewable.py
+++ b/ps2exe-adapter/tests/test_viewable.py
@@ -86,6 +86,19 @@ def test_sniff_mpeg_video():
     assert not viewable.sniff(b"MZ\x90\x00", "video/mpeg")
 
 
+def test_classify_avi_video():
+    assert viewable.classify("/MOVIES/TRAILER.AVI") == ("video", "video/x-msvideo")
+    assert viewable.classify("/fmv/intro.avi") == ("video", "video/x-msvideo")
+
+
+def test_sniff_avi_video():
+    assert viewable.sniff(b"RIFF\x24\x08\x00\x00AVI LIST", "video/x-msvideo")
+    # Other RIFF families (WAV, CDXA) must not pass as AVI.
+    assert not viewable.sniff(b"RIFF\x24\x08\x00\x00WAVEfmt ", "video/x-msvideo")
+    assert not viewable.sniff(b"RIFF\x24\x08\x00\x00CDXAfmt ", "video/x-msvideo")
+    assert not viewable.sniff(b"MZ\x90\x00", "video/x-msvideo")
+
+
 def test_classify_documents():
     assert viewable.classify("/COMIC/BOOK.PDF") == ("document", "application/pdf")
     assert viewable.classify("/ART/LOGO.EPS") == ("document", "application/postscript")

--- a/web/src/app/api/asset/[sha256]/video/route.ts
+++ b/web/src/app/api/asset/[sha256]/video/route.ts
@@ -12,7 +12,7 @@ export const runtime = "nodejs";
 // GET /api/asset/<sha256>/video — the asset transcoded to a browser-playable
 // format (H.264/AAC MP4, or VP9/Opus WebM when the server's ffmpeg lacks
 // libx264), for video formats browsers won't play natively: today MPEG-1/2
-// program streams, i.e. .mpg and DVD .vob. Native formats redirect to the raw
+// program streams (.mpg, DVD .vob) and AVI. Native formats redirect to the raw
 // asset route. The transcode is produced once, cached on disk, and streamed
 // with Range support so the player can seek. The URL is content-addressed, so
 // responses cache hard.

--- a/web/src/app/builds/[buildId]/AssetViewer.tsx
+++ b/web/src/app/builds/[buildId]/AssetViewer.tsx
@@ -34,10 +34,14 @@ export function imageSrc(a: ViewableAsset): string {
     : assetUrl(a);
 }
 
+/** Video mimes browsers won't play natively — served through the server's
+ *  transcode. Must match transcodable() in lib/ffmpeg.ts. */
+const TRANSCODED_VIDEO = new Set(["video/mpeg", "video/x-msvideo"]);
+
 /** Where <video> should point: MP4/WebM play natively, while MPEG-1/2 program
- *  streams (.mpg, DVD .vob) go through the server's transcode. */
+ *  streams (.mpg, DVD .vob) and AVI go through the server's transcode. */
 export function videoSrc(a: ViewableAsset): string {
-  return a.mime === "video/mpeg" ? `${assetUrl(a)}/video` : assetUrl(a);
+  return TRANSCODED_VIDEO.has(a.mime) ? `${assetUrl(a)}/video` : assetUrl(a);
 }
 
 /** Where <audio> should point: WAVs go through the server's codec sniff,
@@ -172,7 +176,7 @@ const TRANSCODE_POLL_MS = 4_000;
 /**
  * Video player over an extracted asset, shared by the viewer body and the
  * gallery cards. MP4/WebM play natively; MPEG program streams (.mpg, DVD
- * .vob) go through the server's ffmpeg transcode, which for DVD-sized inputs
+ * .vob) and AVI go through the server's ffmpeg transcode, which for DVD-sized inputs
  * may still be running when playback is first attempted — the player then
  * polls ./video/status, showing progress over the poster still, and starts
  * playback when the stream is ready. A transcode that is unavailable (no
@@ -271,7 +275,7 @@ export function VideoPlayer({
       title={asset.path}
       className={className}
       onError={() => {
-        if (asset.mime === "video/mpeg" && readyAt === 0) setPhase("preparing");
+        if (TRANSCODED_VIDEO.has(asset.mime) && readyAt === 0) setPhase("preparing");
         else setPhase("failed");
       }}
     />

--- a/web/src/lib/ffmpeg.ts
+++ b/web/src/lib/ffmpeg.ts
@@ -1,6 +1,6 @@
-// ffmpeg-backed transcoding: MPEG-1/2 program streams (.mpg, DVD .vob) and
-// bare MPEG video elementary streams to a format browsers actually play, and
-// ADPCM-family WAVs (Xbox ADPCM and friends) to plain 16-bit PCM WAV.
+// ffmpeg-backed transcoding: MPEG-1/2 program streams (.mpg, DVD .vob), bare
+// MPEG video elementary streams, and AVI to a format browsers actually play,
+// and ADPCM-family WAVs (Xbox ADPCM and friends) to plain 16-bit PCM WAV.
 // Like Ghostscript in gs.ts, ffmpeg is a soft dependency: feature-detected at
 // runtime, and callers degrade (download-only viewer) when it's missing.
 //
@@ -48,7 +48,7 @@ const THUMB_TIMEOUT_MS = 120_000;
 
 /** Mimes ensureTranscode can convert. */
 export function transcodable(mime: string): boolean {
-  return mime === "video/mpeg";
+  return mime === "video/mpeg" || mime === "video/x-msvideo";
 }
 
 export interface TranscodeProfile {

--- a/web/tests/ffmpeg.test.ts
+++ b/web/tests/ffmpeg.test.ts
@@ -24,8 +24,9 @@ const execFileP = promisify(execFile);
 // Transcode tests need real ffmpeg and skip without it (set FFMPEG_BIN when
 // `ffmpeg` isn't on PATH).
 
-test("transcodable covers exactly the MPEG program-stream mime", () => {
+test("transcodable covers exactly the MPEG program-stream and AVI mimes", () => {
   assert.equal(transcodable("video/mpeg"), true);
+  assert.equal(transcodable("video/x-msvideo"), true);
   assert.equal(transcodable("video/mp4"), false);
   assert.equal(transcodable("video/webm"), false);
   assert.equal(transcodable("audio/mpeg"), false);
@@ -104,6 +105,41 @@ test("ensureTranscode converts an MPEG-PS blob and caches the result", async (t)
     const before = (await stat(video.path)).mtimeMs;
     assert.equal((await ensureTranscode(sha)).path, video.path);
     assert.equal((await stat(video.path)).mtimeMs, before);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+/** A 1s 64x48 AVI with the codecs a period disc would carry (MPEG-4 ASP +
+ *  MP2 needs no extra encoders in any ffmpeg build). */
+async function aviFixture(dir: string): Promise<Buffer> {
+  const out = join(dir, "fixture.avi");
+  await execFileP(process.env.FFMPEG_BIN || "ffmpeg", [
+    "-hide_banner", "-loglevel", "error", "-y",
+    "-f", "lavfi", "-i", "testsrc=duration=1:size=64x48:rate=10",
+    "-f", "lavfi", "-i", "sine=frequency=440:duration=1",
+    "-c:v", "mpeg4", "-c:a", "mp2", "-f", "avi",
+    out,
+  ]);
+  return readFile(out);
+}
+
+test("ensureTranscode converts an AVI blob", async (t) => {
+  const profile = await transcodeProfile();
+  if (!profile) return t.skip("ffmpeg not installed");
+  const dir = await tempStore();
+  try {
+    const sha = "ab".repeat(32);
+    const avi = await aviFixture(dir);
+    // The fixture must carry the RIFF/AVI magic viewable.py sniffs for.
+    assert.equal(avi.subarray(0, 4).toString("latin1"), "RIFF");
+    assert.equal(avi.subarray(8, 12).toString("latin1"), "AVI ");
+    await putBlob(sha, avi);
+
+    const video = await ensureTranscode(sha);
+    assert.equal(video.path, transcodePath(sha, profile.ext));
+    assert.equal(video.mime, profile.mime);
+    assert.ok((await stat(video.path)).size > 0);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
The extractor now classifies .avi files as video (RIFF plus AVI header sniff), so they ship whole into the asset store instead of falling back to head snippets. ASSET_PROFILE goes 8 to 9 so the next analyze re-extracts them from existing builds.

On the web side the existing ffmpeg transcode route accepts the new mime, since browsers do not play AVI natively. The player routes it through the same prepare and status-poll flow as MPEG, and poster thumbs work unchanged.