### PR TITLE
Duplicate submission support

### DIFF
--- a/web/db/migrations/007-duplicates.sql
+++ b/web/db/migrations/007-duplicates.sql
@@ -1,0 +1,26 @@
+-- Duplicate-name submissions: a submitted record whose image already exists
+-- as a build, under a different name than both the build's display name and
+-- its stored record's image name, is queued as kind='duplicate'. Accepting it
+-- records the submitted name in build_duplicate instead of re-ingesting, so
+-- the live build is never overwritten by a renamed copy of itself.
+--
+-- build_duplicate is PROD-ONLY USER DATA (same never-wipe rules as
+-- build_media/build_note/build_skip): never drop, truncate, or reload it from
+-- a local dump; the deploy tooling preserves and restores it around any full
+-- DB reload.
+--
+-- Idempotent, safe to re-run. Apply to every prism DB:
+--   psql -d <db> -f db/migrations/007-duplicates.sql
+
+ALTER TABLE submission_queue
+    ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'build'
+        CHECK (kind IN ('build','duplicate'));
+
+CREATE TABLE IF NOT EXISTS build_duplicate (
+    id           BIGSERIAL PRIMARY KEY,
+    build_sha256 TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE,
+    name         TEXT NOT NULL,           -- the name the duplicate was submitted under
+    nickname     TEXT NOT NULL,           -- who submitted it
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (build_sha256, name)
+);

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -247,8 +247,22 @@ CREATE TABLE submission_queue (
     sha256       TEXT PRIMARY KEY,
     nickname     TEXT NOT NULL,
     status       TEXT NOT NULL DEFAULT 'queued',  -- queued|accepted|rejected
+    -- 'duplicate': the image is already a build under a different name;
+    -- accepting records the name in build_duplicate instead of re-ingesting.
+    kind         TEXT NOT NULL DEFAULT 'build' CHECK (kind IN ('build','duplicate')),
     record       JSONB NOT NULL,
     submitted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     reviewed_at  TIMESTAMPTZ
 );
 CREATE INDEX idx_subq_status ON submission_queue(status);
+
+-- Names a build's image has circulated under besides its own — accepted
+-- duplicate submissions. PROD-ONLY USER DATA: same never-wipe rules as above.
+CREATE TABLE build_duplicate (
+    id           BIGSERIAL PRIMARY KEY,
+    build_sha256 TEXT NOT NULL REFERENCES builds(sha256) ON DELETE CASCADE,
+    name         TEXT NOT NULL,           -- the name the duplicate was submitted under
+    nickname     TEXT NOT NULL,           -- who submitted it
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (build_sha256, name)
+);

--- a/web/src/app/api/submissions/[sha256]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/route.ts
@@ -51,6 +51,7 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
   // Accept: ingest and flip status to accepted in ONE transaction so a failed
   // ingest never leaves the submission marked accepted.
   let name = "";
+  let kind = "build";
   const c = await pool.connect();
   try {
     await c.query("BEGIN");
@@ -58,27 +59,52 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
     // audio-IDF refresh below outlives the pool's page-query statement_timeout on
     // slower hosts. Page queries keep their cap.
     await c.query("SET LOCAL statement_timeout = 0");
-    const r = await c.query<{ record: BuildRecord }>(
-      "SELECT record FROM submission_queue WHERE sha256=$1 FOR UPDATE",
+    const r = await c.query<{ record: BuildRecord; kind: string; nickname: string }>(
+      "SELECT record, kind, nickname FROM submission_queue WHERE sha256=$1 FOR UPDATE",
       [sha256]
     );
     if (!r.rowCount) {
       await c.query("ROLLBACK");
       return Response.json({ error: "not found" }, { status: 404 });
     }
-    name = r.rows[0].record.image?.name ?? "";
-    // Force: an accept must replace the live build wholesale — record, row
-    // columns, and derived tables — even when the record looks unchanged.
-    // New submissions start private (unlisted) until a moderator publishes
-    // them; re-accepting an existing build keeps its current visibility.
-    await ingestRecord(c, r.rows[0].record, { force: true, asPrivate: true });
+    kind = r.rows[0].kind;
+    if (kind === "duplicate") {
+      // Duplicate-name submission: the image is already a live build. Accepting
+      // records the submitted name as a known duplicate — the build itself
+      // (record, derived tables, any moderator rename) stays untouched.
+      const b = await c.query<{ name: string }>("SELECT name FROM builds WHERE sha256=$1", [sha256]);
+      if (!b.rowCount) {
+        await c.query("ROLLBACK");
+        return Response.json(
+          { error: "original build no longer exists; reject and have it resubmitted" },
+          { status: 409 }
+        );
+      }
+      name = b.rows[0].name;
+      const dupName = r.rows[0].record.image?.name ?? "";
+      if (dupName && dupName !== name) {
+        await c.query(
+          `INSERT INTO build_duplicate (build_sha256, name, nickname) VALUES ($1,$2,$3)
+           ON CONFLICT (build_sha256, name) DO NOTHING`,
+          [sha256, dupName, r.rows[0].nickname]
+        );
+      }
+    } else {
+      name = r.rows[0].record.image?.name ?? "";
+      // Force: an accept must replace the live build wholesale — record, row
+      // columns, and derived tables — even when the record looks unchanged.
+      // New submissions start private (unlisted) until a moderator publishes
+      // them; re-accepting an existing build keeps its current visibility.
+      await ingestRecord(c, r.rows[0].record, { force: true, asPrivate: true });
+    }
     await c.query(
       "UPDATE submission_queue SET status='accepted', reviewed_at=now() WHERE sha256=$1",
       [sha256]
     );
     // Keep the audio-hash corpus frequencies in step with the new build so the
     // similarity tier's IDF weighting stays accurate; atomic with the accept.
-    await refreshAudioIdf(c);
+    // A duplicate accept changes no corpus rows, so it skips the refresh.
+    if (kind !== "duplicate") await refreshAudioIdf(c);
     await c.query("COMMIT");
   } catch (e) {
     console.error(`accept ${sha256}: ingest failed:`, e);
@@ -94,5 +120,5 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
   revalidatePath(canonical);
   revalidatePath(`${canonical}/assets`);
   revalidatePath(`/builds/${sha256}`);
-  return Response.json({ sha256, status: "accepted" });
+  return Response.json({ sha256, status: "accepted", kind });
 }

--- a/web/src/app/api/submissions/route.ts
+++ b/web/src/app/api/submissions/route.ts
@@ -46,8 +46,8 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: v.error }, { status: 422 });
   }
   try {
-    const sha256 = await enqueueSubmission(getPool(), nickname, v.record);
-    return Response.json({ sha256, status: "queued" }, { status: 202 });
+    const { sha256, kind } = await enqueueSubmission(getPool(), nickname, v.record);
+    return Response.json({ sha256, status: "queued", kind }, { status: 202 });
   } catch {
     return Response.json({ error: "internal error" }, { status: 500 });
   }

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -5,7 +5,7 @@ import { notFound, permanentRedirect } from "next/navigation";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
 import { buildTree, initialExpanded, pruneToExpanded, treeCounts } from "@/lib/filetree";
-import { getBuild, getBuildAssets, getBuildMeta, getBuildRepos, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, listLots, isLotPrivate, resolveBuild } from "@/lib/queries";
+import { getBuild, getBuildAssets, getBuildDuplicates, getBuildMeta, getBuildRepos, findSimilar, findByEmbeddingOf, fuseSimilar, getCapabilities, listLots, isLotPrivate, resolveBuild } from "@/lib/queries";
 import { shortOid } from "@/lib/repo-manifest";
 import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
 import { getBuildMedia, getBuildNotes, getBuildSkip, mediaView } from "@/lib/media";
@@ -142,7 +142,7 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
   const q = deriveQueryFeatures(build.record);
   // Pull a wide candidate set per tier so the fused top-50 is well-populated.
   // Text neighbors use this build's already-stored embedding — no re-embedding per load.
-  const [similar, textNeighbors, assets, lots, repos, lotPrivate, media, notes, skips] = await Promise.all([
+  const [similar, textNeighbors, assets, lots, repos, lotPrivate, media, notes, skips, duplicates] = await Promise.all([
     findSimilar(pool, q, 100),
     findByEmbeddingOf(pool, sha256, 100),
     getBuildAssets(pool, sha256),
@@ -152,6 +152,7 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
     getBuildMedia(pool, sha256),
     getBuildNotes(pool, sha256),
     getBuildSkip(pool, sha256),
+    getBuildDuplicates(pool, sha256),
   ]);
   const fused = fuseSimilar(similar, textNeighbors);
 
@@ -171,6 +172,9 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
   const expanded = initialExpanded(tree);
   const counts = treeCounts(tree);
   const meta = metaSections(build.record);
+  // A later rename can make the build's own name match a recorded duplicate;
+  // don't list the current name under itself.
+  const dupNames = duplicates.filter((d) => d.name !== build.name);
   const filteredContentHash = build.record.composites?.filtered_content_hash;
   const discTitle = build.record.info?.title as string | undefined;
 
@@ -224,7 +228,7 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
         skips={skips}
       />
 
-      {meta.length > 0 && (
+      {(meta.length > 0 || dupNames.length > 0) && (
         <section className="mt-8">
           <h2 className="text-lg font-medium">Metadata</h2>
           <div className="mt-3 grid gap-x-12 gap-y-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -241,6 +245,18 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
                 </dl>
               </div>
             ))}
+            {dupNames.length > 0 && (
+              <div>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-400">Duplicates</h3>
+                <ul className="mt-2 space-y-1 text-sm">
+                  {dupNames.map((d) => (
+                    <li key={d.name} className="break-all">
+                      {d.name} <span className="text-xs text-neutral-500">by {d.nickname}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </div>
         </section>
       )}

--- a/web/src/app/moderate/page.tsx
+++ b/web/src/app/moderate/page.tsx
@@ -8,6 +8,7 @@ interface Submission {
   sha256: string;
   nickname: string;
   status: string;
+  kind: string;
   submitted_at: string;
   reviewed_at: string | null;
   name: string;
@@ -107,6 +108,8 @@ export default function Moderate() {
       <p className="mt-1 text-sm text-neutral-500">
         Review contributor submissions. Accepting ingests the build into the library
         as private (unlisted); publish it from the build page when it is ready.
+        Accepting a <span className="font-medium">duplicate</span> records the submitted
+        name on the existing build instead of replacing it.
         While you are signed in, build pages also show moderator tools (rename, lot).
       </p>
 
@@ -171,6 +174,14 @@ export default function Moderate() {
                   <span>{s.file_count ?? "?"} files</span>
                   <span>by {s.nickname}</span>
                   <span className="font-mono">{s.sha256.slice(0, 12)}…</span>
+                  {s.kind === "duplicate" && (
+                    <span
+                      title="This image is already in the library under a different name. Accept records this name as a duplicate; the existing build is not replaced."
+                      className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 dark:bg-sky-900/40 dark:text-sky-200"
+                    >
+                      duplicate
+                    </span>
+                  )}
                   {s.lot && (
                     <Link
                       href={`/builds?lot=${encodeURIComponent(s.lot)}`}

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -451,18 +451,37 @@ export async function search(
   return { mode: "text", results: r.rows.map((x) => ({ ...x, sim: x.sim == null ? null : Number(x.sim) })) };
 }
 
-/** Enqueue a submission (dedup by sha256). */
-export async function enqueueSubmission(pool: Pool, nickname: string, record: BuildRecord): Promise<string> {
+export type SubmissionKind = "build" | "duplicate";
+
+/** Enqueue a submission (dedup by sha256). A record whose image is already a
+ *  build, under a different name than both the build's display name and its
+ *  stored record's image name, queues as kind='duplicate': accepting records
+ *  the name in build_duplicate instead of re-ingesting (see the moderation
+ *  accept route). Matching either name stays kind='build', so a repair
+ *  resubmission — same file, possibly a moderator-renamed build — still
+ *  replaces the live build wholesale. */
+export async function enqueueSubmission(
+  pool: Pool,
+  nickname: string,
+  record: BuildRecord
+): Promise<{ sha256: string; kind: SubmissionKind }> {
   const sha = record?.image?.sha256;
   if (!sha) throw new Error("record missing image.sha256");
-  await pool.query(
-    `INSERT INTO submission_queue (sha256, nickname, record)
-     VALUES ($1,$2,$3)
-     ON CONFLICT (sha256) DO UPDATE SET nickname=excluded.nickname, record=excluded.record,
-        status='queued', submitted_at=now(), reviewed_at=NULL`,
-    [sha, nickname, record]
+  const name = record?.image?.name ?? "";
+  const existing = await pool.query(
+    `SELECT name, record->'image'->>'name' AS record_name FROM builds WHERE sha256=$1`,
+    [sha]
   );
-  return sha;
+  const b = existing.rows[0] as { name: string; record_name: string | null } | undefined;
+  const kind: SubmissionKind = b && name !== b.name && name !== b.record_name ? "duplicate" : "build";
+  await pool.query(
+    `INSERT INTO submission_queue (sha256, nickname, record, kind)
+     VALUES ($1,$2,$3,$4)
+     ON CONFLICT (sha256) DO UPDATE SET nickname=excluded.nickname, record=excluded.record,
+        kind=excluded.kind, status='queued', submitted_at=now(), reviewed_at=NULL`,
+    [sha, nickname, record, kind]
+  );
+  return { sha256: sha, kind };
 }
 
 export interface BuildRow {
@@ -817,7 +836,7 @@ export async function setLotPrivate(pool: Pool, lot: string, priv: boolean): Pro
 
 export async function submissionStatus(pool: Pool, sha256: string) {
   const r = await pool.query(
-    "SELECT sha256, nickname, status, submitted_at, reviewed_at FROM submission_queue WHERE sha256=$1",
+    "SELECT sha256, nickname, status, kind, submitted_at, reviewed_at FROM submission_queue WHERE sha256=$1",
     [sha256]
   );
   return r.rows[0] || null;
@@ -827,6 +846,8 @@ export interface SubmissionListItem {
   sha256: string;
   nickname: string;
   status: string;
+  /** 'duplicate': accept records the name in build_duplicate, not an ingest. */
+  kind: SubmissionKind;
   submitted_at: string;
   reviewed_at: string | null;
   name: string;
@@ -841,7 +862,7 @@ export async function listSubmissions(pool: Pool, status?: string, limit = 200):
   const where = status ? "WHERE q.status=$1" : "";
   const params = status ? [status, limit] : [limit];
   const r = await pool.query(
-    `SELECT q.sha256, q.nickname, q.status, q.submitted_at, q.reviewed_at,
+    `SELECT q.sha256, q.nickname, q.status, q.kind, q.submitted_at, q.reviewed_at,
             q.record->'image'->>'name'         AS name,
             q.record->'info'->>'system'        AS system,
             (q.record->'structural'->>'file_count')::bigint AS file_count,
@@ -852,6 +873,22 @@ export async function listSubmissions(pool: Pool, status?: string, limit = 200):
     params
   );
   return r.rows as SubmissionListItem[];
+}
+
+/** A name this build's image has circulated under besides its own (an
+ *  accepted duplicate submission). */
+export interface BuildDuplicate {
+  name: string;
+  nickname: string;
+  created_at: string;
+}
+
+export async function getBuildDuplicates(pool: Pool, sha256: string): Promise<BuildDuplicate[]> {
+  const r = await pool.query(
+    "SELECT name, nickname, created_at FROM build_duplicate WHERE build_sha256=$1 ORDER BY created_at, name",
+    [sha256]
+  );
+  return r.rows as BuildDuplicate[];
 }
 
 /// Mark a submission accepted/rejected. Returns the stored record on accept (so the


### PR DESCRIPTION
A submission whose image already exists as a build, under a different name than both the build's display name and its stored record's image name, now queues as a duplicate instead of a normal submission. Accepting it records the submitted name in the new build_duplicate table and leaves the live build untouched, so an accept can no longer overwrite a build with a renamed copy of itself.

Name matches keep the normal flow, so repair resubmissions (including moderator renamed builds) still replace the build wholesale. Migration 007 adds submission_queue.kind and the build_duplicate table (prod only user data, preserved around DB reloads), the moderation queue shows a duplicate badge, and build pages list recorded duplicates under Metadata.