### PR TITLE
Add per-build game classification

### DIFF
--- a/web/db/migrations/008-games.sql
+++ b/web/db/migrations/008-games.sql
@@ -1,0 +1,22 @@
+-- Game classification: a shared games table plus builds.game_id. Populated
+-- by scripts/import-wiki-games.ts (wiki {{Prototype}} infobox "game" field,
+-- joined to builds by archive sha1) and editable per build by moderators via
+-- PATCH /api/build/<sha256> { game } (upserts the name, "" / null clears).
+--
+-- game_id follows the same reload semantics as name/lot/private: local DBs
+-- are the source of truth on a full reload, so prod-side edits since the
+-- last import are expected to be re-importable, not preserved.
+-- games ids are PER-DATABASE (BIGSERIAL): any cross-DB copy of builds rows
+-- must remap game_id through the game NAME, never copy raw ids between
+-- databases.
+--
+-- Idempotent, safe to re-run. Apply to every prism DB:
+--   psql -d <db> -f db/migrations/008-games.sql
+
+CREATE TABLE IF NOT EXISTS games (
+    id   BIGSERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);
+
+ALTER TABLE builds ADD COLUMN IF NOT EXISTS game_id BIGINT REFERENCES games(id);
+CREATE INDEX IF NOT EXISTS idx_builds_game ON builds(game_id) WHERE game_id IS NOT NULL;

--- a/web/db/migrations/009-game-system.sql
+++ b/web/db/migrations/009-game-system.sql
@@ -1,0 +1,17 @@
+-- Games gain a system and a URL slug. The same title on two systems is two
+-- games (Sonic 3D Blast on Genesis vs Saturn), so identity moves from name
+-- to (name, system). system is '' when unknown, never NULL, so the unique
+-- pair behaves. slug is the /games/<slug> path segment
+-- (<name-slug>--<system-slug>, name slug alone when system is ''), computed
+-- in app code (lib/slug.ts gameSlug); rows keep NULL until the import script
+-- or a moderator assignment fills it, and NULLs don't collide in the unique
+-- index. Colliding slugs (near-duplicate wiki spellings) get "-<id>".
+--
+-- Idempotent, safe to re-run. Apply to every prism DB:
+--   psql -d <db> -f db/migrations/009-game-system.sql
+
+ALTER TABLE games ADD COLUMN IF NOT EXISTS system TEXT NOT NULL DEFAULT '';
+ALTER TABLE games ADD COLUMN IF NOT EXISTS slug TEXT;
+ALTER TABLE games DROP CONSTRAINT IF EXISTS games_name_key;
+CREATE UNIQUE INDEX IF NOT EXISTS games_name_system_key ON games(name, system);
+CREATE UNIQUE INDEX IF NOT EXISTS games_slug_key ON games(slug);

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -15,6 +15,16 @@ CREATE EXTENSION IF NOT EXISTS vector;    -- pgvector: text embedding ANN
 -- CREATE EXTENSION IF NOT EXISTS smlar;  -- exact set similarity (identical-file overlap); build/install separately
 CREATE EXTENSION IF NOT EXISTS intarray;  -- fallback array overlap if smlar unavailable
 
+-- ── games ────────────────────────────────────────────────────────────────────
+-- Shared classification: which game each build is a build of. Seeded from the
+-- wiki {{Prototype}} infobox by scripts/import-wiki-games.ts, extended by
+-- moderator edits (upsert by name). ids are PER-DATABASE — cross-DB copies of
+-- builds rows must remap game_id through the name, never raw ids.
+CREATE TABLE games (
+    id   BIGSERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);
+
 -- ── builds ───────────────────────────────────────────────────────────────────
 CREATE TABLE builds (
     sha256                TEXT PRIMARY KEY,         -- image identity / lookup key
@@ -36,7 +46,8 @@ CREATE TABLE builds (
     ingested_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
     build_date            TEXT,                     -- volume creation date, else header release date (sortable copy)
     lot                   TEXT,                     -- moderator-assigned display group, e.g. "Sonic Month 2026"
-    private               BOOLEAN NOT NULL DEFAULT FALSE -- hidden from public list/search/similar (direct URL stays reachable)
+    private               BOOLEAN NOT NULL DEFAULT FALSE, -- hidden from public list/search/similar (direct URL stays reachable)
+    game_id               BIGINT REFERENCES games(id) -- which game this is a build of (wiki import / moderator)
 );
 CREATE INDEX idx_builds_content      ON builds(content_hash);
 CREATE INDEX idx_builds_filtered     ON builds(filtered_content_hash);
@@ -46,6 +57,7 @@ CREATE INDEX idx_builds_name_trgm    ON builds USING gin (name gin_trgm_ops);
 CREATE INDEX idx_builds_textdoc_fts  ON builds USING gin (to_tsvector('simple', text_doc));
 CREATE INDEX idx_builds_embedding    ON builds USING hnsw (text_embedding vector_cosine_ops);
 CREATE INDEX idx_builds_lot          ON builds(lot) WHERE lot IS NOT NULL;
+CREATE INDEX idx_builds_game         ON builds(game_id) WHERE game_id IS NOT NULL;
 
 -- Lots hidden from non-moderators; a build in a listed lot is hidden with it.
 CREATE TABLE private_lots (

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -18,12 +18,19 @@ CREATE EXTENSION IF NOT EXISTS intarray;  -- fallback array overlap if smlar una
 -- ── games ────────────────────────────────────────────────────────────────────
 -- Shared classification: which game each build is a build of. Seeded from the
 -- wiki {{Prototype}} infobox by scripts/import-wiki-games.ts, extended by
--- moderator edits (upsert by name). ids are PER-DATABASE — cross-DB copies of
--- builds rows must remap game_id through the name, never raw ids.
+-- moderator edits (upsert by name+system). The same title on two systems is
+-- two games, so identity is (name, system), '' system when unknown. slug is
+-- the /games/<slug> segment (lib/slug.ts gameSlug, "-<id>" on collision).
+-- ids are PER-DATABASE — cross-DB copies of builds rows must remap game_id
+-- through (name, system), never raw ids.
 CREATE TABLE games (
-    id   BIGSERIAL PRIMARY KEY,
-    name TEXT NOT NULL UNIQUE
+    id     BIGSERIAL PRIMARY KEY,
+    name   TEXT NOT NULL,
+    system TEXT NOT NULL DEFAULT '',
+    slug   TEXT,
+    UNIQUE (name, system)
 );
+CREATE UNIQUE INDEX games_slug_key ON games(slug);
 
 -- ── builds ───────────────────────────────────────────────────────────────────
 CREATE TABLE builds (

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "test": "node --import tsx --test tests/*.test.ts",
     "ingest": "tsx scripts/ingest.ts",
+    "import-wiki-games": "tsx scripts/import-wiki-games.ts",
     "attach-repo": "tsx scripts/attach-repo.ts",
     "push-assets": "tsx scripts/push-assets.ts"
   },

--- a/web/scripts/import-wiki-games.ts
+++ b/web/scripts/import-wiki-games.ts
@@ -6,21 +6,30 @@
 //        (env DATABASE_URL)
 //
 // Joins builds to wiki downloads by archive sha1, then per matched build:
-//  - upserts the infobox "game" into games and sets builds.game_id — only
-//    when game_id is NULL, so re-runs never clobber a moderator's assignment;
+//  - upserts the infobox (game, system) pair into games (with its
+//    /games/<slug> segment) and points builds.game_id at it. A NULL game_id
+//    is filled; an existing assignment is migrated only when its current
+//    game NAME equals the wiki-derived one (re-keying to the system-specific
+//    row) — a moderator's different choice is never clobbered;
 //  - renames the build to the article's as-typed File title (underscores and
 //    spaces are interchangeable in MediaWiki titles, so the imported
 //    underscored disk name is "supposed to be" the spaced title). A build
 //    whose name no longer corresponds to its wiki file — i.e. a moderator
 //    renamed it — is left alone. Game names are imported verbatim: infobox
 //    text keeps intentional underscores (WATCH_DOGS), unlike file names.
+// Any games row still missing a slug gets one (base slug, "-<id>" when a
+// near-duplicate spelling took the base).
 // --underscore-unmatched additionally rewrites _ to space in the name of
 // every build whose sha1 is NOT in the map — only safe when every such build
 // is known to carry a pristine wiki filename (e.g. curator_wiki, or strays
 // whose wiki download was replaced after the dump was taken).
+// --prune deletes games no build references afterwards (safe because games
+// exist only through imports and assignments; an unassigned game is dead
+// weight the combobox recreates on demand).
 
 import fs from "node:fs";
 import pg from "pg";
+import { gameSlug } from "../src/lib/slug";
 import { loadDotEnv } from "./dotenv";
 
 interface MapDownload {
@@ -83,13 +92,12 @@ async function main() {
   ).rows as { sha256: string; sha1: string; name: string; game_id: string | null }[];
 
   const renames: { sha256: string; name: string }[] = [];
-  const assigns: { sha256: string; game: string }[] = [];
+  const assigns: { sha256: string; game: string; system: string }[] = [];
   const stats = {
     builds: rows.length,
     matched: 0,
     renamed: 0,
-    game_set: 0,
-    game_already_set: 0,
+    game_assignable: 0,
     no_infobox_game: 0,
     ambiguous_game: 0,
     unmatched: 0,
@@ -124,26 +132,35 @@ async function main() {
       stats.renamed++;
     }
 
-    const games = new Set(
-      [...e.articles]
-        .map((a) => proto.articles[a]?.prototype?.game?.trim())
-        .filter((g): g is string => !!g)
-    );
-    if (b.game_id != null) {
-      stats.game_already_set++;
-    } else if (games.size === 1) {
-      assigns.push({ sha256: b.sha256, game: [...games][0] });
-      stats.game_set++;
-    } else if (games.size > 1) {
+    // Distinct (game, system) pairs across the articles linking this file;
+    // the same title on two systems is two different games.
+    const pairs = new Map<string, { game: string; system: string }>();
+    for (const a of e.articles) {
+      const pr = proto.articles[a]?.prototype;
+      const g = pr?.game?.trim();
+      if (!g) continue;
+      const s = pr?.system?.trim() ?? "";
+      pairs.set(`${g}\0${s}`, { game: g, system: s });
+    }
+    if (pairs.size === 1) {
+      const [p] = pairs.values();
+      assigns.push({ sha256: b.sha256, ...p });
+      stats.game_assignable++;
+    } else if (pairs.size > 1) {
       stats.ambiguous_game++;
-      console.error(`ambiguous game for ${b.name} (${b.sha256.slice(0, 12)}): ${[...games].join(" | ")}`);
+      console.error(
+        `ambiguous game for ${b.name} (${b.sha256.slice(0, 12)}): ` +
+          [...pairs.values()].map((p) => `${p.game} [${p.system}]`).join(" | ")
+      );
     } else {
       stats.no_infobox_game++;
     }
   }
 
-  const gameNames = [...new Set(assigns.map((a) => a.game))].sort();
-  console.log(JSON.stringify({ ...stats, distinct_games: gameNames.length }, null, 2));
+  const pairKeys = new Map<string, { game: string; system: string }>();
+  for (const a of assigns) pairKeys.set(`${a.game}\0${a.system}`, { game: a.game, system: a.system });
+  const distinctPairs = [...pairKeys.values()];
+  console.log(JSON.stringify({ ...stats, distinct_games: distinctPairs.length }, null, 2));
   if (dryRun) {
     const byName = new Map(rows.map((b) => [b.sha256, b.name]));
     for (const r of renames) console.error(`rename: ${byName.get(r.sha256)}  ->  ${r.name}`);
@@ -151,19 +168,27 @@ async function main() {
     return;
   }
 
+  const prune = process.argv.includes("--prune");
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
     const created = await client.query(
-      "INSERT INTO games(name) SELECT unnest($1::text[]) ON CONFLICT (name) DO NOTHING",
-      [gameNames]
+      `INSERT INTO games(name, system)
+       SELECT * FROM unnest($1::text[], $2::text[])
+       ON CONFLICT (name, system) DO NOTHING`,
+      [distinctPairs.map((p) => p.game), distinctPairs.map((p) => p.system)]
     );
-    await client.query(
+    // Fill NULL game_id, and re-key assignments whose current game NAME is
+    // the wiki-derived one (v1 name-only rows migrate to the (name, system)
+    // row); a moderator's different choice stays.
+    const assigned = await client.query(
       `UPDATE builds b SET game_id = g.id
-       FROM unnest($1::text[], $2::text[]) AS u(sha256, game)
-       JOIN games g ON g.name = u.game
-       WHERE b.sha256 = u.sha256 AND b.game_id IS NULL`,
-      [assigns.map((a) => a.sha256), assigns.map((a) => a.game)]
+       FROM unnest($1::text[], $2::text[], $3::text[]) AS u(sha256, game, system)
+       JOIN games g ON g.name = u.game AND g.system = u.system
+       WHERE b.sha256 = u.sha256 AND b.game_id IS DISTINCT FROM g.id
+         AND (b.game_id IS NULL
+              OR EXISTS (SELECT 1 FROM games cur WHERE cur.id = b.game_id AND cur.name = u.game))`,
+      [assigns.map((a) => a.sha256), assigns.map((a) => a.game), assigns.map((a) => a.system)]
     );
     await client.query(
       `UPDATE builds b SET name = u.name
@@ -171,8 +196,38 @@ async function main() {
        WHERE b.sha256 = u.sha256`,
       [renames.map((r) => r.sha256), renames.map((r) => r.name)]
     );
+    const pruned = prune
+      ? (
+          await client.query(
+            "DELETE FROM games g WHERE NOT EXISTS (SELECT 1 FROM builds WHERE game_id = g.id)"
+          )
+        ).rowCount
+      : 0;
+    // Slug backfill for every row still missing one, in id order so the
+    // first spelling keeps the base and later near-duplicates get "-<id>".
+    const taken = new Set(
+      (await client.query("SELECT slug FROM games WHERE slug IS NOT NULL")).rows.map((r) => r.slug as string)
+    );
+    const bare = (
+      await client.query("SELECT id::int AS id, name, system FROM games WHERE slug IS NULL ORDER BY id")
+    ).rows as { id: number; name: string; system: string }[];
+    const slugged = bare.map((g) => {
+      const base = gameSlug(g.name, g.system);
+      const slug = taken.has(base) ? `${base}-${g.id}` : base;
+      taken.add(slug);
+      return { id: g.id, slug };
+    });
+    await client.query(
+      `UPDATE games g SET slug = u.slug
+       FROM unnest($1::int[], $2::text[]) AS u(id, slug)
+       WHERE g.id = u.id`,
+      [slugged.map((s) => s.id), slugged.map((s) => s.slug)]
+    );
     await client.query("COMMIT");
-    console.log(`games created: ${created.rowCount}; game_id set: ${assigns.length}; renamed: ${renames.length}`);
+    console.log(
+      `games created: ${created.rowCount}; game_id set: ${assigned.rowCount}; ` +
+        `renamed: ${renames.length}; slugs filled: ${slugged.length}; pruned: ${pruned}`
+    );
   } catch (e) {
     await client.query("ROLLBACK");
     throw e;

--- a/web/scripts/import-wiki-games.ts
+++ b/web/scripts/import-wiki-games.ts
@@ -1,0 +1,188 @@
+// Import per-build game classification from the Hidden Palace wiki mapping
+// dumps:
+//   wiki-map.json    articles <-> download files (sha1/url/size per download)
+//   wiki-proto.json  article -> {{Prototype}} infobox fields (game, ...)
+// Usage: npm run import-wiki-games -- --map wiki-map.json --proto wiki-proto.json [--dry-run]
+//        (env DATABASE_URL)
+//
+// Joins builds to wiki downloads by archive sha1, then per matched build:
+//  - upserts the infobox "game" into games and sets builds.game_id — only
+//    when game_id is NULL, so re-runs never clobber a moderator's assignment;
+//  - renames the build to the article's as-typed File title (underscores and
+//    spaces are interchangeable in MediaWiki titles, so the imported
+//    underscored disk name is "supposed to be" the spaced title). A build
+//    whose name no longer corresponds to its wiki file — i.e. a moderator
+//    renamed it — is left alone. Game names are imported verbatim: infobox
+//    text keeps intentional underscores (WATCH_DOGS), unlike file names.
+// --underscore-unmatched additionally rewrites _ to space in the name of
+// every build whose sha1 is NOT in the map — only safe when every such build
+// is known to carry a pristine wiki filename (e.g. curator_wiki, or strays
+// whose wiki download was replaced after the dump was taken).
+
+import fs from "node:fs";
+import pg from "pg";
+import { loadDotEnv } from "./dotenv";
+
+interface MapDownload {
+  file: string; // "File:..." title as typed in the article (spaced form)
+  disk_path?: string; // canonical underscored filename on the MinIO box
+  sha1?: string;
+}
+interface WikiMap {
+  articles: Record<string, { url: string; downloads: MapDownload[] }>;
+}
+interface WikiProto {
+  articles: Record<string, { url: string; prototype: Record<string, string> | null }>;
+}
+
+function usage(): never {
+  console.error("usage: tsx scripts/import-wiki-games.ts --map wiki-map.json --proto wiki-proto.json [--dry-run]");
+  process.exit(2);
+}
+
+function arg(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+async function main() {
+  loadDotEnv();
+  const mapPath = arg("--map");
+  const protoPath = arg("--proto");
+  const dryRun = process.argv.includes("--dry-run");
+  if (!mapPath || !protoPath) usage();
+
+  const map = JSON.parse(fs.readFileSync(mapPath, "utf8")) as WikiMap;
+  const proto = JSON.parse(fs.readFileSync(protoPath, "utf8")) as WikiProto;
+
+  // sha1 -> the articles that link the download, the File titles it goes by
+  // (as typed), and its canonical disk filenames.
+  const bySha1 = new Map<string, { articles: Set<string>; files: Set<string>; disk: Set<string> }>();
+  for (const [article, a] of Object.entries(map.articles)) {
+    for (const d of a.downloads) {
+      if (!d.sha1) continue;
+      let e = bySha1.get(d.sha1);
+      if (!e) bySha1.set(d.sha1, (e = { articles: new Set(), files: new Set(), disk: new Set() }));
+      e.articles.add(article);
+      e.files.add(d.file.replace(/^File:/, ""));
+      if (d.disk_path) e.disk.add(d.disk_path.replace(/^.*\//, ""));
+    }
+  }
+
+  // MediaWiki treats _ and whitespace runs as one space in titles, and
+  // uppercases the leading letter on disk; compare under that equivalence.
+  const collapse = (s: string) => s.replace(/[_\s]+/g, " ").trim();
+  const norm = (s: string) => collapse(s).toLowerCase();
+
+  const pool = new pg.Pool({
+    connectionString: process.env.DATABASE_URL || "postgres:///prism_test",
+    max: 4,
+  });
+  const rows = (
+    await pool.query("SELECT sha256, sha1, name, game_id FROM builds")
+  ).rows as { sha256: string; sha1: string; name: string; game_id: string | null }[];
+
+  const renames: { sha256: string; name: string }[] = [];
+  const assigns: { sha256: string; game: string }[] = [];
+  const stats = {
+    builds: rows.length,
+    matched: 0,
+    renamed: 0,
+    game_set: 0,
+    game_already_set: 0,
+    no_infobox_game: 0,
+    ambiguous_game: 0,
+    unmatched: 0,
+  };
+
+  const underscoreUnmatched = process.argv.includes("--underscore-unmatched");
+
+  for (const b of rows) {
+    const e = bySha1.get(b.sha1);
+    if (!e) {
+      stats.unmatched++;
+      if (underscoreUnmatched && b.name.includes("_")) {
+        renames.push({ sha256: b.sha256, name: b.name.replaceAll("_", " ") });
+        stats.renamed++;
+      }
+      continue;
+    }
+    stats.matched++;
+
+    // Prefer the article's as-typed title (it keeps intended casing like
+    // "iCarly" that the disk name uppercases); fall back to the disk name's
+    // own spaced form when the as-typed title is a redirect to a different
+    // file. A name matching neither was chosen deliberately — leave it.
+    const typed = [...e.files].find((f) => norm(f) === norm(b.name));
+    const target = typed
+      ? collapse(typed)
+      : e.disk.has(b.name)
+        ? b.name.replaceAll("_", " ")
+        : undefined;
+    if (target && target !== b.name) {
+      renames.push({ sha256: b.sha256, name: target });
+      stats.renamed++;
+    }
+
+    const games = new Set(
+      [...e.articles]
+        .map((a) => proto.articles[a]?.prototype?.game?.trim())
+        .filter((g): g is string => !!g)
+    );
+    if (b.game_id != null) {
+      stats.game_already_set++;
+    } else if (games.size === 1) {
+      assigns.push({ sha256: b.sha256, game: [...games][0] });
+      stats.game_set++;
+    } else if (games.size > 1) {
+      stats.ambiguous_game++;
+      console.error(`ambiguous game for ${b.name} (${b.sha256.slice(0, 12)}): ${[...games].join(" | ")}`);
+    } else {
+      stats.no_infobox_game++;
+    }
+  }
+
+  const gameNames = [...new Set(assigns.map((a) => a.game))].sort();
+  console.log(JSON.stringify({ ...stats, distinct_games: gameNames.length }, null, 2));
+  if (dryRun) {
+    const byName = new Map(rows.map((b) => [b.sha256, b.name]));
+    for (const r of renames) console.error(`rename: ${byName.get(r.sha256)}  ->  ${r.name}`);
+    await pool.end();
+    return;
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const created = await client.query(
+      "INSERT INTO games(name) SELECT unnest($1::text[]) ON CONFLICT (name) DO NOTHING",
+      [gameNames]
+    );
+    await client.query(
+      `UPDATE builds b SET game_id = g.id
+       FROM unnest($1::text[], $2::text[]) AS u(sha256, game)
+       JOIN games g ON g.name = u.game
+       WHERE b.sha256 = u.sha256 AND b.game_id IS NULL`,
+      [assigns.map((a) => a.sha256), assigns.map((a) => a.game)]
+    );
+    await client.query(
+      `UPDATE builds b SET name = u.name
+       FROM unnest($1::text[], $2::text[]) AS u(sha256, name)
+       WHERE b.sha256 = u.sha256`,
+      [renames.map((r) => r.sha256), renames.map((r) => r.name)]
+    );
+    await client.query("COMMIT");
+    console.log(`games created: ${created.rowCount}; game_id set: ${assigns.length}; renamed: ${renames.length}`);
+  } catch (e) {
+    await client.query("ROLLBACK");
+    throw e;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/web/src/app/api/build/[sha256]/route.ts
+++ b/web/src/app/api/build/[sha256]/route.ts
@@ -2,13 +2,14 @@ import type { NextRequest } from "next/server";
 import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
-import { getBuild, findSimilar, findByEmbeddingOf, getLotBuilds, updateBuildMeta, setLotPrivate } from "@/lib/queries";
+import { getBuild, findSimilar, findByEmbeddingOf, getLotBuilds, updateBuildMeta, setLotPrivate, setBuildGame } from "@/lib/queries";
 import { getModerator, moderationEnabled } from "@/lib/auth";
 import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
 
 const MAX_NAME_LEN = 300;
 const MAX_LOT_LEN = 200;
+const MAX_GAME_LEN = 200;
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -37,10 +38,11 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   return Response.json({ build, similar: { ...similar, text_neighbors } });
 }
 
-// PATCH /api/build/<sha256> { name?, lot?, private?, lotPrivate? } — moderator
+// PATCH /api/build/<sha256> { name?, lot?, private?, lotPrivate?, game? } — moderator
 // metadata edit. `name` renames the build; `lot` assigns it to a display group
 // ("" or null clears); `private` hides the build from public list/search/similar;
-// `lotPrivate` hides/unhides the build's whole lot (current and future members).
+// `lotPrivate` hides/unhides the build's whole lot (current and future members);
+// `game` names the game the build belongs to (created if new; "" or null clears).
 export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
   if (!(await getModerator(request))) {
     return moderationEnabled()
@@ -86,9 +88,19 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
   if (lotPrivate !== undefined && typeof lotPrivate !== "boolean") {
     return Response.json({ error: "lotPrivate must be a boolean" }, { status: 400 });
   }
+  let game: string | null | undefined;
+  if (body.game !== undefined) {
+    if (body.game !== null && typeof body.game !== "string") {
+      return Response.json({ error: "game must be a string or null" }, { status: 400 });
+    }
+    if (typeof body.game === "string" && body.game.length > MAX_GAME_LEN) {
+      return Response.json({ error: `game exceeds ${MAX_GAME_LEN} characters` }, { status: 400 });
+    }
+    game = ((body.game as string | null) ?? "").trim() || null;
+  }
   const hasFields = fields.name !== undefined || fields.lot !== undefined || fields.private !== undefined;
-  if (!hasFields && lotPrivate === undefined) {
-    return Response.json({ error: "nothing to update (name, lot, private and/or lotPrivate required)" }, { status: 400 });
+  if (!hasFields && lotPrivate === undefined && game === undefined) {
+    return Response.json({ error: "nothing to update (name, lot, private, lotPrivate and/or game required)" }, { status: 400 });
   }
 
   const pool = getPool();
@@ -108,6 +120,11 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
   }
   if (lotPrivate !== undefined && effectiveLot) {
     await setLotPrivate(pool, effectiveLot, lotPrivate);
+  }
+  let gameRow: { id: number; name: string } | null | undefined;
+  if (game !== undefined) {
+    gameRow = await setBuildGame(pool, sha256, game);
+    if (gameRow === undefined) return Response.json({ error: "not found" }, { status: 404 });
   }
 
   // Build pages are ISR-cached (revalidate = 3600); surface the edit now. A
@@ -143,5 +160,6 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
     lot: effectiveLot,
     ...(fields.private !== undefined ? { private: fields.private } : {}),
     ...(lotPrivate !== undefined ? { lotPrivate } : {}),
+    ...(game !== undefined ? { game: gameRow?.name ?? null } : {}),
   });
 }

--- a/web/src/app/api/build/[sha256]/route.ts
+++ b/web/src/app/api/build/[sha256]/route.ts
@@ -38,11 +38,12 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   return Response.json({ build, similar: { ...similar, text_neighbors } });
 }
 
-// PATCH /api/build/<sha256> { name?, lot?, private?, lotPrivate?, game? } — moderator
-// metadata edit. `name` renames the build; `lot` assigns it to a display group
-// ("" or null clears); `private` hides the build from public list/search/similar;
-// `lotPrivate` hides/unhides the build's whole lot (current and future members);
-// `game` names the game the build belongs to (created if new; "" or null clears).
+// PATCH /api/build/<sha256> { name?, lot?, private?, lotPrivate?, game?, gameSystem? }
+// — moderator metadata edit. `name` renames the build; `lot` assigns it to a
+// display group ("" or null clears); `private` hides the build from public
+// list/search/similar; `lotPrivate` hides/unhides the build's whole lot
+// (current and future members); `game` (+ optional `gameSystem`) names the
+// game the build belongs to (created if new; "" or null clears).
 export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
   if (!(await getModerator(request))) {
     return moderationEnabled()
@@ -98,6 +99,13 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
     }
     game = ((body.game as string | null) ?? "").trim() || null;
   }
+  if (body.gameSystem !== undefined && typeof body.gameSystem !== "string") {
+    return Response.json({ error: "gameSystem must be a string" }, { status: 400 });
+  }
+  const gameSystem = ((body.gameSystem as string | undefined) ?? "").trim();
+  if (gameSystem.length > MAX_GAME_LEN) {
+    return Response.json({ error: `gameSystem exceeds ${MAX_GAME_LEN} characters` }, { status: 400 });
+  }
   const hasFields = fields.name !== undefined || fields.lot !== undefined || fields.private !== undefined;
   if (!hasFields && lotPrivate === undefined && game === undefined) {
     return Response.json({ error: "nothing to update (name, lot, private, lotPrivate and/or game required)" }, { status: 400 });
@@ -121,9 +129,9 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
   if (lotPrivate !== undefined && effectiveLot) {
     await setLotPrivate(pool, effectiveLot, lotPrivate);
   }
-  let gameRow: { id: number; name: string } | null | undefined;
+  let gameRow: { id: number; name: string; system: string; slug: string | null } | null | undefined;
   if (game !== undefined) {
-    gameRow = await setBuildGame(pool, sha256, game);
+    gameRow = await setBuildGame(pool, sha256, game, gameSystem);
     if (gameRow === undefined) return Response.json({ error: "not found" }, { status: 404 });
   }
 
@@ -160,6 +168,8 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
     lot: effectiveLot,
     ...(fields.private !== undefined ? { private: fields.private } : {}),
     ...(lotPrivate !== undefined ? { lotPrivate } : {}),
-    ...(game !== undefined ? { game: gameRow?.name ?? null } : {}),
+    ...(game !== undefined
+      ? { game: gameRow?.name ?? null, gameSystem: gameRow?.system ?? null, gameSlug: gameRow?.slug ?? null }
+      : {}),
   });
 }

--- a/web/src/app/api/games/route.ts
+++ b/web/src/app/api/games/route.ts
@@ -1,0 +1,15 @@
+import type { NextRequest } from "next/server";
+import { getPool } from "@/lib/db";
+import { searchGames } from "@/lib/queries";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// GET /api/games?q=<term> — game-name suggestions for the moderator combobox
+// on the build page. Game names are public metadata (they come from wiki
+// articles), so no auth; assignment itself is gated in the PATCH route.
+export async function GET(request: NextRequest) {
+  const q = request.nextUrl.searchParams.get("q") ?? "";
+  const games = await searchGames(getPool(), q);
+  return Response.json({ games });
+}

--- a/web/src/app/builds/[buildId]/ModeratorTools.tsx
+++ b/web/src/app/builds/[buildId]/ModeratorTools.tsx
@@ -18,6 +18,8 @@ interface Props {
   lots: string[];
   /** The game this build is assigned to (games.name), if any. */
   game: string | null;
+  /** The assigned game's system ("Xbox 360", '' unknown). */
+  gameSystem: string | null;
   /** The build's own private flag. */
   privateFlag: boolean;
   /** Whether the build's lot is private (hides every build in it). */
@@ -31,14 +33,15 @@ interface Props {
 // belongs to a moderator group. Purely cosmetic gating — the PATCH route
 // re-checks credentials server-side. The parent keys this component on
 // name+lot, so a router.refresh() after a save remounts it with fresh values.
-export default function ModeratorTools({ sha256, name, lot, lots, game, privateFlag, lotPrivate, skips }: Props) {
+export default function ModeratorTools({ sha256, name, lot, lots, game, gameSystem, privateFlag, lotPrivate, skips }: Props) {
   const router = useRouter();
   const token = useSyncExternalStore(noSubscribe, clientToken, serverToken);
   const [wikiModerator, setWikiModerator] = useState(false);
   const [nameInput, setNameInput] = useState(name);
   const [lotInput, setLotInput] = useState(lot ?? "");
   const [gameInput, setGameInput] = useState(game ?? "");
-  const [gameOpts, setGameOpts] = useState<string[]>([]);
+  const [gameSysInput, setGameSysInput] = useState(gameSystem ?? "");
+  const [gameOpts, setGameOpts] = useState<{ name: string; system: string }[]>([]);
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState("");
 
@@ -64,7 +67,11 @@ export default function ModeratorTools({ sha256, name, lot, lots, game, privateF
     const t = setTimeout(() => {
       fetch(`/api/games?q=${encodeURIComponent(gameInput.trim())}`, { cache: "no-store" })
         .then((r) => r.json())
-        .then((d) => !cancelled && setGameOpts((d.games ?? []).map((g: { name: string }) => g.name)))
+        .then(
+          (d) =>
+            !cancelled &&
+            setGameOpts((d.games ?? []).map((g: { name: string; system: string }) => ({ name: g.name, system: g.system })))
+        )
         .catch(() => {});
     }, 200);
     return () => {
@@ -78,7 +85,7 @@ export default function ModeratorTools({ sha256, name, lot, lots, game, privateF
   async function saveTo(
     path: string,
     patch:
-      | { name?: string; lot?: string | null; game?: string | null; private?: boolean; lotPrivate?: boolean }
+      | { name?: string; lot?: string | null; game?: string | null; gameSystem?: string; private?: boolean; lotPrivate?: boolean }
       | { notes?: boolean; screenshots?: boolean; video?: boolean; physical?: boolean }
   ) {
     setBusy(true);
@@ -106,14 +113,21 @@ export default function ModeratorTools({ sha256, name, lot, lots, game, privateF
     }
   }
 
-  const save = (patch: { name?: string; lot?: string | null; game?: string | null; private?: boolean; lotPrivate?: boolean }) =>
+  const save = (patch: { name?: string; lot?: string | null; game?: string | null; gameSystem?: string; private?: boolean; lotPrivate?: boolean }) =>
     saveTo(`/api/build/${sha256}`, patch);
   const saveSkip = (patch: { notes?: boolean; screenshots?: boolean; video?: boolean; physical?: boolean }) =>
     saveTo(`/api/build/${sha256}/skip`, patch);
 
   const nameDirty = nameInput.trim() !== "" && nameInput.trim() !== name;
   const lotDirty = (lotInput.trim() || null) !== lot;
-  const gameDirty = (gameInput.trim() || null) !== game;
+  const gameDirty =
+    (gameInput.trim() || null) !== game || (gameInput.trim() !== "" && gameSysInput.trim() !== (gameSystem ?? ""));
+  const saveGame = () =>
+    save(gameInput.trim() ? { game: gameInput.trim(), gameSystem: gameSysInput.trim() } : { game: null });
+  // System suggestions: systems the typed name is known under (all systems
+  // from the current suggestion batch when the name doesn't match exactly).
+  const exact = gameOpts.filter((g) => g.name === gameInput.trim());
+  const sysOpts = [...new Set((exact.length ? exact : gameOpts).map((g) => g.system).filter(Boolean))];
 
   return (
     <section className="mt-6 rounded-md border border-dashed border-neutral-300 px-4 py-3 dark:border-neutral-700">
@@ -163,7 +177,9 @@ export default function ModeratorTools({ sha256, name, lot, lots, game, privateF
           </div>
         </label>
         {/* Combobox: pick one of the server-suggested games or type a new
-            title — saving an unknown name creates the game. */}
+            title — saving an unknown (name, system) pair creates the game.
+            The system box suggests the systems the typed title is known
+            under; different systems are different games. */}
         <label className="flex flex-col gap-1">
           <span className="text-xs text-neutral-500">Game</span>
           <div className="flex gap-2">
@@ -171,17 +187,30 @@ export default function ModeratorTools({ sha256, name, lot, lots, game, privateF
               list="prism-game-names"
               value={gameInput}
               onChange={(e) => setGameInput(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && gameDirty && !busy && save({ game: gameInput.trim() || null })}
+              onKeyDown={(e) => e.key === "Enter" && gameDirty && !busy && saveGame()}
               placeholder="e.g. Sonic Adventure"
               className="h-9 w-72 max-w-full rounded-md border border-neutral-300 bg-transparent px-3 outline-none placeholder:text-neutral-400 focus:border-neutral-500 dark:border-neutral-700"
             />
             <datalist id="prism-game-names">
-              {gameOpts.map((g) => (
-                <option key={g} value={g} />
+              {[...new Set(gameOpts.map((g) => g.name))].map((n) => (
+                <option key={n} value={n} />
+              ))}
+            </datalist>
+            <input
+              list="prism-game-systems"
+              value={gameSysInput}
+              onChange={(e) => setGameSysInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && gameDirty && !busy && saveGame()}
+              placeholder="System"
+              className="h-9 w-36 max-w-full rounded-md border border-neutral-300 bg-transparent px-3 outline-none placeholder:text-neutral-400 focus:border-neutral-500 dark:border-neutral-700"
+            />
+            <datalist id="prism-game-systems">
+              {sysOpts.map((s) => (
+                <option key={s} value={s} />
               ))}
             </datalist>
             <button
-              onClick={() => save({ game: gameInput.trim() || null })}
+              onClick={saveGame}
               disabled={busy || !gameDirty}
               className="rounded-md border border-neutral-300 px-3 py-1 font-medium hover:border-neutral-500 disabled:opacity-40 disabled:hover:border-neutral-300 dark:border-neutral-700"
             >

--- a/web/src/app/builds/[buildId]/ModeratorTools.tsx
+++ b/web/src/app/builds/[buildId]/ModeratorTools.tsx
@@ -16,6 +16,8 @@ interface Props {
   lot: string | null;
   /** Existing lot names, offered as suggestions when assigning. */
   lots: string[];
+  /** The game this build is assigned to (games.name), if any. */
+  game: string | null;
   /** The build's own private flag. */
   privateFlag: boolean;
   /** Whether the build's lot is private (hides every build in it). */
@@ -29,12 +31,14 @@ interface Props {
 // belongs to a moderator group. Purely cosmetic gating — the PATCH route
 // re-checks credentials server-side. The parent keys this component on
 // name+lot, so a router.refresh() after a save remounts it with fresh values.
-export default function ModeratorTools({ sha256, name, lot, lots, privateFlag, lotPrivate, skips }: Props) {
+export default function ModeratorTools({ sha256, name, lot, lots, game, privateFlag, lotPrivate, skips }: Props) {
   const router = useRouter();
   const token = useSyncExternalStore(noSubscribe, clientToken, serverToken);
   const [wikiModerator, setWikiModerator] = useState(false);
   const [nameInput, setNameInput] = useState(name);
   const [lotInput, setLotInput] = useState(lot ?? "");
+  const [gameInput, setGameInput] = useState(game ?? "");
+  const [gameOpts, setGameOpts] = useState<string[]>([]);
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState("");
 
@@ -50,12 +54,31 @@ export default function ModeratorTools({ sha256, name, lot, lots, privateFlag, l
     };
   }, [token]);
 
-  if (!token && !wikiModerator) return null;
+  // Game suggestions come from the server as you type (there are thousands of
+  // games — too many to embed like the lot list). Debounced; stale responses
+  // are dropped so a slow early query can't overwrite a fresh one.
+  const visible = !!token || wikiModerator;
+  useEffect(() => {
+    if (!visible) return;
+    let cancelled = false;
+    const t = setTimeout(() => {
+      fetch(`/api/games?q=${encodeURIComponent(gameInput.trim())}`, { cache: "no-store" })
+        .then((r) => r.json())
+        .then((d) => !cancelled && setGameOpts((d.games ?? []).map((g: { name: string }) => g.name)))
+        .catch(() => {});
+    }, 200);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [gameInput, visible]);
+
+  if (!visible) return null;
 
   async function saveTo(
     path: string,
     patch:
-      | { name?: string; lot?: string | null; private?: boolean; lotPrivate?: boolean }
+      | { name?: string; lot?: string | null; game?: string | null; private?: boolean; lotPrivate?: boolean }
       | { notes?: boolean; screenshots?: boolean; video?: boolean; physical?: boolean }
   ) {
     setBusy(true);
@@ -83,13 +106,14 @@ export default function ModeratorTools({ sha256, name, lot, lots, privateFlag, l
     }
   }
 
-  const save = (patch: { name?: string; lot?: string | null; private?: boolean; lotPrivate?: boolean }) =>
+  const save = (patch: { name?: string; lot?: string | null; game?: string | null; private?: boolean; lotPrivate?: boolean }) =>
     saveTo(`/api/build/${sha256}`, patch);
   const saveSkip = (patch: { notes?: boolean; screenshots?: boolean; video?: boolean; physical?: boolean }) =>
     saveTo(`/api/build/${sha256}/skip`, patch);
 
   const nameDirty = nameInput.trim() !== "" && nameInput.trim() !== name;
   const lotDirty = (lotInput.trim() || null) !== lot;
+  const gameDirty = (gameInput.trim() || null) !== game;
 
   return (
     <section className="mt-6 rounded-md border border-dashed border-neutral-300 px-4 py-3 dark:border-neutral-700">
@@ -135,6 +159,33 @@ export default function ModeratorTools({ sha256, name, lot, lots, privateFlag, l
               className="rounded-md border border-neutral-300 px-3 py-1 font-medium hover:border-neutral-500 disabled:opacity-40 disabled:hover:border-neutral-300 dark:border-neutral-700"
             >
               {lotInput.trim() ? "Set lot" : "Clear lot"}
+            </button>
+          </div>
+        </label>
+        {/* Combobox: pick one of the server-suggested games or type a new
+            title — saving an unknown name creates the game. */}
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-neutral-500">Game</span>
+          <div className="flex gap-2">
+            <input
+              list="prism-game-names"
+              value={gameInput}
+              onChange={(e) => setGameInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && gameDirty && !busy && save({ game: gameInput.trim() || null })}
+              placeholder="e.g. Sonic Adventure"
+              className="h-9 w-72 max-w-full rounded-md border border-neutral-300 bg-transparent px-3 outline-none placeholder:text-neutral-400 focus:border-neutral-500 dark:border-neutral-700"
+            />
+            <datalist id="prism-game-names">
+              {gameOpts.map((g) => (
+                <option key={g} value={g} />
+              ))}
+            </datalist>
+            <button
+              onClick={() => save({ game: gameInput.trim() || null })}
+              disabled={busy || !gameDirty}
+              className="rounded-md border border-neutral-300 px-3 py-1 font-medium hover:border-neutral-500 disabled:opacity-40 disabled:hover:border-neutral-300 dark:border-neutral-700"
+            >
+              {gameInput.trim() ? "Set game" : "Clear game"}
             </button>
           </div>
         </label>

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -197,11 +197,19 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
         <Chip>{humanSize(build.total_size)}</Chip>
         <Chip>profile {build.fingerprint_profile}</Chip>
         {assets.length > 0 && <Chip>{assets.length} assets</Chip>}
-        {build.game && (
-          <span className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 dark:bg-sky-900/40 dark:text-sky-200">
-            {build.game}
-          </span>
-        )}
+        {build.game &&
+          (build.game_slug ? (
+            <Link
+              href={`/games/${build.game_slug}`}
+              className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 hover:underline dark:bg-sky-900/40 dark:text-sky-200"
+            >
+              {build.game}
+            </Link>
+          ) : (
+            <span className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 dark:bg-sky-900/40 dark:text-sky-200">
+              {build.game}
+            </span>
+          ))}
         {build.lot && (
           <Link
             href={`/builds?lot=${encodeURIComponent(build.lot)}`}
@@ -223,12 +231,13 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
       </dl>
 
       <ModeratorTools
-        key={`${build.name}\0${build.lot ?? ""}\0${build.game ?? ""}\0${build.private}\0${lotPrivate}\0${JSON.stringify(skips)}`}
+        key={`${build.name}\0${build.lot ?? ""}\0${build.game ?? ""}\0${build.game_system ?? ""}\0${build.private}\0${lotPrivate}\0${JSON.stringify(skips)}`}
         sha256={build.sha256}
         name={build.name}
         lot={build.lot}
         lots={lots}
         game={build.game}
+        gameSystem={build.game_system}
         privateFlag={build.private}
         lotPrivate={lotPrivate}
         skips={skips}

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -197,6 +197,11 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
         <Chip>{humanSize(build.total_size)}</Chip>
         <Chip>profile {build.fingerprint_profile}</Chip>
         {assets.length > 0 && <Chip>{assets.length} assets</Chip>}
+        {build.game && (
+          <span className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 dark:bg-sky-900/40 dark:text-sky-200">
+            {build.game}
+          </span>
+        )}
         {build.lot && (
           <Link
             href={`/builds?lot=${encodeURIComponent(build.lot)}`}
@@ -218,11 +223,12 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
       </dl>
 
       <ModeratorTools
-        key={`${build.name}\0${build.lot ?? ""}\0${build.private}\0${lotPrivate}\0${JSON.stringify(skips)}`}
+        key={`${build.name}\0${build.lot ?? ""}\0${build.game ?? ""}\0${build.private}\0${lotPrivate}\0${JSON.stringify(skips)}`}
         sha256={build.sha256}
         name={build.name}
         lot={build.lot}
         lots={lots}
+        game={build.game}
         privateFlag={build.private}
         lotPrivate={lotPrivate}
         skips={skips}

--- a/web/src/app/games/[slug]/page.tsx
+++ b/web/src/app/games/[slug]/page.tsx
@@ -1,0 +1,76 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getPool } from "@/lib/db";
+import { getGameBySlug, getGameBuilds } from "@/lib/queries";
+import { humanSize } from "@/lib/meta";
+import { buildHref } from "@/lib/slug";
+
+export const runtime = "nodejs";
+// Assignments change through moderation, not ingest; render fresh each time
+// (one indexed query, nowhere near the page budget).
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { slug } = await params;
+  const game = await getGameBySlug(getPool(), decodeURIComponent(slug));
+  if (!game) return {};
+  const title = game.system ? `${game.name} (${game.system})` : game.name;
+  return { title: `${title} · Hidden Palace` };
+}
+
+// /games/<slug> — every visible build of one game, oldest first. The slug is
+// <name>--<system> (name alone when the system is unknown); private builds
+// stay hidden, exactly like the /builds browser.
+export default async function GamePage({ params }: Params) {
+  const { slug } = await params;
+  const pool = getPool();
+  const game = await getGameBySlug(pool, decodeURIComponent(slug));
+  if (!game) notFound();
+
+  const builds = await getGameBuilds(pool, game.id);
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-10 sm:px-8">
+      <Link href="/builds" className="text-sm text-neutral-500 hover:underline">&larr; All builds</Link>
+      <h1 className="mt-3 text-2xl font-semibold tracking-tight">{game.name}</h1>
+      <div className="mt-2 flex flex-wrap gap-2 text-xs">
+        {game.system && (
+          <span className="rounded bg-neutral-100 px-1.5 py-0.5 font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+            {game.system}
+          </span>
+        )}
+        <span className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 dark:bg-sky-900/40 dark:text-sky-200">
+          {builds.length} {builds.length === 1 ? "build" : "builds"}
+        </span>
+      </div>
+
+      {builds.length === 0 ? (
+        <p className="mt-8 text-sm text-neutral-500">No public builds for this game.</p>
+      ) : (
+        <ul className="mt-6 divide-y divide-neutral-200 dark:divide-neutral-800">
+          {builds.map((b) => (
+            <li key={b.sha256}>
+              <Link
+                href={buildHref(b.sha256, b.name)}
+                className="flex flex-wrap items-baseline gap-x-4 gap-y-1 py-2.5 hover:bg-neutral-50 dark:hover:bg-neutral-900"
+              >
+                <span className="min-w-0 flex-1 break-words font-medium">{b.name}</span>
+                <span className="shrink-0 text-xs tabular-nums text-neutral-500">
+                  {b.build_date ? b.build_date.slice(0, 10) : "—"}
+                </span>
+                <span className="w-20 shrink-0 text-right text-xs tabular-nums text-neutral-500">
+                  {humanSize(b.total_size)}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -502,6 +502,10 @@ export interface BuildRow {
   /** Hidden from public list/search/similar (the build's own flag; a private
    *  lot hides its builds without setting this). */
   private: boolean;
+  /** The game this is a build of (games.id), wiki import / moderator edit. */
+  game_id: number | null;
+  /** The game's display name (joined from games). */
+  game: string | null;
 }
 
 export interface BuildListItem {
@@ -753,9 +757,11 @@ export async function getBuildMeta(pool: Pool, sha256: string): Promise<BuildMet
 /// Fetch one stored build (with its full canonical record) by sha256.
 export async function getBuild(pool: Pool, sha256: string): Promise<BuildRow | null> {
   const r = await pool.query(
-    `SELECT sha256, name, system, size, md5, sha1, content_hash, file_count,
-            total_size, fingerprint_profile, ingested_at, record, lot, private
-     FROM builds WHERE sha256=$1`,
+    `SELECT b.sha256, b.name, b.system, b.size, b.md5, b.sha1, b.content_hash, b.file_count,
+            b.total_size, b.fingerprint_profile, b.ingested_at, b.record, b.lot, b.private,
+            b.game_id::int AS game_id, g.name AS game
+     FROM builds b LEFT JOIN games g ON g.id = b.game_id
+     WHERE b.sha256=$1`,
     [sha256]
   );
   return (r.rows[0] as BuildRow) ?? null;
@@ -817,6 +823,50 @@ export async function listLots(pool: Pool): Promise<string[]> {
      ORDER BY lot`
   );
   return r.rows.map((row) => row.lot as string);
+}
+
+export interface GameRow {
+  id: number;
+  name: string;
+}
+
+/** Game-name suggestions for the moderator combobox: substring match ranked
+ *  by trigram similarity, alphabetical when the query is empty. The games
+ *  table is small (thousands), so ILIKE without an index is fine. */
+export async function searchGames(pool: Pool, q: string, limit = 20): Promise<GameRow[]> {
+  const t = q.trim();
+  const r = t
+    ? await pool.query(
+        `SELECT id::int AS id, name FROM games
+         WHERE name ILIKE $1
+         ORDER BY similarity(name, $2) DESC, lower(name) LIMIT $3`,
+        ["%" + t.replace(/([\\%_])/g, "\\$1") + "%", t, limit]
+      )
+    : await pool.query("SELECT id::int AS id, name FROM games ORDER BY lower(name) LIMIT $1", [limit]);
+  return r.rows as GameRow[];
+}
+
+/// Moderator game assignment: null clears; a name upserts into games (so
+/// typing a new title creates it) and points the build at it. Returns the
+/// resulting game, or undefined when the build doesn't exist.
+export async function setBuildGame(
+  pool: Pool,
+  sha256: string,
+  game: string | null
+): Promise<GameRow | null | undefined> {
+  if (game === null) {
+    const r = await pool.query("UPDATE builds SET game_id=NULL WHERE sha256=$1 RETURNING sha256", [sha256]);
+    return r.rows.length ? null : undefined;
+  }
+  const g = await pool.query(
+    `INSERT INTO games(name) VALUES ($1)
+     ON CONFLICT (name) DO UPDATE SET name=excluded.name
+     RETURNING id::int AS id, name`,
+    [game]
+  );
+  const row = g.rows[0] as GameRow;
+  const r = await pool.query("UPDATE builds SET game_id=$2 WHERE sha256=$1 RETURNING sha256", [sha256, row.id]);
+  return r.rows.length ? row : undefined;
 }
 
 /** Whether a lot is hidden from non-moderators. */

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -2,7 +2,7 @@
 
 import type { Pool } from "pg";
 import { minhashJaccard, arrayLit, type QueryFeatures, type AudioTrack } from "./fingerprint";
-import { slugify } from "./slug";
+import { slugify, gameSlug } from "./slug";
 import { tlshDiff } from "./tlsh";
 import type { BuildRecord, SimilarityResult } from "./types";
 import type { FusedBuild, TierKey } from "./tiers";
@@ -506,6 +506,9 @@ export interface BuildRow {
   game_id: number | null;
   /** The game's display name (joined from games). */
   game: string | null;
+  /** The game's system ("Xbox 360", '' unknown) and /games/<slug> segment. */
+  game_system: string | null;
+  game_slug: string | null;
 }
 
 export interface BuildListItem {
@@ -759,7 +762,7 @@ export async function getBuild(pool: Pool, sha256: string): Promise<BuildRow | n
   const r = await pool.query(
     `SELECT b.sha256, b.name, b.system, b.size, b.md5, b.sha1, b.content_hash, b.file_count,
             b.total_size, b.fingerprint_profile, b.ingested_at, b.record, b.lot, b.private,
-            b.game_id::int AS game_id, g.name AS game
+            b.game_id::int AS game_id, g.name AS game, g.system AS game_system, g.slug AS game_slug
      FROM builds b LEFT JOIN games g ON g.id = b.game_id
      WHERE b.sha256=$1`,
     [sha256]
@@ -828,43 +831,86 @@ export async function listLots(pool: Pool): Promise<string[]> {
 export interface GameRow {
   id: number;
   name: string;
+  /** Display system from the wiki infobox ("Xbox 360"), '' when unknown. */
+  system: string;
+  /** /games/<slug> path segment; NULL only on rows not yet visited by the
+   *  import or a moderator assignment. */
+  slug: string | null;
 }
 
-/** Game-name suggestions for the moderator combobox: substring match ranked
- *  by trigram similarity, alphabetical when the query is empty. The games
- *  table is small (thousands), so ILIKE without an index is fine. */
+/** Game suggestions for the moderator combobox: substring match ranked by
+ *  trigram similarity, alphabetical when the query is empty. The games table
+ *  is small (thousands), so ILIKE without an index is fine. */
 export async function searchGames(pool: Pool, q: string, limit = 20): Promise<GameRow[]> {
   const t = q.trim();
   const r = t
     ? await pool.query(
-        `SELECT id::int AS id, name FROM games
+        `SELECT id::int AS id, name, system, slug FROM games
          WHERE name ILIKE $1
-         ORDER BY similarity(name, $2) DESC, lower(name) LIMIT $3`,
+         ORDER BY similarity(name, $2) DESC, lower(name), system LIMIT $3`,
         ["%" + t.replace(/([\\%_])/g, "\\$1") + "%", t, limit]
       )
-    : await pool.query("SELECT id::int AS id, name FROM games ORDER BY lower(name) LIMIT $1", [limit]);
+    : await pool.query("SELECT id::int AS id, name, system, slug FROM games ORDER BY lower(name), system LIMIT $1", [limit]);
   return r.rows as GameRow[];
 }
 
-/// Moderator game assignment: null clears; a name upserts into games (so
-/// typing a new title creates it) and points the build at it. Returns the
-/// resulting game, or undefined when the build doesn't exist.
+/** Resolve a /games/<slug> segment to its game. */
+export async function getGameBySlug(pool: Pool, slug: string): Promise<GameRow | null> {
+  const r = await pool.query("SELECT id::int AS id, name, system, slug FROM games WHERE slug=$1", [slug]);
+  return (r.rows[0] as GameRow) ?? null;
+}
+
+/// All visible builds of a game, oldest prototype first (missing dates last).
+/// Public surface — private builds stay hidden (visibleSql).
+export async function getGameBuilds(pool: Pool, gameId: number, includePrivate = false): Promise<BuildListItem[]> {
+  const r = await pool.query(
+    `SELECT sha256, name, system, file_count, total_size, ingested_at, build_date, lot
+     FROM builds WHERE game_id=$1 AND ${includePrivate ? "TRUE" : visibleSql("builds")}
+     ORDER BY build_date NULLS LAST, lower(name)`,
+    [gameId]
+  );
+  return r.rows as BuildListItem[];
+}
+
+/** Fill a game's slug if still NULL: the computed base, or base-<id> when a
+ *  near-duplicate spelling already claimed the base. */
+async function ensureGameSlug(pool: Pool, row: GameRow): Promise<GameRow> {
+  if (row.slug) return row;
+  const base = gameSlug(row.name, row.system);
+  const u = await pool.query(
+    `UPDATE games SET slug=$2 WHERE id=$1 AND slug IS NULL
+       AND NOT EXISTS (SELECT 1 FROM games WHERE slug=$2 AND id<>$1)
+     RETURNING slug`,
+    [row.id, base]
+  );
+  if (u.rows.length) return { ...row, slug: u.rows[0].slug as string };
+  const u2 = await pool.query(
+    "UPDATE games SET slug=$2 WHERE id=$1 AND slug IS NULL RETURNING slug",
+    [row.id, `${base}-${row.id}`]
+  );
+  return { ...row, slug: (u2.rows[0]?.slug as string) ?? row.slug };
+}
+
+/// Moderator game assignment: null clears; a (name, system) upserts into
+/// games (so typing a new title creates it) and points the build at it.
+/// Returns the resulting game, or undefined when the build doesn't exist.
 export async function setBuildGame(
   pool: Pool,
   sha256: string,
-  game: string | null
+  game: string | null,
+  system = ""
 ): Promise<GameRow | null | undefined> {
   if (game === null) {
     const r = await pool.query("UPDATE builds SET game_id=NULL WHERE sha256=$1 RETURNING sha256", [sha256]);
     return r.rows.length ? null : undefined;
   }
   const g = await pool.query(
-    `INSERT INTO games(name) VALUES ($1)
-     ON CONFLICT (name) DO UPDATE SET name=excluded.name
-     RETURNING id::int AS id, name`,
-    [game]
+    `INSERT INTO games(name, system) VALUES ($1, $2)
+     ON CONFLICT (name, system) DO UPDATE SET name=excluded.name
+     RETURNING id::int AS id, name, system, slug`,
+    [game, system]
   );
-  const row = g.rows[0] as GameRow;
+  const row = await ensureGameSlug(pool, g.rows[0] as GameRow);
   const r = await pool.query("UPDATE builds SET game_id=$2 WHERE sha256=$1 RETURNING sha256", [sha256, row.id]);
   return r.rows.length ? row : undefined;
 }

--- a/web/src/lib/slug.ts
+++ b/web/src/lib/slug.ts
@@ -23,6 +23,16 @@ export function slugify(name: string): string {
     .replace(/-+$/, "");
 }
 
+/** The /games/<slug> segment: name slug, "--" + system slug when the system
+ *  is known. Slugify collapses dash runs, so "--" can never occur inside a
+ *  part — the delimiter is unambiguous. Uniqueness is enforced at insert
+ *  (colliding spellings get a "-<id>" suffix appended). */
+export function gameSlug(name: string, system = ""): string {
+  const n = slugify(name);
+  const s = slugify(system);
+  return s ? `${n}--${s}` : n;
+}
+
 /** The canonical /builds/ path segment: "<short sha>-<slug>" (short sha alone for empty slugs). */
 export function canonicalBuildId(sha256: string, name: string): string {
   const short = sha256.slice(0, SHORT_SHA_LEN);


### PR DESCRIPTION
Adds a games table and builds.game_id, with a game chip on the build page and a moderator combobox that assigns an existing game or creates a new one by name. Suggestions come from GET /api/games and assignment goes through the existing moderator gated PATCH.

scripts/import-wiki-games.ts seeds the data from the wiki mapping dumps by archive sha1 (6,312 games across 15,711 builds locally) and converts imported underscore names to their spaced wiki titles. Migration 008 applies to every prism DB, and game ids are per database, so any cross DB copy of builds rows must remap game_id by name.