### PR TITLE
Add game asset viewer and bulk edits

### DIFF
--- a/web/db/migrations/010-asset-dates.sql
+++ b/web/db/migrations/010-asset-dates.sql
@@ -1,0 +1,10 @@
+-- Per-asset file date (the timestamp of the file inside the build, from the
+-- record's contents tree), for the game pages' month timeline. TEXT in the
+-- record's own "YYYY-MM-DD HH:MM:SS" shape, like builds.build_date; NULL
+-- when the container format carries no dates. Filled at ingest; existing
+-- rows are backfilled by scripts/backfill-asset-dates.ts.
+--
+-- Idempotent, safe to re-run. Apply to every prism DB:
+--   psql -d <db> -f db/migrations/010-asset-dates.sql
+
+ALTER TABLE build_asset ADD COLUMN IF NOT EXISTS file_date TEXT;

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -99,6 +99,7 @@ CREATE TABLE build_asset (
     size         BIGINT NOT NULL,         -- stored blob size (a head snippet's, not the file's)
     mime         TEXT NOT NULL,           -- as served; text is always text/plain
     kind         TEXT NOT NULL,           -- image|audio|video|source|text|binary
+    file_date    TEXT,                    -- the file's own timestamp from the record contents (month timeline)
     PRIMARY KEY (build_sha256, path)
 );
 CREATE INDEX idx_build_asset_sha256 ON build_asset(sha256);

--- a/web/scripts/backfill-asset-dates.ts
+++ b/web/scripts/backfill-asset-dates.ts
@@ -1,0 +1,57 @@
+// Fill build_asset.file_date for rows ingested before migration 010, from
+// each build's record contents tree (the same mapping ingest now applies).
+// Usage: npx tsx scripts/backfill-asset-dates.ts [--all]   (env DATABASE_URL)
+// By default only NULL file_date rows are touched; --all recomputes every row.
+
+import pg from "pg";
+import { assetFileDates } from "../src/lib/ingest";
+import type { Node } from "../src/lib/types";
+import { loadDotEnv } from "./dotenv";
+
+async function main() {
+  loadDotEnv();
+  const all = process.argv.includes("--all");
+  const pool = new pg.Pool({
+    connectionString: process.env.DATABASE_URL || "postgres:///prism_test",
+    max: 2,
+  });
+  const builds = (
+    await pool.query(
+      `SELECT DISTINCT build_sha256 AS sha FROM build_asset ${all ? "" : "WHERE file_date IS NULL"} ORDER BY 1`
+    )
+  ).rows as { sha: string }[];
+
+  let updated = 0;
+  for (const { sha } of builds) {
+    const r = await pool.query("SELECT record->'contents' AS contents FROM builds WHERE sha256=$1", [sha]);
+    const contents = (r.rows[0]?.contents ?? []) as Node[];
+    const dates = assetFileDates(contents);
+    const paths = (
+      await pool.query(
+        `SELECT path FROM build_asset WHERE build_sha256=$1 ${all ? "" : "AND file_date IS NULL"}`,
+        [sha]
+      )
+    ).rows.map((x) => x.path as string);
+    const pairs = paths.flatMap((p) => {
+      const d = dates.get(p);
+      return d ? [{ p, d }] : [];
+    });
+    if (pairs.length) {
+      const res = await pool.query(
+        `UPDATE build_asset b SET file_date = u.d
+         FROM unnest($2::text[], $3::text[]) AS u(p, d)
+         WHERE b.build_sha256=$1 AND b.path = u.p`,
+        [sha, pairs.map((x) => x.p), pairs.map((x) => x.d)]
+      );
+      updated += res.rowCount ?? 0;
+    }
+    console.log(`${sha.slice(0, 10)}: ${pairs.length}/${paths.length} dated`);
+  }
+  console.log(`updated ${updated} rows across ${builds.length} builds`);
+  await pool.end();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/web/src/app/api/builds/route.ts
+++ b/web/src/app/api/builds/route.ts
@@ -1,0 +1,91 @@
+import type { NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getPool } from "@/lib/db";
+import { bulkUpdateBuilds } from "@/lib/queries";
+import { getModerator, moderationEnabled } from "@/lib/auth";
+import { buildHref } from "@/lib/slug";
+import { isSha256 } from "@/lib/validate";
+
+const MAX_BATCH = 500;
+const MAX_GAME_LEN = 200;
+const MAX_LOT_LEN = 200;
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// POST /api/builds { sha256s: [...], game?, gameSystem?, lot? } — bulk
+// moderator edit: assign or clear the game and/or lot of many builds at
+// once (the mass-apply bar on the build tables). Semantics per field match
+// PATCH /api/build/<sha256>; unknown sha256s are skipped, the response
+// carries how many rows actually changed.
+export async function POST(request: NextRequest) {
+  if (!(await getModerator(request))) {
+    return moderationEnabled()
+      ? Response.json({ error: "unauthorized" }, { status: 401 })
+      : Response.json({ error: "moderation disabled (set MODERATION_TOKEN or WIKI_API_URL)" }, { status: 403 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const sha256s = body.sha256s;
+  if (!Array.isArray(sha256s) || sha256s.length === 0 || !sha256s.every((s) => typeof s === "string" && isSha256(s))) {
+    return Response.json({ error: "sha256s must be a non-empty array of sha256 strings" }, { status: 400 });
+  }
+  if (sha256s.length > MAX_BATCH) {
+    return Response.json({ error: `at most ${MAX_BATCH} builds per request` }, { status: 400 });
+  }
+
+  const fields: { game?: string | null; gameSystem?: string; lot?: string | null } = {};
+  if (body.game !== undefined) {
+    if (body.game !== null && typeof body.game !== "string") {
+      return Response.json({ error: "game must be a string or null" }, { status: 400 });
+    }
+    if (typeof body.game === "string" && body.game.length > MAX_GAME_LEN) {
+      return Response.json({ error: `game exceeds ${MAX_GAME_LEN} characters` }, { status: 400 });
+    }
+    fields.game = ((body.game as string | null) ?? "").trim() || null;
+  }
+  if (body.gameSystem !== undefined && typeof body.gameSystem !== "string") {
+    return Response.json({ error: "gameSystem must be a string" }, { status: 400 });
+  }
+  fields.gameSystem = ((body.gameSystem as string | undefined) ?? "").trim();
+  if (fields.gameSystem.length > MAX_GAME_LEN) {
+    return Response.json({ error: `gameSystem exceeds ${MAX_GAME_LEN} characters` }, { status: 400 });
+  }
+  if (body.lot !== undefined) {
+    if (body.lot !== null && typeof body.lot !== "string") {
+      return Response.json({ error: "lot must be a string or null" }, { status: 400 });
+    }
+    if (typeof body.lot === "string" && body.lot.length > MAX_LOT_LEN) {
+      return Response.json({ error: `lot exceeds ${MAX_LOT_LEN} characters` }, { status: 400 });
+    }
+    fields.lot = (body.lot ?? "").trim() || null;
+  }
+  if (fields.game === undefined && fields.lot === undefined) {
+    return Response.json({ error: "nothing to update (game and/or lot required)" }, { status: 400 });
+  }
+
+  const pool = getPool();
+  const { updated, game } = await bulkUpdateBuilds(pool, sha256s as string[], fields);
+
+  // Build pages are ISR-cached; surface the new chips now. The game pages
+  // themselves are dynamic and need no revalidation.
+  revalidatePath("/builds");
+  for (const b of updated) {
+    for (const path of [buildHref(b.sha256, b.name), `/builds/${b.sha256}`]) {
+      revalidatePath(path);
+      revalidatePath(`${path}/assets`);
+    }
+  }
+
+  return Response.json({
+    updated: updated.length,
+    ...(fields.game !== undefined ? { game: game?.name ?? null, gameSlug: game?.slug ?? null } : {}),
+    ...(fields.lot !== undefined ? { lot: fields.lot } : {}),
+  });
+}

--- a/web/src/app/builds/BuildsBrowser.tsx
+++ b/web/src/app/builds/BuildsBrowser.tsx
@@ -3,7 +3,9 @@
 import { useEffect, useRef, useState, useTransition } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import RowLink from "./RowLink";
+import MassApply from "@/components/MassApply";
 import Select from "@/components/Select";
+import { useModerator } from "@/components/useModerator";
 import { buildHref } from "@/lib/slug";
 import type { BuildListItem, BuildSortKey } from "@/lib/queries";
 
@@ -47,6 +49,27 @@ export default function BuildsBrowser({ rows, total, systems, page, perPage, q, 
   const [isPending, startTransition] = useTransition();
   const [input, setInput] = useState(q);
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Bulk moderation: selection is keyed by sha256 and survives paging, so a
+  // moderator can gather builds across pages and apply once.
+  const { moderator, token } = useModerator();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const toggleSelected = (sha: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(sha)) next.delete(sha);
+      else next.add(sha);
+      return next;
+    });
+  const pageSelected = rows.length > 0 && rows.every((b) => selected.has(b.sha256));
+  const togglePage = () =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const b of rows) {
+        if (pageSelected) next.delete(b.sha256);
+        else next.add(b.sha256);
+      }
+      return next;
+    });
 
   const navigate = (
     next: Partial<{ q: string; system: string; lot: string; sort: BuildSortKey; dir: "asc" | "desc"; page: number }>,
@@ -113,12 +136,34 @@ export default function BuildsBrowser({ rows, total, systems, page, perPage, q, 
         </span>
       </div>
 
+      {moderator && (
+        <MassApply
+          selected={[...selected]}
+          token={token}
+          onClear={() => setSelected(new Set())}
+          onDone={() => {
+            setSelected(new Set());
+            router.refresh();
+          }}
+        />
+      )}
+
       {rows.length === 0 ? (
         <p className="mt-6 text-sm text-neutral-500">No builds match.</p>
       ) : (
         <table className={`mt-4 w-full border-collapse text-sm ${isPending ? "opacity-60" : ""}`}>
           <thead>
             <tr className="border-b border-neutral-200/80 text-left text-xs font-medium text-neutral-400 dark:border-neutral-800/80">
+              {moderator && (
+                <th className="w-6 py-1.5 pr-2">
+                  <input
+                    type="checkbox"
+                    checked={pageSelected}
+                    onChange={togglePage}
+                    aria-label="Select all builds on this page"
+                  />
+                </th>
+              )}
               <Th label="Name" sortKey="name" sort={sort} dir={dir} onSort={toggleSort} />
               <th className="px-3 py-1.5">SHA-256</th>
               <Th label="System" sortKey="system" sort={sort} dir={dir} onSort={toggleSort} />
@@ -136,7 +181,17 @@ export default function BuildsBrowser({ rows, total, systems, page, perPage, q, 
               const href = buildHref(b.sha256, b.name);
               return (
               <tr key={b.sha256} className="hover:bg-neutral-50 dark:hover:bg-neutral-900/40">
-                <td className="h-full p-0 font-medium first:[&>a]:pl-0">
+                {moderator && (
+                  <td className="py-0 pr-2">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(b.sha256)}
+                      onChange={() => toggleSelected(b.sha256)}
+                      aria-label={`Select ${b.name}`}
+                    />
+                  </td>
+                )}
+                <td className="h-full p-0 font-medium [&>a]:pl-0">
                   <RowLink href={href} focusable className="px-3 hover:underline">
                     {b.name}
                     {b.lot && (

--- a/web/src/app/builds/[buildId]/AssetGallery.tsx
+++ b/web/src/app/builds/[buildId]/AssetGallery.tsx
@@ -160,8 +160,13 @@ export default function AssetGallery({
                       </span>
                       <span className="shrink-0 text-[10px] text-neutral-400">{humanSize(a.size)}</span>
                     </div>
-                    {/* Binary cards preview the head snippet as spaced hex pairs. */}
-                    <pre className="mt-1.5 line-clamp-4 whitespace-pre-wrap break-words font-mono text-[11px] leading-4 text-neutral-500">
+                    {/* Binary cards preview the head snippet as spaced hex
+                        pairs, elided to a single line; text wraps to a few. */}
+                    <pre
+                      className={`mt-1.5 font-mono text-[11px] leading-4 text-neutral-500 ${
+                        kind === "binary" ? "truncate" : "line-clamp-4 whitespace-pre-wrap break-words"
+                      }`}
+                    >
                       {kind === "source" ? (
                         <SourceCode path={a.path} text={excerpts[a.path] ?? ""} />
                       ) : (

--- a/web/src/app/builds/[buildId]/AssetGallery.tsx
+++ b/web/src/app/builds/[buildId]/AssetGallery.tsx
@@ -10,6 +10,7 @@
 // which deep-links the asset in the URL; audio and video play inline, so for
 // those it's the filename that opens the viewer.
 
+import { useState } from "react";
 import Link from "next/link";
 import { assetUrl, humanSize, imageSrc, VideoPlayer, type ViewableAsset } from "./AssetViewer";
 import { useOpenAsset } from "./AssetViewerHost";
@@ -48,6 +49,9 @@ export default function AssetGallery({
   const openAsset = useOpenAsset();
   const open = (a: ViewableAsset) => openAsset(a.path);
   const allHref = `${buildHref}/assets`;
+  // The unidentified-bytes section is noise most of the time: collapsed to a
+  // one-line count until asked for.
+  const [showBinary, setShowBinary] = useState(false);
 
   return (
     <>
@@ -56,6 +60,18 @@ export default function AssetGallery({
         if (group.length === 0) return null;
         const total = totals[kind] ?? group.length;
         const more = total - group.length;
+        if (kind === "binary" && !showBinary) {
+          return (
+            <div key={kind} className="mt-5 first:mt-3">
+              <button
+                onClick={() => setShowBinary(true)}
+                className="text-xs text-neutral-400 hover:text-sky-700 hover:underline dark:hover:text-sky-400"
+              >
+                {total} unidentified file{total === 1 ? "" : "s"}…
+              </button>
+            </div>
+          );
+        }
         return (
           <div key={kind} className="mt-5 first:mt-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-400">

--- a/web/src/app/games/[slug]/GameBuilds.tsx
+++ b/web/src/app/games/[slug]/GameBuilds.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+// The game page's build list. For moderators each row grows a checkbox and
+// a mass-apply bar appears while anything is selected (reassign a
+// mis-filed build to another game, clear it, or move builds between lots).
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import MassApply from "@/components/MassApply";
+import { useModerator } from "@/components/useModerator";
+import { buildHref } from "@/lib/slug";
+import type { BuildListItem } from "@/lib/queries";
+
+function humanSize(bytes?: number): string {
+  if (bytes == null) return "—";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let v = Number(bytes);
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return i === 0 ? `${v} B` : `${v.toFixed(1)} ${units[i]}`;
+}
+
+export default function GameBuilds({ builds }: { builds: BuildListItem[] }) {
+  const router = useRouter();
+  const { moderator, token } = useModerator();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const toggle = (sha: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(sha)) next.delete(sha);
+      else next.add(sha);
+      return next;
+    });
+  const allSelected = builds.length > 0 && builds.every((b) => selected.has(b.sha256));
+
+  if (builds.length === 0) {
+    return <p className="mt-8 text-sm text-neutral-500">No public builds for this game.</p>;
+  }
+
+  return (
+    <>
+      {moderator && (
+        <>
+          <label className="mt-4 flex items-center gap-1.5 text-xs text-neutral-500">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={() =>
+                setSelected(allSelected ? new Set() : new Set(builds.map((b) => b.sha256)))
+              }
+            />
+            Select all
+          </label>
+          <MassApply
+            selected={[...selected]}
+            token={token}
+            onClear={() => setSelected(new Set())}
+            onDone={() => {
+              setSelected(new Set());
+              router.refresh();
+            }}
+          />
+        </>
+      )}
+      <ul className="mt-4 divide-y divide-neutral-200 dark:divide-neutral-800">
+        {builds.map((b) => (
+          <li key={b.sha256} className="flex items-center gap-3">
+            {moderator && (
+              <input
+                type="checkbox"
+                checked={selected.has(b.sha256)}
+                onChange={() => toggle(b.sha256)}
+                aria-label={`Select ${b.name}`}
+              />
+            )}
+            <Link
+              href={buildHref(b.sha256, b.name)}
+              className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-4 gap-y-1 py-2.5 hover:bg-neutral-50 dark:hover:bg-neutral-900"
+            >
+              <span className="min-w-0 flex-1 break-words font-medium">{b.name}</span>
+              <span className="shrink-0 text-xs tabular-nums text-neutral-500">
+                {b.build_date ? b.build_date.slice(0, 10) : "—"}
+              </span>
+              <span className="w-20 shrink-0 text-right text-xs tabular-nums text-neutral-500">
+                {humanSize(b.total_size)}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/web/src/app/games/[slug]/GameBuilds.tsx
+++ b/web/src/app/games/[slug]/GameBuilds.tsx
@@ -82,7 +82,14 @@ export default function GameBuilds({ builds }: { builds: BuildListItem[] }) {
               href={buildHref(b.sha256, b.name)}
               className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-4 gap-y-1 py-2.5 hover:bg-neutral-50 dark:hover:bg-neutral-900"
             >
-              <span className="min-w-0 flex-1 break-words font-medium">{b.name}</span>
+              <span className="min-w-0 flex-1 break-words font-medium">
+                {b.name}
+                {b.private && (
+                  <span className="ml-2 rounded border border-red-300 px-1.5 py-0.5 text-xs font-normal text-red-600 dark:border-red-800 dark:text-red-400">
+                    private
+                  </span>
+                )}
+              </span>
               <span className="shrink-0 text-xs tabular-nums text-neutral-500">
                 {b.build_date ? b.build_date.slice(0, 10) : "—"}
               </span>

--- a/web/src/app/games/[slug]/assets/[[...path]]/page.tsx
+++ b/web/src/app/games/[slug]/assets/[[...path]]/page.tsx
@@ -18,6 +18,9 @@ export const dynamic = "force-dynamic";
 // Excerpt reads are tiny (2KB head per file) but keep them bounded on games
 // whose builds carry pathological text counts.
 const MAX_EXCERPT_READS = 200;
+// At most this many items per kind per month, matching the game page; the
+// rare overflow (a 200+ image month) stays reachable on each build's page.
+const MONTH_PER_KIND = 200;
 
 interface Params {
   params: Promise<{ slug: string; path?: string[] }>;
@@ -46,10 +49,10 @@ export default async function GameAssetsPage({ params }: Params) {
   // matching the game page itself.
   const includePrivate = !!(await getModeratorFromHeaders(await headers()));
   const assets = await getGameAssets(pool, game.id, includePrivate);
-  // Same month timeline as the game page, uncapped.
+  // Same month timeline as the game page.
   const months = assetMonths(assets).map((m) => ({
     ...m,
-    ordered: orderAssets(m.assets),
+    ordered: orderAssets(m.assets, MONTH_PER_KIND),
     totals: assetTotals(m.assets),
   }));
   const ordered = months.flatMap((m) => m.ordered);
@@ -75,7 +78,8 @@ export default async function GameAssetsPage({ params }: Params) {
         ) : (
           months.map((m) => (
             <div key={m.key} className="mt-8 first:mt-4">
-              <h3 className="border-b border-neutral-200 pb-1 text-sm font-semibold dark:border-neutral-800">
+              {/* Sticky per-month header, same treatment as the game page. */}
+              <h3 className="sticky top-0 z-10 border-b border-neutral-200 bg-[var(--background)] pb-1 pt-2 text-sm font-semibold dark:border-neutral-800">
                 {m.label}
                 <span className="ml-2 font-normal text-neutral-400">
                   {m.assets.length} {m.assets.length === 1 ? "file" : "files"}

--- a/web/src/app/games/[slug]/assets/[[...path]]/page.tsx
+++ b/web/src/app/games/[slug]/assets/[[...path]]/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from "next/navigation";
 import { getModeratorFromHeaders } from "@/lib/auth";
 import { getPool } from "@/lib/db";
 import { getGameAssets, getGameBySlug } from "@/lib/queries";
-import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
+import { assetExcerpts, assetMonths, assetTotals, orderAssets } from "@/lib/assets";
 import { safeDecodeSegment } from "@/lib/slug";
 import AssetGallery from "../../../../builds/[buildId]/AssetGallery";
 import AssetViewerHost from "../../../../builds/[buildId]/AssetViewerHost";
@@ -46,7 +46,13 @@ export default async function GameAssetsPage({ params }: Params) {
   // matching the game page itself.
   const includePrivate = !!(await getModeratorFromHeaders(await headers()));
   const assets = await getGameAssets(pool, game.id, includePrivate);
-  const ordered = orderAssets(assets);
+  // Same month timeline as the game page, uncapped.
+  const months = assetMonths(assets).map((m) => ({
+    ...m,
+    ordered: orderAssets(m.assets),
+    totals: assetTotals(m.assets),
+  }));
+  const ordered = months.flatMap((m) => m.ordered);
   const excerpts = await assetExcerpts(ordered, MAX_EXCERPT_READS);
 
   // Deep link: open the viewer on the named file; unknown paths just render
@@ -67,7 +73,17 @@ export default async function GameAssetsPage({ params }: Params) {
         {assets.length === 0 ? (
           <p className="mt-6 text-sm text-neutral-500">No viewable assets in this game&apos;s builds.</p>
         ) : (
-          <AssetGallery buildHref={href} assets={ordered} totals={assetTotals(assets)} excerpts={excerpts} />
+          months.map((m) => (
+            <div key={m.key} className="mt-8 first:mt-4">
+              <h3 className="border-b border-neutral-200 pb-1 text-sm font-semibold dark:border-neutral-800">
+                {m.label}
+                <span className="ml-2 font-normal text-neutral-400">
+                  {m.assets.length} {m.assets.length === 1 ? "file" : "files"}
+                </span>
+              </h3>
+              <AssetGallery buildHref={href} assets={m.ordered} totals={m.totals} excerpts={excerpts} />
+            </div>
+          ))
         )}
       </AssetViewerHost>
     </main>

--- a/web/src/app/games/[slug]/assets/[[...path]]/page.tsx
+++ b/web/src/app/games/[slug]/assets/[[...path]]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
+import { getModeratorFromHeaders } from "@/lib/auth";
 import { getPool } from "@/lib/db";
 import { getGameAssets, getGameBySlug } from "@/lib/queries";
 import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
@@ -40,7 +42,10 @@ export default async function GameAssetsPage({ params }: Params) {
   if (!game) notFound();
   const href = `/games/${game.slug}`;
 
-  const assets = await getGameAssets(pool, game.id);
+  // Per-request render: wiki-moderators see private builds' assets too,
+  // matching the game page itself.
+  const includePrivate = !!(await getModeratorFromHeaders(await headers()));
+  const assets = await getGameAssets(pool, game.id, includePrivate);
   const ordered = orderAssets(assets);
   const excerpts = await assetExcerpts(ordered, MAX_EXCERPT_READS);
 

--- a/web/src/app/games/[slug]/assets/[[...path]]/page.tsx
+++ b/web/src/app/games/[slug]/assets/[[...path]]/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getPool } from "@/lib/db";
+import { getGameAssets, getGameBySlug } from "@/lib/queries";
+import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
+import { safeDecodeSegment } from "@/lib/slug";
+import AssetGallery from "../../../../builds/[buildId]/AssetGallery";
+import AssetViewerHost from "../../../../builds/[buildId]/AssetViewerHost";
+
+export const runtime = "nodejs";
+// Same shape as the game page: assignments change through moderation, so
+// render fresh (the asset set itself only changes at ingest).
+export const dynamic = "force-dynamic";
+
+// Excerpt reads are tiny (2KB head per file) but keep them bounded on games
+// whose builds carry pathological text counts.
+const MAX_EXCERPT_READS = 200;
+
+interface Params {
+  params: Promise<{ slug: string; path?: string[] }>;
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { slug, path } = await params;
+  const game = await getGameBySlug(getPool(), decodeURIComponent(slug));
+  if (!game) return {};
+  const relPath = (path ?? []).map(safeDecodeSegment).join("/");
+  const name = relPath.split("/").pop();
+  return { title: name || `Assets · ${game.name}` };
+}
+
+// /games/<slug>/assets — the full combined gallery over every visible build
+// of the game; /games/<slug>/assets/<build name>/<path…> — the same gallery
+// with the viewer open on that file (the URL the lightbox writes).
+export default async function GameAssetsPage({ params }: Params) {
+  const { slug, path } = await params;
+  const pool = getPool();
+  const game = await getGameBySlug(pool, decodeURIComponent(slug));
+  if (!game) notFound();
+  const href = `/games/${game.slug}`;
+
+  const assets = await getGameAssets(pool, game.id);
+  const ordered = orderAssets(assets);
+  const excerpts = await assetExcerpts(ordered, MAX_EXCERPT_READS);
+
+  // Deep link: open the viewer on the named file; unknown paths just render
+  // the plain gallery.
+  const segments = (path ?? []).map(safeDecodeSegment);
+  const initialPath = segments.length ? segments.join("/") : undefined;
+
+  return (
+    <main className="mx-auto max-w-none px-4 py-10 sm:px-8">
+      <AssetViewerHost assets={ordered} buildHref={href} returnHref={`${href}/assets`} initialPath={initialPath}>
+        <Link href={href} className="text-sm text-neutral-500 hover:underline">
+          &larr; {game.system ? `${game.name} (${game.system})` : game.name}
+        </Link>
+        <h1 className="mt-3 text-2xl font-semibold tracking-tight">Assets</h1>
+        <p className="mt-1 text-xs text-neutral-500">
+          Extracted from every build of {game.name}; the path prefix names the build each file came from.
+        </p>
+        {assets.length === 0 ? (
+          <p className="mt-6 text-sm text-neutral-500">No viewable assets in this game&apos;s builds.</p>
+        ) : (
+          <AssetGallery buildHref={href} assets={ordered} totals={assetTotals(assets)} excerpts={excerpts} />
+        )}
+      </AssetViewerHost>
+    </main>
+  );
+}

--- a/web/src/app/games/[slug]/page.tsx
+++ b/web/src/app/games/[slug]/page.tsx
@@ -10,9 +10,9 @@ import AssetGallery from "../../builds/[buildId]/AssetGallery";
 import AssetViewerHost from "../../builds/[buildId]/AssetViewerHost";
 import GameBuilds from "./GameBuilds";
 
-// The timeline previews at most this many items per kind per month; the
-// rest live on /games/<slug>/assets. Excerpt reads stay bounded regardless.
-const MONTH_PREVIEW_PER_KIND = { image: 18, audio: 8, video: 6, document: 8, source: 6, text: 6, binary: 6 };
+// The timeline shows at most this many items per kind per month; the rest
+// live on /games/<slug>/assets. Excerpt reads stay bounded regardless.
+const MONTH_PREVIEW_PER_KIND = 200;
 const MAX_EXCERPT_READS = 200;
 
 export const runtime = "nodejs";
@@ -58,11 +58,10 @@ export default async function GamePage({ params }: Params) {
     preview: orderAssets(m.assets, MONTH_PREVIEW_PER_KIND),
     totals: assetTotals(m.assets),
   }));
-  const ordered = months.flatMap((m) => orderAssets(m.assets));
-  const excerpts = await assetExcerpts(
-    months.flatMap((m) => m.preview),
-    MAX_EXCERPT_READS
-  );
+  // The lightbox steps through exactly what the galleries show, so the
+  // serialized asset list stays bounded with the same per-kind cap.
+  const ordered = months.flatMap((m) => m.preview);
+  const excerpts = await assetExcerpts(ordered, MAX_EXCERPT_READS);
 
   return (
     <main className="mx-auto max-w-none px-4 py-10 sm:px-8">
@@ -92,7 +91,10 @@ export default async function GamePage({ params }: Params) {
             </p>
             {months.map((m) => (
               <div key={m.key} className="mt-8 first:mt-4">
-                <h3 className="border-b border-neutral-200 pb-1 text-sm font-semibold dark:border-neutral-800">
+                {/* Sticky per-month header; the page background keeps the
+                    scrolled cards from showing through. Below the lightbox
+                    overlay, above the cards. */}
+                <h3 className="sticky top-0 z-10 border-b border-neutral-200 bg-[var(--background)] pb-1 pt-2 text-sm font-semibold dark:border-neutral-800">
                   {m.label}
                   <span className="ml-2 font-normal text-neutral-400">
                     {m.assets.length} {m.assets.length === 1 ? "file" : "files"}

--- a/web/src/app/games/[slug]/page.tsx
+++ b/web/src/app/games/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
+import { getModeratorFromHeaders } from "@/lib/auth";
 import { getPool } from "@/lib/db";
 import { getGameAssets, getGameBySlug, getGameBuilds } from "@/lib/queries";
 import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
@@ -40,7 +42,13 @@ export default async function GamePage({ params }: Params) {
   if (!game) notFound();
   const href = `/games/${game.slug}`;
 
-  const [builds, assets] = await Promise.all([getGameBuilds(pool, game.id), getGameAssets(pool, game.id)]);
+  // The page renders per-request (force-dynamic), so a wiki-moderator's
+  // cookies reveal private builds here — badged, exactly like /builds.
+  const includePrivate = !!(await getModeratorFromHeaders(await headers()));
+  const [builds, assets] = await Promise.all([
+    getGameBuilds(pool, game.id, includePrivate),
+    getGameAssets(pool, game.id, includePrivate),
+  ]);
   const previewAssets = orderAssets(assets, ASSET_PREVIEW_PER_KIND);
   const excerpts = await assetExcerpts(previewAssets);
 

--- a/web/src/app/games/[slug]/page.tsx
+++ b/web/src/app/games/[slug]/page.tsx
@@ -5,14 +5,15 @@ import { notFound } from "next/navigation";
 import { getModeratorFromHeaders } from "@/lib/auth";
 import { getPool } from "@/lib/db";
 import { getGameAssets, getGameBySlug, getGameBuilds } from "@/lib/queries";
-import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
+import { assetExcerpts, assetMonths, assetTotals, orderAssets } from "@/lib/assets";
 import AssetGallery from "../../builds/[buildId]/AssetGallery";
 import AssetViewerHost from "../../builds/[buildId]/AssetViewerHost";
 import GameBuilds from "./GameBuilds";
 
-// The combined gallery previews at most this many items per kind across all
-// of the game's builds; the rest live on /games/<slug>/assets.
-const ASSET_PREVIEW_PER_KIND = { image: 30, audio: 20, video: 10, document: 12, source: 10, text: 10, binary: 9 };
+// The timeline previews at most this many items per kind per month; the
+// rest live on /games/<slug>/assets. Excerpt reads stay bounded regardless.
+const MONTH_PREVIEW_PER_KIND = { image: 18, audio: 8, video: 6, document: 8, source: 6, text: 6, binary: 6 };
+const MAX_EXCERPT_READS = 200;
 
 export const runtime = "nodejs";
 // Assignments change through moderation, not ingest; render fresh each time
@@ -49,32 +50,57 @@ export default async function GamePage({ params }: Params) {
     getGameBuilds(pool, game.id, includePrivate),
     getGameAssets(pool, game.id, includePrivate),
   ]);
-  const previewAssets = orderAssets(assets, ASSET_PREVIEW_PER_KIND);
-  const excerpts = await assetExcerpts(previewAssets);
+  // Timeline: one bucket per month of the assets' own file dates. The viewer
+  // steps through the whole timeline in order; each month's gallery shows a
+  // capped preview, with the full set on /games/<slug>/assets.
+  const months = assetMonths(assets).map((m) => ({
+    ...m,
+    preview: orderAssets(m.assets, MONTH_PREVIEW_PER_KIND),
+    totals: assetTotals(m.assets),
+  }));
+  const ordered = months.flatMap((m) => orderAssets(m.assets));
+  const excerpts = await assetExcerpts(
+    months.flatMap((m) => m.preview),
+    MAX_EXCERPT_READS
+  );
 
   return (
-    <main className="mx-auto max-w-4xl px-4 py-10 sm:px-8">
-      <AssetViewerHost assets={orderAssets(assets)} buildHref={href} returnHref={href}>
-        <Link href="/builds" className="text-sm text-neutral-500 hover:underline">&larr; All builds</Link>
-        <h1 className="mt-3 text-2xl font-semibold tracking-tight">{game.name}</h1>
-        <div className="mt-2 flex flex-wrap gap-2 text-xs">
-          {game.system && (
-            <span className="rounded bg-neutral-100 px-1.5 py-0.5 font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
-              {game.system}
+    <main className="mx-auto max-w-none px-4 py-10 sm:px-8">
+      <AssetViewerHost assets={ordered} buildHref={href} returnHref={href}>
+        <div className="mx-auto max-w-4xl">
+          <Link href="/builds" className="text-sm text-neutral-500 hover:underline">&larr; All builds</Link>
+          <h1 className="mt-3 text-2xl font-semibold tracking-tight">{game.name}</h1>
+          <div className="mt-2 flex flex-wrap gap-2 text-xs">
+            {game.system && (
+              <span className="rounded bg-neutral-100 px-1.5 py-0.5 font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+                {game.system}
+              </span>
+            )}
+            <span className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 dark:bg-sky-900/40 dark:text-sky-200">
+              {builds.length} {builds.length === 1 ? "build" : "builds"}
             </span>
-          )}
-          <span className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 dark:bg-sky-900/40 dark:text-sky-200">
-            {builds.length} {builds.length === 1 ? "build" : "builds"}
-          </span>
-        </div>
+          </div>
 
-        <GameBuilds builds={builds} />
+          <GameBuilds builds={builds} />
+        </div>
 
         {assets.length > 0 && (
           <section className="mt-10">
             <h2 className="text-lg font-medium">Assets</h2>
-            <p className="mt-1 text-xs text-neutral-500">Extracted from every build of this game.</p>
-            <AssetGallery buildHref={href} assets={previewAssets} totals={assetTotals(assets)} excerpts={excerpts} />
+            <p className="mt-1 text-xs text-neutral-500">
+              Extracted from every build of this game, by the files&apos; own dates.
+            </p>
+            {months.map((m) => (
+              <div key={m.key} className="mt-8 first:mt-4">
+                <h3 className="border-b border-neutral-200 pb-1 text-sm font-semibold dark:border-neutral-800">
+                  {m.label}
+                  <span className="ml-2 font-normal text-neutral-400">
+                    {m.assets.length} {m.assets.length === 1 ? "file" : "files"}
+                  </span>
+                </h3>
+                <AssetGallery buildHref={href} assets={m.preview} totals={m.totals} excerpts={excerpts} />
+              </div>
+            ))}
           </section>
         )}
       </AssetViewerHost>

--- a/web/src/app/games/[slug]/page.tsx
+++ b/web/src/app/games/[slug]/page.tsx
@@ -2,9 +2,15 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getPool } from "@/lib/db";
-import { getGameBySlug, getGameBuilds } from "@/lib/queries";
-import { humanSize } from "@/lib/meta";
-import { buildHref } from "@/lib/slug";
+import { getGameAssets, getGameBySlug, getGameBuilds } from "@/lib/queries";
+import { assetExcerpts, assetTotals, orderAssets } from "@/lib/assets";
+import AssetGallery from "../../builds/[buildId]/AssetGallery";
+import AssetViewerHost from "../../builds/[buildId]/AssetViewerHost";
+import GameBuilds from "./GameBuilds";
+
+// The combined gallery previews at most this many items per kind across all
+// of the game's builds; the rest live on /games/<slug>/assets.
+const ASSET_PREVIEW_PER_KIND = { image: 30, audio: 20, video: 10, document: 12, source: 10, text: 10, binary: 9 };
 
 export const runtime = "nodejs";
 // Assignments change through moderation, not ingest; render fresh each time
@@ -19,11 +25,12 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
   const { slug } = await params;
   const game = await getGameBySlug(getPool(), decodeURIComponent(slug));
   if (!game) return {};
-  const title = game.system ? `${game.name} (${game.system})` : game.name;
-  return { title: `${title} · Hidden Palace` };
+  return { title: game.system ? `${game.name} (${game.system})` : game.name };
 }
 
-// /games/<slug> — every visible build of one game, oldest first. The slug is
+// /games/<slug> — every visible build of one game, oldest first, plus one
+// combined asset gallery across all of those builds (paths namespaced by
+// build name, so the lightbox shows where each file came from). The slug is
 // <name>--<system> (name alone when the system is unknown); private builds
 // stay hidden, exactly like the /builds browser.
 export default async function GamePage({ params }: Params) {
@@ -31,46 +38,38 @@ export default async function GamePage({ params }: Params) {
   const pool = getPool();
   const game = await getGameBySlug(pool, decodeURIComponent(slug));
   if (!game) notFound();
+  const href = `/games/${game.slug}`;
 
-  const builds = await getGameBuilds(pool, game.id);
+  const [builds, assets] = await Promise.all([getGameBuilds(pool, game.id), getGameAssets(pool, game.id)]);
+  const previewAssets = orderAssets(assets, ASSET_PREVIEW_PER_KIND);
+  const excerpts = await assetExcerpts(previewAssets);
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-10 sm:px-8">
-      <Link href="/builds" className="text-sm text-neutral-500 hover:underline">&larr; All builds</Link>
-      <h1 className="mt-3 text-2xl font-semibold tracking-tight">{game.name}</h1>
-      <div className="mt-2 flex flex-wrap gap-2 text-xs">
-        {game.system && (
-          <span className="rounded bg-neutral-100 px-1.5 py-0.5 font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
-            {game.system}
+      <AssetViewerHost assets={orderAssets(assets)} buildHref={href} returnHref={href}>
+        <Link href="/builds" className="text-sm text-neutral-500 hover:underline">&larr; All builds</Link>
+        <h1 className="mt-3 text-2xl font-semibold tracking-tight">{game.name}</h1>
+        <div className="mt-2 flex flex-wrap gap-2 text-xs">
+          {game.system && (
+            <span className="rounded bg-neutral-100 px-1.5 py-0.5 font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+              {game.system}
+            </span>
+          )}
+          <span className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 dark:bg-sky-900/40 dark:text-sky-200">
+            {builds.length} {builds.length === 1 ? "build" : "builds"}
           </span>
-        )}
-        <span className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 dark:bg-sky-900/40 dark:text-sky-200">
-          {builds.length} {builds.length === 1 ? "build" : "builds"}
-        </span>
-      </div>
+        </div>
 
-      {builds.length === 0 ? (
-        <p className="mt-8 text-sm text-neutral-500">No public builds for this game.</p>
-      ) : (
-        <ul className="mt-6 divide-y divide-neutral-200 dark:divide-neutral-800">
-          {builds.map((b) => (
-            <li key={b.sha256}>
-              <Link
-                href={buildHref(b.sha256, b.name)}
-                className="flex flex-wrap items-baseline gap-x-4 gap-y-1 py-2.5 hover:bg-neutral-50 dark:hover:bg-neutral-900"
-              >
-                <span className="min-w-0 flex-1 break-words font-medium">{b.name}</span>
-                <span className="shrink-0 text-xs tabular-nums text-neutral-500">
-                  {b.build_date ? b.build_date.slice(0, 10) : "—"}
-                </span>
-                <span className="w-20 shrink-0 text-right text-xs tabular-nums text-neutral-500">
-                  {humanSize(b.total_size)}
-                </span>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
+        <GameBuilds builds={builds} />
+
+        {assets.length > 0 && (
+          <section className="mt-10">
+            <h2 className="text-lg font-medium">Assets</h2>
+            <p className="mt-1 text-xs text-neutral-500">Extracted from every build of this game.</p>
+            <AssetGallery buildHref={href} assets={previewAssets} totals={assetTotals(assets)} excerpts={excerpts} />
+          </section>
+        )}
+      </AssetViewerHost>
     </main>
   );
 }

--- a/web/src/components/MassApply.tsx
+++ b/web/src/components/MassApply.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+// Bulk moderation bar shown above a builds table while rows are selected:
+// pick an action, fill it in, Apply hits POST /api/builds over the whole
+// selection at once. Game suggestions come from the server as you type,
+// exactly like the single-build editor on the build page.
+
+import { useEffect, useState } from "react";
+import Select from "@/components/Select";
+
+type Action = "game" | "cleargame" | "lot" | "clearlot";
+
+const ACTIONS: { value: Action; label: string }[] = [
+  { value: "game", label: "Set game" },
+  { value: "cleargame", label: "Clear game" },
+  { value: "lot", label: "Set lot" },
+  { value: "clearlot", label: "Clear lot" },
+];
+
+export default function MassApply({
+  selected,
+  token,
+  onClear,
+  onDone,
+}: {
+  /** sha256s of the selected builds. */
+  selected: string[];
+  /** Shared moderation token, "" when the wiki session is the credential. */
+  token: string;
+  /** Deselect everything (the bar's Clear button). */
+  onClear: () => void;
+  /** Called after a successful apply (refresh + deselect). */
+  onDone: () => void;
+}) {
+  const [action, setAction] = useState<Action>("game");
+  const [gameName, setGameName] = useState("");
+  const [gameSys, setGameSys] = useState("");
+  const [gameOpts, setGameOpts] = useState<{ name: string; system: string }[]>([]);
+  const [lotName, setLotName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState("");
+
+  // Debounced game suggestions; stale responses are dropped.
+  useEffect(() => {
+    if (action !== "game") return;
+    let cancelled = false;
+    const t = setTimeout(() => {
+      fetch(`/api/games?q=${encodeURIComponent(gameName.trim())}`, { cache: "no-store" })
+        .then((r) => r.json())
+        .then(
+          (d) =>
+            !cancelled &&
+            setGameOpts((d.games ?? []).map((g: { name: string; system: string }) => ({ name: g.name, system: g.system })))
+        )
+        .catch(() => {});
+    }, 200);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [gameName, action]);
+
+  const exact = gameOpts.filter((g) => g.name === gameName.trim());
+  const sysOpts = [...new Set((exact.length ? exact : gameOpts).map((g) => g.system).filter(Boolean))];
+
+  const ready =
+    selected.length > 0 &&
+    (action === "game" ? gameName.trim() !== "" : action === "lot" ? lotName.trim() !== "" : true);
+
+  async function apply() {
+    const fields =
+      action === "game"
+        ? { game: gameName.trim(), gameSystem: gameSys.trim() }
+        : action === "cleargame"
+          ? { game: null }
+          : action === "lot"
+            ? { lot: lotName.trim() }
+            : { lot: null };
+    setBusy(true);
+    setNote("");
+    try {
+      const res = await fetch("/api/builds", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { "x-moderation-token": token } : {}),
+        },
+        body: JSON.stringify({ sha256s: selected, ...fields }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setNote(`Error: ${data.error}`);
+        return;
+      }
+      setNote(`Applied to ${data.updated} build${data.updated === 1 ? "" : "s"}.`);
+      onDone();
+    } catch (e) {
+      setNote(`Failed: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (selected.length === 0) return null;
+
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2 rounded-md border border-dashed border-neutral-300 px-3 py-2 text-sm dark:border-neutral-700">
+      <span className="text-xs font-medium text-neutral-500">
+        {selected.length} selected
+      </span>
+      <button
+        onClick={onClear}
+        className="text-xs text-neutral-400 underline-offset-2 hover:underline"
+      >
+        clear
+      </button>
+      <Select
+        value={action}
+        onChange={(v) => setAction(v as Action)}
+        ariaLabel="Bulk action"
+        className="h-8 w-32 px-2 text-sm"
+        options={ACTIONS}
+      />
+      {action === "game" && (
+        <>
+          <input
+            list="prism-mass-game-names"
+            value={gameName}
+            onChange={(e) => setGameName(e.target.value)}
+            placeholder="e.g. Baldur's Gate: Dark Alliance II"
+            className="h-8 w-72 max-w-full rounded-md border border-neutral-300 bg-transparent px-2 outline-none placeholder:text-neutral-400 focus:border-neutral-500 dark:border-neutral-700"
+          />
+          <datalist id="prism-mass-game-names">
+            {[...new Set(gameOpts.map((g) => g.name))].map((n) => (
+              <option key={n} value={n} />
+            ))}
+          </datalist>
+          <input
+            list="prism-mass-game-systems"
+            value={gameSys}
+            onChange={(e) => setGameSys(e.target.value)}
+            placeholder="System"
+            className="h-8 w-32 max-w-full rounded-md border border-neutral-300 bg-transparent px-2 outline-none placeholder:text-neutral-400 focus:border-neutral-500 dark:border-neutral-700"
+          />
+          <datalist id="prism-mass-game-systems">
+            {sysOpts.map((s) => (
+              <option key={s} value={s} />
+            ))}
+          </datalist>
+        </>
+      )}
+      {action === "lot" && (
+        <input
+          value={lotName}
+          onChange={(e) => setLotName(e.target.value)}
+          placeholder="e.g. Sonic Month 2026"
+          className="h-8 w-72 max-w-full rounded-md border border-neutral-300 bg-transparent px-2 outline-none placeholder:text-neutral-400 focus:border-neutral-500 dark:border-neutral-700"
+        />
+      )}
+      <button
+        onClick={apply}
+        disabled={busy || !ready}
+        className="rounded-md border border-neutral-300 px-3 py-1 font-medium hover:border-neutral-500 disabled:opacity-40 disabled:hover:border-neutral-300 dark:border-neutral-700"
+      >
+        Apply
+      </button>
+      {note && <span className="text-xs text-neutral-500">{note}</span>}
+    </div>
+  );
+}

--- a/web/src/components/useModerator.ts
+++ b/web/src/components/useModerator.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+// The token never changes while a page is mounted (it's set on /moderate),
+// so there is nothing to subscribe to — the store only bridges the
+// SSR/client gap: the server snapshot renders nothing, hydration reveals
+// the saved token.
+const noSubscribe = () => () => {};
+const clientToken = () => sessionStorage.getItem("prism-mod-token") ?? "";
+const serverToken = () => "";
+
+/** Moderator UI gating: the shared token saved by /moderate, or a wiki
+ *  session whose user is in a moderator group. Purely cosmetic — every
+ *  mutating route re-checks credentials server-side. */
+export function useModerator(): { moderator: boolean; token: string } {
+  const token = useSyncExternalStore(noSubscribe, clientToken, serverToken);
+  const [wikiModerator, setWikiModerator] = useState(false);
+
+  useEffect(() => {
+    if (token) return;
+    let cancelled = false;
+    fetch("/api/whoami", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((w) => !cancelled && setWikiModerator(!!w.moderator))
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  return { moderator: !!token || wikiModerator, token };
+}

--- a/web/src/lib/assets.ts
+++ b/web/src/lib/assets.ts
@@ -43,6 +43,34 @@ export function orderAssets<T extends { kind: string }>(
   return ASSET_KIND_ORDER.flatMap((k) => assets.filter((a) => a.kind === k).slice(0, cap(k)));
 }
 
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+/** Month buckets for the game pages' asset timeline: chronological
+ *  "YYYY-MM" keys (labelled "March 2003"), assets without a parseable
+ *  file date last under "Undated". Order within a bucket is preserved. */
+export function assetMonths<T extends { file_date: string | null }>(
+  assets: T[]
+): { key: string; label: string; assets: T[] }[] {
+  const by = new Map<string, T[]>();
+  for (const a of assets) {
+    const m = a.file_date?.match(/^(\d{4})-(\d{2})/);
+    const key = m && Number(m[2]) >= 1 && Number(m[2]) <= 12 ? `${m[1]}-${m[2]}` : "undated";
+    let bucket = by.get(key);
+    if (!bucket) by.set(key, (bucket = []));
+    bucket.push(a);
+  }
+  const keys = [...by.keys()].filter((k) => k !== "undated").sort();
+  if (by.has("undated")) keys.push("undated");
+  return keys.map((key) => ({
+    key,
+    label: key === "undated" ? "Undated" : `${MONTH_NAMES[Number(key.slice(5, 7)) - 1]} ${key.slice(0, 4)}`,
+    assets: by.get(key)!,
+  }));
+}
+
 /** Leading bytes of a blob, or null when it is missing from the store. */
 export async function readAssetBytes(sha256: string, maxBytes = 2048): Promise<Buffer | null> {
   return readBlobHead(sha256, maxBytes);

--- a/web/src/lib/ingest.ts
+++ b/web/src/lib/ingest.ts
@@ -5,7 +5,23 @@
 import type { Pool } from "pg";
 import { hexToId63, toSigned64, lshBands, flattenFiles, arrayLit, parseU64, semanticDoc } from "./fingerprint";
 import { embed, toPgVector } from "./embed";
-import type { BuildRecord } from "./types";
+import type { BuildRecord, Node } from "./types";
+
+/** path ("/DIR/FILE", nested archives included) -> the file's own timestamp,
+ *  from the record's contents tree. Feeds build_asset.file_date (the game
+ *  pages' month timeline); scripts/backfill-asset-dates.ts reuses it. */
+export function assetFileDates(nodes: Node[]): Map<string, string> {
+  const map = new Map<string, string>();
+  const walk = (ns: Node[], prefix: string) => {
+    for (const n of ns) {
+      const p = `${prefix}/${n.name}`;
+      if (n.date) map.set(p, n.date);
+      if (n.type === "dir") walk(n.children, p);
+    }
+  };
+  walk(nodes, "");
+  return map;
+}
 
 /** Anything with a pg-style `query` (Pool, Client, or PoolClient). */
 export interface Queryable {
@@ -166,17 +182,18 @@ export async function ingestRecord(
         typeof a.kind === "string" &&
         Number.isFinite(a.size)
     );
+    const fileDates = assetFileDates(rec.contents);
     for (let off = 0; off < assets.length; off += ROWS_PER_INSERT) {
       const chunk = assets.slice(off, off + ROWS_PER_INSERT);
       const rows: string[] = [];
       const params: unknown[] = [];
       for (const a of chunk) {
         const i = params.length;
-        rows.push(`($${i + 1},$${i + 2},$${i + 3},$${i + 4},$${i + 5},$${i + 6})`);
-        params.push(sha, a.path, a.sha256, a.size, a.mime, a.kind);
+        rows.push(`($${i + 1},$${i + 2},$${i + 3},$${i + 4},$${i + 5},$${i + 6},$${i + 7})`);
+        params.push(sha, a.path, a.sha256, a.size, a.mime, a.kind, fileDates.get(a.path) ?? null);
       }
       await db.query(
-        `INSERT INTO build_asset (build_sha256,path,sha256,size,mime,kind) VALUES ${rows.join(",")}
+        `INSERT INTO build_asset (build_sha256,path,sha256,size,mime,kind,file_date) VALUES ${rows.join(",")}
          ON CONFLICT (build_sha256,path) DO NOTHING`,
         params
       );

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -898,10 +898,12 @@ export async function getGameBySlug(pool: Pool, slug: string): Promise<GameRow |
 }
 
 /// All visible builds of a game, oldest prototype first (missing dates last).
-/// Public surface — private builds stay hidden (visibleSql).
+/// The game pages render per-request (no shared cache), so moderators pass
+/// includePrivate and see private builds marked via the `private` field.
 export async function getGameBuilds(pool: Pool, gameId: number, includePrivate = false): Promise<BuildListItem[]> {
   const r = await pool.query(
-    `SELECT sha256, name, system, file_count, total_size, ingested_at, build_date, lot
+    `SELECT sha256, name, system, file_count, total_size, ingested_at, build_date, lot,
+            (private OR EXISTS (SELECT 1 FROM private_lots _pl WHERE _pl.lot = builds.lot)) AS private
      FROM builds WHERE game_id=$1 AND ${includePrivate ? "TRUE" : visibleSql("builds")}
      ORDER BY build_date NULLS LAST, lower(name)`,
     [gameId]

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -681,6 +681,8 @@ export async function getBuildAssets(pool: Pool, sha256: string): Promise<BuildA
 export interface GameAsset extends BuildAsset {
   build_sha256: string;
   build_name: string;
+  /** The file's own timestamp ("YYYY-MM-DD HH:MM:SS"), for the month timeline. */
+  file_date: string | null;
 }
 
 /// Every visible build's assets for one game, builds in the game page's
@@ -690,7 +692,7 @@ export interface GameAsset extends BuildAsset {
 export async function getGameAssets(pool: Pool, gameId: number, includePrivate = false): Promise<GameAsset[]> {
   const r = await pool.query(
     `SELECT b.sha256 AS build_sha256, b.name AS build_name,
-            a.path, a.sha256, a.size::float8 AS size, a.mime, a.kind
+            a.path, a.sha256, a.size::float8 AS size, a.mime, a.kind, a.file_date
      FROM build_asset a JOIN builds b ON b.sha256 = a.build_sha256
      WHERE b.game_id=$1 AND ${includePrivate ? "TRUE" : visibleSql("b")}
      ORDER BY b.build_date NULLS LAST, lower(b.name), a.path`,

--- a/web/src/lib/queries.ts
+++ b/web/src/lib/queries.ts
@@ -675,6 +675,43 @@ export async function getBuildAssets(pool: Pool, sha256: string): Promise<BuildA
   return r.rows as BuildAsset[];
 }
 
+/** An asset in the game-wide combined gallery: `path` is namespaced as
+ *  "/<build name>/<path within the build>" so paths stay unique across the
+ *  game's builds and the viewer title shows which build a file came from. */
+export interface GameAsset extends BuildAsset {
+  build_sha256: string;
+  build_name: string;
+}
+
+/// Every visible build's assets for one game, builds in the game page's
+/// order (oldest first), paths namespaced by build name. Public surface —
+/// private builds stay hidden (visibleSql). Two builds sharing a display
+/// name get the second's short sha appended so namespaces never collide.
+export async function getGameAssets(pool: Pool, gameId: number, includePrivate = false): Promise<GameAsset[]> {
+  const r = await pool.query(
+    `SELECT b.sha256 AS build_sha256, b.name AS build_name,
+            a.path, a.sha256, a.size::float8 AS size, a.mime, a.kind
+     FROM build_asset a JOIN builds b ON b.sha256 = a.build_sha256
+     WHERE b.game_id=$1 AND ${includePrivate ? "TRUE" : visibleSql("b")}
+     ORDER BY b.build_date NULLS LAST, lower(b.name), a.path`,
+    [gameId]
+  );
+  const rows = r.rows as GameAsset[];
+  const nsBySha = new Map<string, string>();
+  const taken = new Set<string>();
+  for (const a of rows) {
+    if (!nsBySha.has(a.build_sha256)) {
+      const ns = taken.has(a.build_name) ? `${a.build_name} (${a.build_sha256.slice(0, 10)})` : a.build_name;
+      taken.add(ns);
+      nsBySha.set(a.build_sha256, ns);
+    }
+  }
+  return rows.map((a) => ({
+    ...a,
+    path: `/${nsBySha.get(a.build_sha256)}/${a.path.replace(/^\/+/, "")}`,
+  }));
+}
+
 /** One attached source repository of a build (see db build_repo; the bytes —
  *  manifest + git blobs — live in the asset store). */
 export interface BuildRepoRow {
@@ -891,6 +928,17 @@ async function ensureGameSlug(pool: Pool, row: GameRow): Promise<GameRow> {
   return { ...row, slug: (u2.rows[0]?.slug as string) ?? row.slug };
 }
 
+/** Get-or-create a game by (name, system), slug filled. */
+export async function upsertGame(pool: Pool, name: string, system = ""): Promise<GameRow> {
+  const g = await pool.query(
+    `INSERT INTO games(name, system) VALUES ($1, $2)
+     ON CONFLICT (name, system) DO UPDATE SET name=excluded.name
+     RETURNING id::int AS id, name, system, slug`,
+    [name, system]
+  );
+  return ensureGameSlug(pool, g.rows[0] as GameRow);
+}
+
 /// Moderator game assignment: null clears; a (name, system) upserts into
 /// games (so typing a new title creates it) and points the build at it.
 /// Returns the resulting game, or undefined when the build doesn't exist.
@@ -904,15 +952,41 @@ export async function setBuildGame(
     const r = await pool.query("UPDATE builds SET game_id=NULL WHERE sha256=$1 RETURNING sha256", [sha256]);
     return r.rows.length ? null : undefined;
   }
-  const g = await pool.query(
-    `INSERT INTO games(name, system) VALUES ($1, $2)
-     ON CONFLICT (name, system) DO UPDATE SET name=excluded.name
-     RETURNING id::int AS id, name, system, slug`,
-    [game, system]
-  );
-  const row = await ensureGameSlug(pool, g.rows[0] as GameRow);
+  const row = await upsertGame(pool, game, system);
   const r = await pool.query("UPDATE builds SET game_id=$2 WHERE sha256=$1 RETURNING sha256", [sha256, row.id]);
   return r.rows.length ? row : undefined;
+}
+
+/// Bulk moderator edit over a set of builds: assign/clear game and/or move
+/// between lots in one statement each. Returns the affected builds (sha256 +
+/// name, for page revalidation) and the game when one was assigned.
+export async function bulkUpdateBuilds(
+  pool: Pool,
+  sha256s: string[],
+  fields: { game?: string | null; gameSystem?: string; lot?: string | null }
+): Promise<{ updated: { sha256: string; name: string }[]; game: GameRow | null }> {
+  let game: GameRow | null = null;
+  const sets: string[] = [];
+  const params: unknown[] = [sha256s];
+  if (fields.game !== undefined) {
+    if (fields.game === null) {
+      sets.push("game_id=NULL");
+    } else {
+      game = await upsertGame(pool, fields.game, fields.gameSystem ?? "");
+      params.push(game.id);
+      sets.push(`game_id=$${params.length}`);
+    }
+  }
+  if (fields.lot !== undefined) {
+    params.push(fields.lot);
+    sets.push(`lot=$${params.length}`);
+  }
+  if (!sets.length) throw new Error("bulkUpdateBuilds: no fields to update");
+  const r = await pool.query(
+    `UPDATE builds SET ${sets.join(", ")} WHERE sha256 = ANY($1::text[]) RETURNING sha256, name`,
+    params
+  );
+  return { updated: r.rows as { sha256: string; name: string }[], game };
 }
 
 /** Whether a lot is hidden from non-moderators. */


### PR DESCRIPTION
Game pages now show one combined asset gallery across every visible build of the game, with paths namespaced by build name so the lightbox shows where each file came from. The gallery deep-links through /games/<slug>/assets/<build>/<path>, mirroring the per-build assets pages.

For moderators, the /builds table and the game page build list gain row checkboxes and a mass-apply bar: select builds, then set or clear their game or lot in one request. The new POST /api/builds endpoint applies the whole selection at once and reuses the PATCH validation and revalidation semantics.