### PR TITLE
Make build tree sidebar narrower and resizable

### DIFF
--- a/windows/PrismWin/MainWindow.xaml
+++ b/windows/PrismWin/MainWindow.xaml
@@ -78,20 +78,22 @@
                  rounded layer card at right (the Windows 11 Settings layout). -->
             <Grid x:Name="BuildPane">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="2*" MinWidth="220" />
-                    <ColumnDefinition Width="3*" />
+                    <ColumnDefinition x:Name="TreeColumn" Width="280" MinWidth="200" MaxWidth="560" />
+                    <ColumnDefinition Width="8" />
+                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
                 <Grid Grid.Column="0" Margin="8,0,0,8">
                     <TreeView x:Name="FsTree" SelectionMode="Single" ItemInvoked="FsTree_ItemInvoked"
-                              Margin="0,4,4,0">
+                              Margin="0,4,0,0">
                         <TreeView.ItemTemplate>
                             <DataTemplate x:DataType="local:DiscNodeVm">
                                 <TreeViewItem ItemsSource="{x:Bind Children}" IsExpanded="{x:Bind IsRoot}">
-                                    <StackPanel Orientation="Horizontal" Spacing="9">
+                                    <StackPanel Orientation="Horizontal" Spacing="5">
                                         <FontIcon Glyph="{x:Bind Glyph}" FontSize="14"
+                                                  VerticalAlignment="Center"
                                                   Foreground="{x:Bind IconBrush}" />
-                                        <TextBlock Text="{x:Bind Name}" />
+                                        <TextBlock Text="{x:Bind Name}" VerticalAlignment="Center" />
                                     </StackPanel>
                                 </TreeViewItem>
                             </DataTemplate>
@@ -112,7 +114,14 @@
                     </StackPanel>
                 </Grid>
 
-                <Border Grid.Column="1" Margin="4,4,16,8" CornerRadius="8"
+                <!-- Invisible drag strip in the gutter between the panes. -->
+                <local:SizerBar Grid.Column="1" Background="Transparent" Margin="0,4,0,8"
+                                PointerPressed="TreeSizer_PointerPressed"
+                                PointerMoved="TreeSizer_PointerMoved"
+                                PointerReleased="TreeSizer_PointerReleased"
+                                PointerCaptureLost="TreeSizer_PointerCaptureLost" />
+
+                <Border Grid.Column="2" Margin="0,4,16,8" CornerRadius="8"
                         Background="{ThemeResource LayerFillColorDefaultBrush}"
                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1">
                     <Grid>

--- a/windows/PrismWin/MainWindow.xaml.cs
+++ b/windows/PrismWin/MainWindow.xaml.cs
@@ -859,6 +859,40 @@ public sealed partial class MainWindow : Window
         }
     }
 
+    // Hand-rolled tree/detail splitter: the toolkit's GridSplitter would pull
+    // the WindowsAppSDK meta package back in (see the csproj note).
+    private bool _treeSizing;
+    private double _treeSizeStartX;
+    private double _treeSizeStartWidth;
+
+    private void TreeSizer_PointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        var point = e.GetCurrentPoint(BuildPane);
+        if (point.Properties.IsRightButtonPressed) return;
+        _treeSizing = ((UIElement)sender).CapturePointer(e.Pointer);
+        _treeSizeStartX = point.Position.X;
+        _treeSizeStartWidth = TreeColumn.ActualWidth;
+    }
+
+    private void TreeSizer_PointerMoved(object sender, PointerRoutedEventArgs e)
+    {
+        if (!_treeSizing) return;
+        var dx = e.GetCurrentPoint(BuildPane).Position.X - _treeSizeStartX;
+        TreeColumn.Width = new GridLength(Math.Clamp(
+            _treeSizeStartWidth + dx, TreeColumn.MinWidth, TreeColumn.MaxWidth));
+    }
+
+    private void TreeSizer_PointerReleased(object sender, PointerRoutedEventArgs e)
+    {
+        _treeSizing = false;
+        ((UIElement)sender).ReleasePointerCapture(e.Pointer);
+    }
+
+    private void TreeSizer_PointerCaptureLost(object sender, PointerRoutedEventArgs e)
+    {
+        _treeSizing = false;
+    }
+
     // ---- assets ----
 
     private static readonly string[] AssetKindOrder = { "image", "audio", "video", "document", "source", "text", "binary" };

--- a/windows/PrismWin/SizerBar.cs
+++ b/windows/PrismWin/SizerBar.cs
@@ -5,8 +5,9 @@ namespace PrismWin;
 
 /// Hit strip between resizable panes showing the east-west resize cursor.
 /// ProtectedCursor is only settable from inside a UIElement subclass, hence
-/// this class; the drag logic lives with the owner of the sized column.
-public sealed partial class SizerBar : Border
+/// this class (a Panel because Border is sealed in the WinRT projection);
+/// the drag logic lives with the owner of the sized column.
+public sealed partial class SizerBar : Panel
 {
     public SizerBar()
     {

--- a/windows/PrismWin/SizerBar.cs
+++ b/windows/PrismWin/SizerBar.cs
@@ -1,0 +1,15 @@
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml.Controls;
+
+namespace PrismWin;
+
+/// Hit strip between resizable panes showing the east-west resize cursor.
+/// ProtectedCursor is only settable from inside a UIElement subclass, hence
+/// this class; the drag logic lives with the owner of the sized column.
+public sealed partial class SizerBar : Border
+{
+    public SizerBar()
+    {
+        ProtectedCursor = InputSystemCursor.Create(InputSystemCursorShape.SizeWestEast);
+    }
+}


### PR DESCRIPTION
The file tree pane in the Windows app now starts at 280px instead of taking 40% of the window, and can be resized by dragging the gutter between the panes (200 to 560px). The splitter is hand rolled because the toolkit's GridSplitter would pull the WindowsAppSDK meta package back into the self-contained output.

Tree rows also read tighter: icon to label spacing drops from 9 to 5 and the glyph and text are vertically centered.