### PR TITLE
InstallShield cabinet support

### DIFF
--- a/ps2exe-adapter/prism_adapter/cli.py
+++ b/ps2exe-adapter/prism_adapter/cli.py
@@ -462,11 +462,16 @@ def _gather_info(processor, reader, system, mods):
 # untouched — composite hashing sees only the archive file's own hashes (the
 # consumer skips in_archive records there), and members carry no chunk/shingle
 # fingerprints. Detection is by leading bytes (plus
-# tar's magic at offset 257); anything ArchiveWrapper can't open (bare gzip of
-# a single file, InstallShield cab, passworded/corrupt archives) quietly stays
-# a plain file.
+# tar's magic at offset 257). InstallShield cabinets expand the same way, with
+# one twist: a multi-volume set is anchored at one member (the .hdr on IS6+,
+# data1.cab before that) whose expansion pulls the sibling volumes in through
+# the containing reader, while the secondary volumes themselves stay plain
+# files. Anything that can't be opened (bare gzip of a single file,
+# passworded/corrupt archives, a data-only cab volume) quietly stays a plain file.
 _ARCHIVE_SNIFF_BYTES = 512
 _ARCHIVE_MAX_DEPTH = 3
+
+_ISHIELD_MAGIC = b"ISc("    # installshield cabinet/header
 
 _ARCHIVE_MAGICS = (
     b"PK\x03\x04",          # zip
@@ -476,6 +481,7 @@ _ARCHIVE_MAGICS = (
     b"\x1F\x8B\x08",        # gzip (a .tar.gz; a bare .gz fails to open and stays a file)
     b"BZh",                 # bzip2
     b"\xFD7zXZ\x00",        # xz
+    _ISHIELD_MAGIC,
 )
 
 
@@ -495,21 +501,36 @@ class _ArchiveSource:
         return getattr(self._fh, attr)
 
 
-def _open_member_archive(reader, entry, path, manager):
-    """A CompressedPathReader over an archive member, or None when the member
-    can't be opened as one (unsupported/corrupt/passworded). The caller must
-    hand the result to _close_member_archive, which also releases the
-    decompression spool and the member handle."""
+def _open_member_archive(reader, entry, path, manager, head=b""):
+    """A CompressedPathReader over an archive or InstallShield-cabinet member, or
+    None when the member can't be opened as one (unsupported/corrupt/passworded/a
+    secondary cab volume). The caller must hand the result to
+    _close_member_archive, which also releases the decompression spool and the
+    member handle."""
     if str(_PS2EXE_DIR) not in sys.path:  # set by _import_ps2exe in normal runs
         sys.path.insert(0, str(_PS2EXE_DIR))
-    from common.iso_path_reader.methods.compressed import CompressedPathReader  # noqa: E402
+    from common.iso_path_reader.methods.compressed import (  # noqa: E402
+        CompressedPathReader,
+        InstallShieldPathReader,
+    )
     from utils.archives import ArchiveWrapper  # noqa: E402
+    from utils.installshield import InstallShieldCabWrapper  # noqa: E402
 
     fh = None
     try:
         fh = reader.open_file(entry)
         if hasattr(fh, "__enter__"):
             fh.__enter__()
+        if head.startswith(_ISHIELD_MAGIC):
+            # The wrapper resolves the set's other pieces (the .hdr anchor,
+            # data2.cab, external files) by name through `reader`, so it gets
+            # the reader-native member path, not the display path.
+            native = str(reader.get_file_path(entry))
+            src = _ArchiveSource(fh, native)
+            name = os.path.basename(native.replace("\\", "/"))
+            return InstallShieldPathReader(
+                InstallShieldCabWrapper(src, name, reader, manager), src, reader
+            )
         src = fh if getattr(fh, "name", None) else _ArchiveSource(fh, path)
         return CompressedPathReader(ArchiveWrapper(src, reader, manager), src, reader)
     except Exception as e:  # noqa: BLE001 — any failure means "not an archive we can read"
@@ -565,15 +586,15 @@ def _hash_files(reader, manager, prefix="", depth=0):
 
             files.append(rec)
             if head is not None and depth < _ARCHIVE_MAX_DEPTH and _looks_like_archive(head):
-                files.extend(_archive_member_files(reader, f, path, manager, depth))
+                files.extend(_archive_member_files(reader, f, path, manager, depth, head))
             pbar.update()
     return files
 
 
-def _archive_member_files(reader, entry, path, manager, depth):
+def _archive_member_files(reader, entry, path, manager, depth, head=b""):
     """Hash an archive member's own members as `<path>/...` records. Best-effort:
     an archive that can't be opened or dies mid-listing just stays a plain file."""
-    child = _open_member_archive(reader, entry, path, manager)
+    child = _open_member_archive(reader, entry, path, manager, head)
     if child is None:
         return []
     try:
@@ -868,7 +889,7 @@ def _extract_assets(reader, out_dir, manager, prefix="", depth=0):
                 head = _read_head(reader, f, viewable.SNIPPET_BYTES)
                 asset = (head, viewable.SNIPPET_MIME, viewable.SNIPPET_KIND) if head else None
                 if head and depth < _ARCHIVE_MAX_DEPTH and _looks_like_archive(head):
-                    out.extend(_archive_member_assets(reader, f, path, out_dir, manager, depth))
+                    out.extend(_archive_member_assets(reader, f, path, out_dir, manager, depth, head))
             else:
                 kind, mime = classified
                 if size is not None and size > viewable.MAX_ASSET_SIZE:
@@ -904,10 +925,10 @@ def _extract_assets(reader, out_dir, manager, prefix="", depth=0):
     return out
 
 
-def _archive_member_assets(reader, entry, path, out_dir, manager, depth):
+def _archive_member_assets(reader, entry, path, out_dir, manager, depth, head=b""):
     """Extract an archive member's own members as `<path>/...` assets.
     Best-effort, like the listing pass."""
-    child = _open_member_archive(reader, entry, path, manager)
+    child = _open_member_archive(reader, entry, path, manager, head)
     if child is None:
         return []
     try:

--- a/ps2exe-adapter/tests/test_installshield.py
+++ b/ps2exe-adapter/tests/test_installshield.py
@@ -1,0 +1,209 @@
+"""InstallShield cabinets inside a volume expand like archives.
+
+These run the real InstallShieldCabWrapper/InstallShieldPathReader stack from
+lib/ps2exe over synthetic single-volume IS5 cabinets served through a minimal
+fake volume reader. The builder writes just the format subset the parser needs:
+common header, V5 volume header, file table, V5 file descriptors, stored and
+zlib-chunk file data.
+"""
+
+import hashlib
+import io
+import struct
+import zlib
+
+from prism_adapter import viewable
+from prism_adapter.cli import _extract_assets, _hash_files
+from prism_adapter.progress import ProgressManager
+
+_COMMON = struct.Struct("<4sIIII")
+_VOLHDR = struct.Struct("<I4x8I")
+_FD_V5 = struct.Struct("<IH2xHII4xH2xH2x8xI")
+
+_VERSION_IS5 = 0x01005000  # (version >> 12) & 0xF == 5
+_FILE_COMPRESSED = 4
+
+# 1999-06-15 12:30:00 in DOS date/time fields.
+_DOS_DATE = (19 << 9) | (6 << 5) | 15
+_DOS_TIME = (12 << 11) | (30 << 5)
+
+
+def deflate_chunk(data):
+    """One new-style chunk: 2-byte length prefix + a complete raw-deflate stream."""
+    co = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+    stream = co.compress(data) + co.flush()
+    return struct.pack("<H", len(stream)) + stream
+
+
+def make_iscab(files, compress=()):
+    """A minimal single-volume InstallShield 5 cabinet.
+
+    `files` maps member path (at most one directory level) to bytes; paths in
+    `compress` are stored as new-style zlib chunks, the rest stored plain.
+    """
+    items = []  # (dir, name, plain, blob, flags)
+    dirs = []
+    for path, data in files.items():
+        d, _, n = path.rpartition("/")
+        if d and d not in dirs:
+            dirs.append(d)
+        if path in compress:
+            items.append((d, n, data, deflate_chunk(data), _FILE_COMPRESSED))
+        else:
+            items.append((d, n, data, data, 0))
+
+    data_off = _COMMON.size + _VOLHDR.size
+    offsets, pos = [], data_off
+    for _d, _n, _plain, blob, _fl in items:
+        offsets.append(pos)
+        pos += len(blob)
+    desc_off = pos
+
+    # Descriptor region: CabDescriptor at +0, the 71 file-group list heads at
+    # +0x3E left zero (no groups), file table just past them.
+    table_off = 0x3E + 71 * 4 + 6
+    count = len(dirs) + len(items)
+    heap = bytearray()
+    heap_base = count * 4
+
+    def put(blob):
+        off = heap_base + len(heap)
+        heap.extend(blob)
+        return off
+
+    table = []
+    for d in dirs:
+        table.append(put(d.encode("cp1252") + b"\x00"))
+    for (d, n, plain, blob, flags), off in zip(items, offsets):
+        name_off = put(n.encode("cp1252") + b"\x00")
+        fd = _FD_V5.pack(name_off, dirs.index(d) if d else 0xFFFF, flags,
+                         len(plain), len(blob), _DOS_DATE, _DOS_TIME, off)
+        table.append(put(fd + b"\x00" * 16))  # V5 reads a trailing md5 slot
+    table_size = count * 4 + len(heap)
+
+    descriptor = bytearray(table_off)
+    descriptor[:48] = struct.pack("<12xI4xIII8xII", table_off, table_size,
+                                  table_size, len(dirs), len(items), 0)
+    descriptor.extend(struct.pack("<%dI" % count, *table) if table else b"")
+    descriptor.extend(heap)
+
+    # Sized so the FILE_SPLIT derivation sees whole files in this volume.
+    first_sizes = (len(items[0][2]), len(items[0][3])) if items else (0, 0)
+    last_sizes = (len(items[-1][2]), len(items[-1][3])) if items else (0, 0)
+    volhdr = _VOLHDR.pack(data_off, 0, max(len(items) - 1, 0),
+                          offsets[0] if items else 0, *first_sizes,
+                          offsets[-1] if items else 0, *last_sizes)
+
+    out = bytearray(_COMMON.pack(b"ISc(", _VERSION_IS5, 0, desc_off, len(descriptor)))
+    out.extend(volhdr)
+    for _d, _n, _plain, blob, _fl in items:
+        out.extend(blob)
+    out.extend(descriptor)
+    return bytes(out)
+
+
+class FakeVolume:
+    """Minimal volume reader: files as {path: bytes}. Unlike the archive tests'
+    fake this also resolves paths, which the cab wrapper uses to find the other
+    pieces of a volume set (data2.cab, a .hdr anchor)."""
+
+    def __init__(self, files):
+        self.files = list(files.items())
+
+    def get_root_dir(self):
+        return None
+
+    def iso_iterator(self, _root, recursive=True, include_dirs=False):
+        return iter(range(len(self.files)))
+
+    def is_directory(self, f):
+        return False
+
+    def get_file_date(self, f):
+        return None
+
+    def get_file_path(self, f):
+        return self.files[f][0]
+
+    def get_file_size(self, f):
+        return len(self.files[f][1])
+
+    def get_file(self, path):
+        for i, (name, _data) in enumerate(self.files):
+            if name.lstrip("/") == path.lstrip("/"):
+                return i
+        raise FileNotFoundError(path)
+
+    def open_file(self, f):
+        return io.BytesIO(self.files[f][1])
+
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+INI = b"[Setup]\nTitle=Proto\n"
+EXE = b"MZ" + bytes(range(256)) * 8
+
+
+def hash_files(files):
+    recs = _hash_files(FakeVolume(files), ProgressManager())
+    return {r["path"]: r for r in recs}
+
+
+def test_cab_members_are_listed_as_directory_contents():
+    cab = make_iscab({"SETUP.INI": INI, "prog/GAME.EXE": EXE},
+                     compress={"prog/GAME.EXE"})
+    recs = hash_files({"/DATA1.CAB": cab, "/README.TXT": b"hello"})
+
+    # The cabinet itself stays a normal, fully hashed file (identity input).
+    c = recs["/DATA1.CAB"]
+    assert "in_archive" not in c
+    assert c["sha1"] == hashlib.sha1(cab).hexdigest()
+
+    # Members ride under the cabinet's path, hashed but unfingerprinted.
+    ini = recs["/DATA1.CAB/SETUP.INI"]
+    assert ini["in_archive"] is True
+    assert ini["size"] == len(INI)
+    assert ini["sha1"] == hashlib.sha1(INI).hexdigest()
+    assert ini["date"] == "1999-06-15 12:30:00"
+    assert "chunks" not in ini and "shingle" not in ini
+
+    # A compressed member decodes through the zlib chunk path.
+    exe = recs["/DATA1.CAB/prog/GAME.EXE"]
+    assert exe["sha256"] == hashlib.sha256(EXE).hexdigest()
+    assert "unreadable" not in exe
+
+
+def test_secondary_volume_stays_a_plain_file():
+    cab = make_iscab({"SETUP.INI": INI})
+    # A data volume: valid signature, but the set is anchored at DATA1.CAB.
+    data2 = _COMMON.pack(b"ISc(", _VERSION_IS5, 0, 0, 0) + b"\x00" * 64
+    recs = hash_files({"/DATA1.CAB": cab, "/DATA2.CAB": data2})
+
+    assert recs["/DATA1.CAB/SETUP.INI"]["in_archive"] is True
+    assert recs["/DATA2.CAB"]["sha1"] == hashlib.sha1(data2).hexdigest()
+    assert [p for p in recs if p.startswith("/DATA2.CAB/")] == []
+
+
+def test_empty_and_corrupt_cabs_stay_plain_files():
+    empty = make_iscab({})
+    corrupt = b"ISc(" + b"\xde\xad\xbe\xef" * 20
+    recs = hash_files({"/EMPTY.CAB": empty, "/BROKEN.CAB": corrupt, "/OK.BIN": b"fine"})
+
+    assert recs["/EMPTY.CAB"]["sha1"] == hashlib.sha1(empty).hexdigest()
+    assert recs["/BROKEN.CAB"]["sha1"] == hashlib.sha1(corrupt).hexdigest()
+    assert "unreadable" not in recs["/BROKEN.CAB"]
+    assert [p for p in recs if "/EMPTY.CAB/" in p or "/BROKEN.CAB/" in p] == []
+
+
+def test_cab_member_assets_are_extracted(tmp_path):
+    cab = make_iscab({"ART/TITLE.PNG": PNG}, compress={"ART/TITLE.PNG"})
+    out = _extract_assets(FakeVolume({"/DATA1.CAB": cab}), str(tmp_path), ProgressManager())
+    assets = {a["path"]: a for a in out}
+
+    # The cabinet keeps its own head-snippet asset (hex view) …
+    assert assets["/DATA1.CAB"]["kind"] == viewable.SNIPPET_KIND
+
+    # … and its viewable members ship whole under prefixed paths.
+    png = assets["/DATA1.CAB/ART/TITLE.PNG"]
+    assert (png["kind"], png["mime"], png["size"]) == ("image", "image/png", len(PNG))
+    blob = (tmp_path / png["sha256"][:2] / png["sha256"]).read_bytes()
+    assert blob == PNG

--- a/web/scripts/ingest.ts
+++ b/web/scripts/ingest.ts
@@ -122,12 +122,38 @@ function openRecords(path: string): { lines: Readable; done: Promise<void> } {
   return { lines: fs.createReadStream(path), done: Promise.resolve() };
 }
 
+/** Bust the web app's caches for the ingested builds (ISR pages + tree caches)
+ *  via /api/refresh. Opt-in: needs REFRESH_TOKEN in the environment (and
+ *  REFRESH_URL when the app isn't on localhost:6800). Best-effort — a failure
+ *  leaves the pages to their hourly revalidation, never the ingest broken. */
+async function refreshWeb(shas: string[]) {
+  const token = process.env.REFRESH_TOKEN;
+  if (!token || shas.length === 0) return;
+  const base = process.env.REFRESH_URL || "http://localhost:6800";
+  try {
+    const res = await fetch(`${base}/api/refresh`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-refresh-token": token },
+      body: JSON.stringify({ sha256s: shas }),
+    });
+    if (res.ok) {
+      const { refreshed } = (await res.json()) as { refreshed: number };
+      console.log(`refreshed ${refreshed} build page(s)`);
+    } else {
+      console.warn(`page refresh failed: HTTP ${res.status}`);
+    }
+  } catch (e) {
+    console.warn(`page refresh failed: ${(e as Error).message}`);
+  }
+}
+
 async function main() {
   const pool = new pg.Pool({
     connectionString: process.env.DATABASE_URL || "postgres:///prism_test",
   });
   let n = 0;
   let lineNo = 0;
+  const ingested: string[] = [];
   const failures: { line: number; sha?: string; name?: string; error: string }[] = [];
   try {
     // Blobs before rows: once a build_asset row exists, its blob is servable.
@@ -153,6 +179,7 @@ async function main() {
       try {
         await ingestRecordTx(pool, rec);
         n++;
+        if (rec.image?.sha256) ingested.push(rec.image.sha256);
       } catch (e) {
         failures.push({
           line: lineNo,
@@ -170,6 +197,7 @@ async function main() {
     await pool.end();
   }
   console.log(`ingested ${n} builds`);
+  await refreshWeb(ingested);
   if (failures.length) {
     console.error(`\n${failures.length} record(s) failed and were skipped:`);
     for (const f of failures) {

--- a/web/src/app/api/build/[sha256]/tree/route.ts
+++ b/web/src/app/api/build/[sha256]/tree/route.ts
@@ -24,7 +24,9 @@ const getTree = (sha256: string) =>
       const build = await getBuild(getPool(), sha256);
       return build ? buildTree(build.record.contents) : null;
     },
-    ["build-tree", sha256],
+    // v2: untagged v1 entries predate /api/refresh and can't be revalidated,
+    // so they get a fresh key namespace and age out on their own.
+    ["build-tree-v2", sha256],
     { revalidate: 3600, tags: [`build-tree:${sha256}`] }
   )();
 

--- a/web/src/app/api/build/[sha256]/tree/route.ts
+++ b/web/src/app/api/build/[sha256]/tree/route.ts
@@ -16,15 +16,17 @@ export const runtime = "nodejs";
 const CACHE = "public, max-age=3600";
 
 // Expanding folder after folder of the same build would otherwise re-fetch and
-// re-parse the full record (8MB+ for the biggest builds) per click.
-const getTree = unstable_cache(
-  async (sha256: string): Promise<TreeNode[] | null> => {
-    const build = await getBuild(getPool(), sha256);
-    return build ? buildTree(build.record.contents) : null;
-  },
-  ["build-tree"],
-  { revalidate: 3600 }
-);
+// re-parse the full record (8MB+ for the biggest builds) per click. Tagged
+// per build so a re-ingest can revalidate one build's tree (see /api/refresh).
+const getTree = (sha256: string) =>
+  unstable_cache(
+    async (): Promise<TreeNode[] | null> => {
+      const build = await getBuild(getPool(), sha256);
+      return build ? buildTree(build.record.contents) : null;
+    },
+    ["build-tree", sha256],
+    { revalidate: 3600, tags: [`build-tree:${sha256}`] }
+  )();
 
 export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
   const { sha256 } = await ctx.params;

--- a/web/src/app/api/refresh/route.ts
+++ b/web/src/app/api/refresh/route.ts
@@ -1,0 +1,52 @@
+import { timingSafeEqual } from "node:crypto";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { getPool } from "@/lib/db";
+import { buildHref } from "@/lib/slug";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+
+// POST /api/refresh { sha256s: [...] } — bust the caches of re-ingested builds:
+// each build's ISR page (canonical path, bare-sha redirect, assets subpage),
+// its tagged tree cache, and the /builds listing. The moderation endpoints
+// revalidate what they touch on their own; this is for scripts/ingest.ts,
+// whose record updates otherwise sit behind the hour-long caches.
+//
+// Gated by REFRESH_TOKEN from the environment (x-refresh-token header) and
+// disabled when the variable is unset.
+export async function POST(request: Request) {
+  const token = process.env.REFRESH_TOKEN;
+  if (!token) return Response.json({ error: "not found" }, { status: 404 });
+  const given = Buffer.from(request.headers.get("x-refresh-token") ?? "");
+  const expected = Buffer.from(token);
+  if (given.length !== expected.length || !timingSafeEqual(given, expected)) {
+    return Response.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  let body: { sha256s?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "require { sha256s: [...] }" }, { status: 400 });
+  }
+  const shas = Array.isArray(body.sha256s)
+    ? [...new Set(body.sha256s.filter((s): s is string => typeof s === "string" && isSha256(s)))]
+    : [];
+  if (shas.length === 0) {
+    return Response.json({ error: "require { sha256s: [...] }" }, { status: 400 });
+  }
+
+  const named = (await getPool().query("SELECT sha256, name FROM builds WHERE sha256 = ANY($1)", [
+    shas,
+  ])) as { rows: { sha256: string; name: string }[] };
+
+  revalidatePath("/builds");
+  for (const { sha256, name } of named.rows) {
+    const href = buildHref(sha256, name);
+    revalidatePath(href);
+    revalidatePath(`${href}/assets`);
+    revalidatePath(`/builds/${sha256}`);
+    revalidateTag(`build-tree:${sha256}`, "max");
+  }
+  return Response.json({ refreshed: named.rows.length });
+}


### PR DESCRIPTION
Updates ps2exe to pick up its new InstallShield cabinet reader and teaches the adapter to expand cabinets found inside volumes, the same way zip and 7z members already ride under the archive's path with in_archive set. Multi-volume sets are anchored at the .hdr file (data1.cab on IS5 and older), secondary volumes stay plain files, and build identity is unaffected since archive members are excluded from composites.

Also adds a token-gated POST /api/refresh that busts a build's ISR page and its newly tagged tree cache, with ingest.ts calling it after committing records, so re-ingested builds surface without waiting out the hour-long caches. Deployed to hpwiki with REFRESH_TOKEN set in the server env. Tested on synthetic IS5 cabinets in the adapter suite and on the Baldur's Gate demo and Tales of the Sword Coast discs, whose build pages now list the cabinet contents.