### PR TITLE
Harden uploads

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,22 @@
 import type { NextConfig } from "next";
 
+// Baseline security headers on every response. Kept conservative so they can't
+// break the app: `frame-ancestors 'none'` (+ legacy X-Frame-Options) stops
+// clickjacking without touching how pages load, and the asset routes still set
+// their own stricter per-response CSP on top. No page-level default-src here —
+// that would need Next's nonce plumbing and is out of scope.
+const SECURITY_HEADERS = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
+  { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains" },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [{ source: "/:path*", headers: SECURITY_HEADERS }];
+  },
 };
 
 export default nextConfig;

--- a/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/assets/[assetSha]/route.ts
@@ -4,7 +4,13 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
-import { assetStagingPath, blobExists, storeBlobFromFile } from "@/lib/blobstore";
+import {
+  assetStagingPath,
+  blobExists,
+  hasStagingHeadroom,
+  reapStaleAssetStaging,
+  storeBlobFromFile,
+} from "@/lib/blobstore";
 import { referencedAssets, MAX_BUILD_ASSET_BYTES } from "@/lib/submission-assets";
 import { rateLimitCheck, clientKey } from "@/lib/ratelimit";
 import { isSha256 } from "@/lib/validate";
@@ -65,6 +71,15 @@ export async function PUT(
     return Response.json({ error: "invalid offset" }, { status: 400 });
   }
   if (!request.body) return Response.json({ error: "missing body" }, { status: 400 });
+
+  // Reap abandoned staging, then refuse to grow it when the disk is low: the
+  // endpoint is unauthenticated, so a partial-upload flood must never fill the
+  // store out from under Postgres and the transcode caches. The reserve is kept
+  // regardless of how many distinct blobs are in flight.
+  await reapStaleAssetStaging();
+  if (!(await hasStagingHeadroom(claimed - offset))) {
+    return Response.json({ error: "insufficient storage" }, { status: 507 });
+  }
 
   // A non-zero offset must continue exactly where the staging file ends.
   const part = assetStagingPath(assetSha);

--- a/web/src/app/api/submissions/route.ts
+++ b/web/src/app/api/submissions/route.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
 import { enqueueSubmission, listSubmissions } from "@/lib/queries";
 import { getModerator, moderationEnabled } from "@/lib/auth";
-import { MAX_BODY_BYTES, validateBuildRecord } from "@/lib/validate";
+import { MAX_BODY_BYTES, MAX_NICKNAME_LEN, validateBuildRecord } from "@/lib/validate";
 import { rateLimit, clientKey } from "@/lib/ratelimit";
 import type { BuildRecord } from "@/lib/types";
 
@@ -27,6 +27,12 @@ export async function POST(request: NextRequest) {
   if (!rateLimit(`submissions:${clientKey(request)}`, 30, 60_000)) {
     return Response.json({ error: "rate limit exceeded" }, { status: 429 });
   }
+  // Reject an oversized body by its declared length before buffering it whole
+  // into memory; the post-read check still guards chunked requests that omit it.
+  const declared = Number(request.headers.get("content-length") ?? "0");
+  if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+    return Response.json({ error: "request body too large" }, { status: 413 });
+  }
   const text = await request.text();
   if (text.length > MAX_BODY_BYTES) {
     return Response.json({ error: "request body too large" }, { status: 413 });
@@ -38,8 +44,11 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: "invalid JSON body" }, { status: 400 });
   }
   const { nickname } = body;
-  if (!nickname) {
+  if (!nickname || typeof nickname !== "string") {
     return Response.json({ error: "require { nickname, record(with image.sha256) }" }, { status: 400 });
+  }
+  if (nickname.length > MAX_NICKNAME_LEN) {
+    return Response.json({ error: `nickname exceeds ${MAX_NICKNAME_LEN} characters` }, { status: 400 });
   }
   const v = validateBuildRecord(body.record);
   if (!v.ok) {

--- a/web/src/lib/blobstore.ts
+++ b/web/src/lib/blobstore.ts
@@ -56,6 +56,59 @@ export function assetStagingPath(sha256: string): string {
   return path.join(assetStoreDir(), ".staging", `${sha256}.part`);
 }
 
+// Asset staging files (`<sha>.part`) abandoned this long are reaped, so a flood
+// of never-finalized uploads can't pile up on the store disk. Media sessions
+// (`media-*`) carry their own reaper and are left alone here.
+const ASSET_STAGING_TTL_MS = 24 * 3600_000;
+
+/** Remove asset staging files past the TTL. Best-effort and opportunistic —
+ *  the asset upload route calls it before staging a fresh chunk. */
+export async function reapStaleAssetStaging(): Promise<void> {
+  const dir = path.join(assetStoreDir(), ".staging");
+  const cutoff = Date.now() - ASSET_STAGING_TTL_MS;
+  let names: string[];
+  try {
+    names = await fsp.readdir(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (!name.endsWith(".part") || name.startsWith("media-")) continue;
+    const p = path.join(dir, name);
+    try {
+      if ((await fsp.stat(p)).mtimeMs < cutoff) await fsp.rm(p, { force: true });
+    } catch {
+      // Raced with another reaper or an active finalize; leave it.
+    }
+  }
+}
+
+/** Free space the store filesystem must keep in reserve: staging writes refuse
+ *  below it, so an upload flood can't fill the disk out from under Postgres and
+ *  in-flight transcodes (env ASSET_STORE_MIN_FREE_BYTES, default 5 GiB). */
+export function storeMinFreeBytes(): number {
+  const raw = Number(process.env.ASSET_STORE_MIN_FREE_BYTES);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 5 * 1024 * 1024 * 1024;
+}
+
+/** Free bytes on the filesystem backing the local store, or null when it can't
+ *  be determined (a stat failure must never wedge uploads). */
+export async function storeFreeBytes(): Promise<number | null> {
+  try {
+    const s = await fsp.statfs(assetStoreDir());
+    return s.bavail * s.bsize;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether the store can take `need` more bytes and still hold the reserve. */
+export async function hasStagingHeadroom(need = 0): Promise<boolean> {
+  const free = await storeFreeBytes();
+  if (free === null) return true;
+  return free - need >= storeMinFreeBytes();
+}
+
 /** Whether blob reads/writes go to the S3 backend. */
 export function s3Enabled(): boolean {
   return !!process.env.ASSET_S3_ENDPOINT;

--- a/web/src/lib/validate.ts
+++ b/web/src/lib/validate.ts
@@ -6,6 +6,9 @@ import type { BuildRecord, Node } from "./types";
 // few hundred bytes of JSON, so cap-sized records run tens of MB.
 export const MAX_BODY_BYTES = 64_000_000;
 
+/** Longest accepted submitter nickname (display/attribution only). */
+export const MAX_NICKNAME_LEN = 100;
+
 const MAX_FILES = 200_000;
 const MAX_SIGNATURE_VALUES = 4096;
 const MAX_MEDIA = 4096;

--- a/web/tests/blobstore.test.ts
+++ b/web/tests/blobstore.test.ts
@@ -1,17 +1,19 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
   assetBlobPath,
   blobExists,
   blobSize,
+  hasStagingHeadroom,
   missingBlobs,
   openBlobStream,
   readBlob,
   readBlobHead,
+  reapStaleAssetStaging,
   storeBlobBytes,
   storeBlobFromFile,
   withBlobFile,
@@ -93,6 +95,39 @@ test("withBlobFile hands the local blob path through and null when missing", asy
     return (await readFile(p)).toString();
   });
   assert.equal(got, "payload");
+});
+
+test("reapStaleAssetStaging drops old .part files, keeps fresh and media ones", async () => {
+  const dir = await tempStore();
+  const staging = join(dir, ".staging");
+  await mkdir(staging, { recursive: true });
+  const old = join(staging, `${SHA_A}.part`);
+  const fresh = join(staging, `${SHA_B}.part`);
+  const media = join(staging, "media-deadbeef.part");
+  for (const p of [old, fresh, media]) await writeFile(p, "x");
+  const stale = new Date(Date.now() - 48 * 3600_000);
+  await utimes(old, stale, stale);
+  await utimes(media, stale, stale); // stale but not ours to reap
+
+  await reapStaleAssetStaging();
+  assert.equal(existsSync(old), false); // reaped
+  assert.equal(existsSync(fresh), true); // too new
+  assert.equal(existsSync(media), true); // media sessions reap themselves
+});
+
+test("hasStagingHeadroom refuses below the configured reserve", async () => {
+  await tempStore();
+  const prev = process.env.ASSET_STORE_MIN_FREE_BYTES;
+  try {
+    process.env.ASSET_STORE_MIN_FREE_BYTES = "0";
+    assert.equal(await hasStagingHeadroom(0), true);
+    // A reserve larger than any real disk forces a refusal.
+    process.env.ASSET_STORE_MIN_FREE_BYTES = String(2 ** 62);
+    assert.equal(await hasStagingHeadroom(0), false);
+  } finally {
+    if (prev === undefined) delete process.env.ASSET_STORE_MIN_FREE_BYTES;
+    else process.env.ASSET_STORE_MIN_FREE_BYTES = prev;
+  }
 });
 
 test("readBlobHead of an empty blob answers empty, not missing", async () => {


### PR DESCRIPTION
Reap abandoned asset-upload staging and refuse staging when the store disk is low, so the unauthenticated upload path can't fill it. Also caps the submission body/nickname and adds baseline security headers.