### PR TITLE
Dedupe web backend

### DIFF
--- a/web/src/app/api/asset/[sha256]/audio/route.ts
+++ b/web/src/app/api/asset/[sha256]/audio/route.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
-import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
+import { getAssetMeta } from "@/lib/assets";
 import { readBlobHead } from "@/lib/blobstore";
-import { getPool } from "@/lib/db";
 import { ensureAudioTranscode } from "@/lib/ffmpeg";
+import { IMMUTABLE_CACHE, SANDBOX_CSP, contentDisposition, streamResponse } from "@/lib/http";
 import { parseRange } from "@/lib/range";
 import { isSha256 } from "@/lib/validate";
 import { wavBrowserPlayable } from "@/lib/wav";
@@ -20,18 +20,11 @@ export const runtime = "nodejs";
 // to 16-bit PCM WAV, cached on disk, and streamed with Range support. The URL
 // is content-addressed, so responses cache hard.
 
-const CACHE = "public, max-age=31536000, immutable";
-const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
-
 export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
 
-  const r = await getPool().query(
-    "SELECT path, mime FROM build_asset WHERE sha256=$1 LIMIT 1",
-    [sha256]
-  );
-  const meta = r.rows[0] as { path: string; mime: string } | undefined;
+  const meta = await getAssetMeta(sha256);
   if (!meta) return Response.json({ error: "not found" }, { status: 404 });
 
   // Relative Location: request.url behind the reverse proxy is the internal
@@ -39,7 +32,7 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   const toRaw = () =>
     new Response(null, {
       status: 308,
-      headers: { Location: `/api/asset/${sha256}`, "Cache-Control": CACHE },
+      headers: { Location: `/api/asset/${sha256}`, "Cache-Control": IMMUTABLE_CACHE },
     });
 
   if (meta.mime !== "audio/wav") {
@@ -54,7 +47,7 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   if (request.headers.get("if-none-match") === `"${sha256}-audio"`) {
     return new Response(null, {
       status: 304,
-      headers: { "Cache-Control": CACHE, ETag: `"${sha256}-audio"` },
+      headers: { "Cache-Control": IMMUTABLE_CACHE, ETag: `"${sha256}-audio"` },
     });
   }
 
@@ -76,27 +69,18 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   const stat = await fsp.stat(audioPath);
 
   const name = meta.path.split("/").pop() || `${sha256}.wav`;
-  const asciiName = name.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
   const headers: Record<string, string> = {
     "Content-Type": "audio/wav",
-    "Content-Disposition": `inline; filename="${asciiName}"`,
-    "Cache-Control": CACHE,
+    "Content-Disposition": contentDisposition(name, true),
+    "Cache-Control": IMMUTABLE_CACHE,
     ETag: `"${sha256}-audio"`,
     "X-Content-Type-Options": "nosniff",
-    "Content-Security-Policy": CSP,
+    "Content-Security-Policy": SANDBOX_CSP,
     "Accept-Ranges": "bytes",
   };
 
   // Single-range support so <audio> can seek.
   const range = parseRange(request.headers.get("range"), stat.size);
-  if (range) {
-    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${stat.size}`;
-    headers["Content-Length"] = String(range.end - range.start + 1);
-    const stream = fs.createReadStream(audioPath, { start: range.start, end: range.end });
-    return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
-  }
-
-  headers["Content-Length"] = String(stat.size);
-  const stream = fs.createReadStream(audioPath);
-  return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
+  const stream = fs.createReadStream(audioPath, range ? { start: range.start, end: range.end } : {});
+  return streamResponse(stream, stat.size, range, headers);
 }

--- a/web/src/app/api/asset/[sha256]/png/route.ts
+++ b/web/src/app/api/asset/[sha256]/png/route.ts
@@ -1,7 +1,8 @@
 import type { NextRequest } from "next/server";
+import { getAssetMeta } from "@/lib/assets";
 import { readBlob } from "@/lib/blobstore";
-import { getPool } from "@/lib/db";
 import { gsAvailable, gsRenderable, gsToPng } from "@/lib/gs";
+import { IMMUTABLE_CACHE, contentDisposition } from "@/lib/http";
 import { pngConvertible, toPng, WEB_SAFE_IMAGE } from "@/lib/imgpng";
 import { isSha256 } from "@/lib/validate";
 
@@ -13,8 +14,6 @@ export const runtime = "nodejs";
 // pages through Ghostscript when the server has it). Web-safe formats
 // redirect to the raw asset route; content-addressed, so responses cache hard.
 
-const CACHE = "public, max-age=31536000, immutable";
-
 // Bound what the in-process decoder will chew on (decoded size is capped
 // separately by the converters' MAX_PIXELS). Matches the adapter's
 // MAX_ASSET_SIZE so any stored image asset is convertible.
@@ -24,11 +23,7 @@ export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
 
-  const r = await getPool().query(
-    "SELECT path, mime, size::float8 AS size FROM build_asset WHERE sha256=$1 LIMIT 1",
-    [sha256]
-  );
-  const meta = r.rows[0] as { path: string; mime: string; size: number } | undefined;
+  const meta = await getAssetMeta(sha256);
   if (!meta) return Response.json({ error: "not found" }, { status: 404 });
 
   if (WEB_SAFE_IMAGE.test(meta.mime)) {
@@ -52,12 +47,11 @@ export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256
   }
 
   const base = (meta.path.split("/").pop() || sha256).replace(/\.[^.]*$/, "");
-  const asciiName = base.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
   return new Response(new Uint8Array(png), {
     headers: {
       "Content-Type": "image/png",
-      "Content-Disposition": `inline; filename="${asciiName}.png"`,
-      "Cache-Control": CACHE,
+      "Content-Disposition": contentDisposition(`${base}.png`, true),
+      "Cache-Control": IMMUTABLE_CACHE,
       ETag: `"${sha256}-png"`,
       "X-Content-Type-Options": "nosniff",
     },

--- a/web/src/app/api/asset/[sha256]/route.ts
+++ b/web/src/app/api/asset/[sha256]/route.ts
@@ -1,9 +1,7 @@
-import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
-import { unstable_cache } from "next/cache";
-import { publicAssetUrl } from "@/lib/assets";
+import { getAssetMeta, publicAssetUrl } from "@/lib/assets";
 import { blobSize, openBlobStream } from "@/lib/blobstore";
-import { getPool } from "@/lib/db";
+import { IMMUTABLE_CACHE, PDF_CSP, SANDBOX_CSP, contentDisposition, streamResponse } from "@/lib/http";
 import { parseRange } from "@/lib/range";
 import { isSha256 } from "@/lib/validate";
 
@@ -12,7 +10,6 @@ export const runtime = "nodejs";
 // GET /api/asset/<sha256> — stream one viewable asset from the blob store.
 //
 // The URL is content-addressed, so a response never changes: cache hard.
-const CACHE = "public, max-age=31536000, immutable";
 
 // Defense against a hostile mime smuggled in through the submissions API: only
 // media types, PDF, and bare text/plain are ever served inline. text/html (or
@@ -23,34 +20,11 @@ function servableMime(mime: string): boolean {
   return mime === "text/plain" || mime === "application/pdf" || /^(image|audio|video)\/[\w.+-]+$/.test(mime);
 }
 
-const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
-
-// PDFs render in the browser's PDF viewer, which `sandbox` blocks (Chrome
-// treats a sandboxed response as plugin-forbidden and downloads instead).
-// Dropping the directive is safe for this type only: with nosniff the
-// response can never be reinterpreted as HTML, and script inside a PDF runs
-// in the viewer's isolated world, not against this origin.
-const PDF_CSP = "default-src 'none'; style-src 'unsafe-inline'";
-
-// Asset metadata is immutable for a given content hash — cache the row lookup
-// so a screenshot gallery's burst of first-loads costs one query, not N.
-const getMeta = unstable_cache(
-  async (sha256: string): Promise<{ path: string; mime: string } | null> => {
-    const r = await getPool().query(
-      "SELECT path, mime FROM build_asset WHERE sha256=$1 LIMIT 1",
-      [sha256]
-    );
-    return (r.rows[0] as { path: string; mime: string }) ?? null;
-  },
-  ["asset-meta"],
-  { revalidate: 3600 }
-);
-
 export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
 
-  const meta = await getMeta(sha256);
+  const meta = await getAssetMeta(sha256);
   if (!meta) return Response.json({ error: "not found" }, { status: 404 });
 
   // Media bytes come straight off the public bucket gateway when one is
@@ -65,7 +39,7 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
 
   // The browser already holds an immutable copy — never re-send the bytes.
   if (request.headers.get("if-none-match") === `"${sha256}"`) {
-    return new Response(null, { status: 304, headers: { "Cache-Control": CACHE, ETag: `"${sha256}"` } });
+    return new Response(null, { status: 304, headers: { "Cache-Control": IMMUTABLE_CACHE, ETag: `"${sha256}"` } });
   }
 
   const size = await blobSize(sha256);
@@ -75,7 +49,6 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   }
 
   const name = meta.path.split("/").pop() || sha256;
-  const asciiName = name.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
   const inline = servableMime(meta.mime);
   const headers: Record<string, string> = {
     "Content-Type": inline
@@ -83,11 +56,11 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
         ? "text/plain; charset=utf-8"
         : meta.mime
       : "application/octet-stream",
-    "Content-Disposition": `${inline ? "inline" : "attachment"}; filename="${asciiName}"`,
-    "Cache-Control": CACHE,
+    "Content-Disposition": contentDisposition(name, inline),
+    "Cache-Control": IMMUTABLE_CACHE,
     ETag: `"${sha256}"`,
     "X-Content-Type-Options": "nosniff",
-    "Content-Security-Policy": meta.mime === "application/pdf" && inline ? PDF_CSP : CSP,
+    "Content-Security-Policy": meta.mime === "application/pdf" && inline ? PDF_CSP : SANDBOX_CSP,
     "Accept-Ranges": "bytes",
   };
 
@@ -95,12 +68,5 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   const range = parseRange(request.headers.get("range"), size);
   const stream = await openBlobStream(sha256, range ?? undefined);
   if (!stream) return Response.json({ error: "asset bytes not in store" }, { status: 404 });
-  if (range) {
-    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${size}`;
-    headers["Content-Length"] = String(range.end - range.start + 1);
-    return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
-  }
-
-  headers["Content-Length"] = String(size);
-  return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
+  return streamResponse(stream, size, range, headers);
 }

--- a/web/src/app/api/asset/[sha256]/thumb/route.ts
+++ b/web/src/app/api/asset/[sha256]/thumb/route.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
-import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
-import { getPool } from "@/lib/db";
+import { getAssetMeta } from "@/lib/assets";
 import { ensureThumb } from "@/lib/ffmpeg";
+import { IMMUTABLE_CACHE, SANDBOX_CSP, streamResponse } from "@/lib/http";
 import { isSha256 } from "@/lib/validate";
 
 export const runtime = "nodejs";
@@ -14,18 +14,11 @@ export const runtime = "nodejs";
 // responses cache hard; clients treat a failure (no ffmpeg on the server, or
 // a stream with no decodable frame) as "no poster" and degrade.
 
-const CACHE = "public, max-age=31536000, immutable";
-const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
-
 export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
 
-  const r = await getPool().query(
-    "SELECT mime FROM build_asset WHERE sha256=$1 LIMIT 1",
-    [sha256]
-  );
-  const meta = r.rows[0] as { mime: string } | undefined;
+  const meta = await getAssetMeta(sha256);
   if (!meta) return Response.json({ error: "not found" }, { status: 404 });
   if (!meta.mime.startsWith("video/")) {
     return Response.json({ error: `no thumbnail for ${meta.mime}` }, { status: 415 });
@@ -35,7 +28,7 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   if (request.headers.get("if-none-match") === `"${sha256}-thumb"`) {
     return new Response(null, {
       status: 304,
-      headers: { "Cache-Control": CACHE, ETag: `"${sha256}-thumb"` },
+      headers: { "Cache-Control": IMMUTABLE_CACHE, ETag: `"${sha256}-thumb"` },
     });
   }
 
@@ -48,15 +41,11 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   }
   const stat = await fsp.stat(thumb);
   const stream = fs.createReadStream(thumb);
-  return new Response(Readable.toWeb(stream) as ReadableStream, {
-    status: 200,
-    headers: {
-      "Content-Type": "image/jpeg",
-      "Content-Length": String(stat.size),
-      "Cache-Control": CACHE,
-      ETag: `"${sha256}-thumb"`,
-      "X-Content-Type-Options": "nosniff",
-      "Content-Security-Policy": CSP,
-    },
+  return streamResponse(stream, stat.size, null, {
+    "Content-Type": "image/jpeg",
+    "Cache-Control": IMMUTABLE_CACHE,
+    ETag: `"${sha256}-thumb"`,
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": SANDBOX_CSP,
   });
 }

--- a/web/src/app/api/asset/[sha256]/video/route.ts
+++ b/web/src/app/api/asset/[sha256]/video/route.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
-import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
-import { getPool } from "@/lib/db";
+import { getAssetMeta } from "@/lib/assets";
 import { ensureTranscode, transcodable } from "@/lib/ffmpeg";
+import { IMMUTABLE_CACHE, SANDBOX_CSP, contentDisposition, streamResponse } from "@/lib/http";
 import { parseRange } from "@/lib/range";
 import { isSha256 } from "@/lib/validate";
 
@@ -21,9 +21,6 @@ export const runtime = "nodejs";
 // A DVD-sized input keeps transcoding in the background while this request
 // answers 202 — the client polls ./video/status and comes back when ready.
 
-const CACHE = "public, max-age=31536000, immutable";
-const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
-
 // How long one request holds on for a transcode before handing off to the
 // status-poll flow. Long enough for the short clips that dominate the corpus.
 const SOFT_WAIT_MS = 25_000;
@@ -32,11 +29,7 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
 
-  const r = await getPool().query(
-    "SELECT path, mime FROM build_asset WHERE sha256=$1 LIMIT 1",
-    [sha256]
-  );
-  const meta = r.rows[0] as { path: string; mime: string } | undefined;
+  const meta = await getAssetMeta(sha256);
   if (!meta) return Response.json({ error: "not found" }, { status: 404 });
 
   if (meta.mime === "video/mp4" || meta.mime === "video/webm") {
@@ -44,7 +37,7 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
     // origin (localhost:6800), which must never leak into a redirect target.
     return new Response(null, {
       status: 308,
-      headers: { Location: `/api/asset/${sha256}`, "Cache-Control": CACHE },
+      headers: { Location: `/api/asset/${sha256}`, "Cache-Control": IMMUTABLE_CACHE },
     });
   }
   if (!transcodable(meta.mime)) {
@@ -55,7 +48,7 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   if (request.headers.get("if-none-match") === `"${sha256}-video"`) {
     return new Response(null, {
       status: 304,
-      headers: { "Cache-Control": CACHE, ETag: `"${sha256}-video"` },
+      headers: { "Cache-Control": IMMUTABLE_CACHE, ETag: `"${sha256}-video"` },
     });
   }
 
@@ -84,28 +77,19 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   const stat = await fsp.stat(video.path);
 
   const base = (meta.path.split("/").pop() || sha256).replace(/\.[^.]*$/, "");
-  const asciiName = base.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
   const ext = video.mime === "video/webm" ? "webm" : "mp4";
   const headers: Record<string, string> = {
     "Content-Type": video.mime,
-    "Content-Disposition": `inline; filename="${asciiName}.${ext}"`,
-    "Cache-Control": CACHE,
+    "Content-Disposition": contentDisposition(`${base}.${ext}`, true),
+    "Cache-Control": IMMUTABLE_CACHE,
     ETag: `"${sha256}-video"`,
     "X-Content-Type-Options": "nosniff",
-    "Content-Security-Policy": CSP,
+    "Content-Security-Policy": SANDBOX_CSP,
     "Accept-Ranges": "bytes",
   };
 
   // Single-range support so <video> can seek.
   const range = parseRange(request.headers.get("range"), stat.size);
-  if (range) {
-    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${stat.size}`;
-    headers["Content-Length"] = String(range.end - range.start + 1);
-    const stream = fs.createReadStream(video.path, { start: range.start, end: range.end });
-    return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
-  }
-
-  headers["Content-Length"] = String(stat.size);
-  const stream = fs.createReadStream(video.path);
-  return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
+  const stream = fs.createReadStream(video.path, range ? { start: range.start, end: range.end } : {});
+  return streamResponse(stream, stat.size, range, headers);
 }

--- a/web/src/app/api/asset/[sha256]/video/status/route.ts
+++ b/web/src/app/api/asset/[sha256]/video/status/route.ts
@@ -1,4 +1,4 @@
-import { getPool } from "@/lib/db";
+import { getAssetMeta } from "@/lib/assets";
 import { ensureTranscode, transcodable, transcodeStatus } from "@/lib/ffmpeg";
 import { isSha256 } from "@/lib/validate";
 
@@ -15,8 +15,7 @@ export async function GET(_request: Request, ctx: { params: Promise<{ sha256: st
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
 
-  const r = await getPool().query("SELECT mime FROM build_asset WHERE sha256=$1 LIMIT 1", [sha256]);
-  const meta = r.rows[0] as { mime: string } | undefined;
+  const meta = await getAssetMeta(sha256);
   if (!meta) return Response.json({ error: "not found" }, { status: 404 });
 
   const headers = { "Cache-Control": "no-store" };

--- a/web/src/app/api/build/[sha256]/media/upload/[token]/route.ts
+++ b/web/src/app/api/build/[sha256]/media/upload/[token]/route.ts
@@ -1,7 +1,7 @@
 import fsp from "node:fs/promises";
 import type { NextRequest } from "next/server";
 import { storeBlobFromFile } from "@/lib/blobstore";
-import { getContributor, contributionTarget, revalidateBuildPages } from "@/lib/contrib";
+import { requireContributor, revalidateBuildPages } from "@/lib/contrib";
 import { getPool } from "@/lib/db";
 import { extractStill } from "@/lib/ffmpeg";
 import {
@@ -39,16 +39,10 @@ export async function PUT(
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
   if (!isMediaToken(token)) return Response.json({ error: "invalid token" }, { status: 400 });
 
-  const contributor = await getContributor(request);
-  if (!contributor) {
-    return Response.json({ error: "log in to the wiki to contribute" }, { status: 401 });
-  }
   const pool = getPool();
-  const target = await contributionTarget(pool, sha256);
-  if (!target) return Response.json({ error: "not found" }, { status: 404 });
-  if (!target.visible && !contributor.moderator) {
-    return Response.json({ error: "this build is not open for contributions" }, { status: 403 });
-  }
+  const gate = await requireContributor(request, pool, sha256);
+  if (!gate.ok) return gate.response;
+  const { target } = gate;
 
   const session = await readMediaSession(token);
   if (!session || session.build !== sha256) {

--- a/web/src/app/api/build/[sha256]/media/upload/route.ts
+++ b/web/src/app/api/build/[sha256]/media/upload/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
-import { getContributor, contributionTarget } from "@/lib/contrib";
+import { requireContributor } from "@/lib/contrib";
 import {
   createMediaSession,
   isMediaKind,
@@ -28,16 +28,10 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
 
-  const contributor = await getContributor(request);
-  if (!contributor) {
-    return Response.json({ error: "log in to the wiki to contribute" }, { status: 401 });
-  }
   const pool = getPool();
-  const target = await contributionTarget(pool, sha256);
-  if (!target) return Response.json({ error: "not found" }, { status: 404 });
-  if (!target.visible && !contributor.moderator) {
-    return Response.json({ error: "this build is not open for contributions" }, { status: 403 });
-  }
+  const gate = await requireContributor(request, pool, sha256);
+  if (!gate.ok) return gate.response;
+  const { contributor } = gate;
 
   const rl = rateLimitCheck(`media:${contributor.name}:${clientKey(request)}`, CREATE_LIMIT, CREATE_WINDOW_MS);
   if (!rl.ok) {

--- a/web/src/app/api/build/[sha256]/notes/route.ts
+++ b/web/src/app/api/build/[sha256]/notes/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { getContributor, contributionTarget, revalidateBuildPages } from "@/lib/contrib";
+import { requireContributor, revalidateBuildPages } from "@/lib/contrib";
 import { getPool } from "@/lib/db";
 import { MAX_NOTE_LEN, insertNote } from "@/lib/media";
 import { clientKey, rateLimitCheck } from "@/lib/ratelimit";
@@ -17,16 +17,10 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
 
-  const contributor = await getContributor(request);
-  if (!contributor) {
-    return Response.json({ error: "log in to the wiki to contribute" }, { status: 401 });
-  }
   const pool = getPool();
-  const target = await contributionTarget(pool, sha256);
-  if (!target) return Response.json({ error: "not found" }, { status: 404 });
-  if (!target.visible && !contributor.moderator) {
-    return Response.json({ error: "this build is not open for contributions" }, { status: 403 });
-  }
+  const gate = await requireContributor(request, pool, sha256);
+  if (!gate.ok) return gate.response;
+  const { contributor, target } = gate;
 
   const rl = rateLimitCheck(`notes:${contributor.name}:${clientKey(request)}`, NOTE_LIMIT, NOTE_WINDOW_MS);
   if (!rl.ok) {

--- a/web/src/app/api/build/[sha256]/route.ts
+++ b/web/src/app/api/build/[sha256]/route.ts
@@ -3,7 +3,7 @@ import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
 import { getBuild, findSimilar, findByEmbeddingOf, getLotBuilds, updateBuildMeta, setLotPrivate, setBuildGame } from "@/lib/queries";
-import { getModerator, moderationEnabled } from "@/lib/auth";
+import { getModerator, requireModerator } from "@/lib/auth";
 import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
 
@@ -45,11 +45,8 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
 // (current and future members); `game` (+ optional `gameSystem`) names the
 // game the build belongs to (created if new; "" or null clears).
 export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
-  if (!(await getModerator(request))) {
-    return moderationEnabled()
-      ? Response.json({ error: "unauthorized" }, { status: 401 })
-      : Response.json({ error: "moderation disabled (set MODERATION_TOKEN or WIKI_API_URL)" }, { status: 403 });
-  }
+  const denied = await requireModerator(request);
+  if (denied) return denied;
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
 

--- a/web/src/app/api/build/[sha256]/skip/route.ts
+++ b/web/src/app/api/build/[sha256]/skip/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { getModerator, moderationEnabled } from "@/lib/auth";
+import { requireModerator } from "@/lib/auth";
 import { contributionTarget, revalidateBuildPages } from "@/lib/contrib";
 import { getPool } from "@/lib/db";
 import { upsertSkip, type SkipFlags } from "@/lib/media";
@@ -13,11 +13,8 @@ export const dynamic = "force-dynamic";
 // to this build (its 0 in the /builds columns stops rendering orange).
 // Omitted fields keep their stored value.
 export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
-  if (!(await getModerator(request))) {
-    return moderationEnabled()
-      ? Response.json({ error: "unauthorized" }, { status: 401 })
-      : Response.json({ error: "moderation disabled (set MODERATION_TOKEN or WIKI_API_URL)" }, { status: 403 });
-  }
+  const denied = await requireModerator(request);
+  if (denied) return denied;
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
 

--- a/web/src/app/api/builds/route.ts
+++ b/web/src/app/api/builds/route.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server";
 import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { bulkUpdateBuilds } from "@/lib/queries";
-import { getModerator, moderationEnabled } from "@/lib/auth";
+import { requireModerator } from "@/lib/auth";
 import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
 
@@ -19,11 +19,8 @@ export const dynamic = "force-dynamic";
 // PATCH /api/build/<sha256>; unknown sha256s are skipped, the response
 // carries how many rows actually changed.
 export async function POST(request: NextRequest) {
-  if (!(await getModerator(request))) {
-    return moderationEnabled()
-      ? Response.json({ error: "unauthorized" }, { status: 401 })
-      : Response.json({ error: "moderation disabled (set MODERATION_TOKEN or WIKI_API_URL)" }, { status: 403 });
-  }
+  const denied = await requireModerator(request);
+  if (denied) return denied;
 
   let body: Record<string, unknown>;
   try {

--- a/web/src/app/api/media/[sha256]/route.ts
+++ b/web/src/app/api/media/[sha256]/route.ts
@@ -1,16 +1,13 @@
-import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
 import { blobSize, openBlobStream } from "@/lib/blobstore";
 import { getPool } from "@/lib/db";
+import { IMMUTABLE_CACHE, SANDBOX_CSP, streamResponse } from "@/lib/http";
 import { MEDIA_NS, mediaContentType } from "@/lib/media";
 import { parseRange } from "@/lib/range";
 import { isSha256 } from "@/lib/validate";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-const CACHE = "public, max-age=31536000, immutable";
-const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
 
 const EXT: Record<string, string> = {
   "image/png": "png",
@@ -33,7 +30,7 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   if (!contentType) return Response.json({ error: "not found" }, { status: 404 });
 
   if (request.headers.get("if-none-match") === `"${sha256}-media"`) {
-    return new Response(null, { status: 304, headers: { "Cache-Control": CACHE, ETag: `"${sha256}-media"` } });
+    return new Response(null, { status: 304, headers: { "Cache-Control": IMMUTABLE_CACHE, ETag: `"${sha256}-media"` } });
   }
 
   const size = await blobSize(sha256, MEDIA_NS);
@@ -42,10 +39,10 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   const headers: Record<string, string> = {
     "Content-Type": contentType,
     "Content-Disposition": `inline; filename="${sha256.slice(0, 12)}.${EXT[contentType] ?? "bin"}"`,
-    "Cache-Control": CACHE,
+    "Cache-Control": IMMUTABLE_CACHE,
     ETag: `"${sha256}-media"`,
     "X-Content-Type-Options": "nosniff",
-    "Content-Security-Policy": CSP,
+    "Content-Security-Policy": SANDBOX_CSP,
     "Accept-Ranges": "bytes",
   };
 
@@ -53,11 +50,5 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   const range = parseRange(request.headers.get("range"), size);
   const stream = await openBlobStream(sha256, range ?? undefined, MEDIA_NS);
   if (!stream) return Response.json({ error: "blob missing from store" }, { status: 404 });
-  if (range) {
-    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${size}`;
-    headers["Content-Length"] = String(range.end - range.start + 1);
-    return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
-  }
-  headers["Content-Length"] = String(size);
-  return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
+  return streamResponse(stream, size, range, headers);
 }

--- a/web/src/app/api/repo/[sha256]/blob/[oid]/route.ts
+++ b/web/src/app/api/repo/[sha256]/blob/[oid]/route.ts
@@ -1,6 +1,7 @@
-import { Readable } from "node:stream";
 import type { NextRequest } from "next/server";
 import { blobSize, openBlobStream } from "@/lib/blobstore";
+import { IMMUTABLE_CACHE, SANDBOX_CSP, contentDisposition, streamResponse } from "@/lib/http";
+import { parseRange } from "@/lib/range";
 import { loadRepo, repoAttached } from "@/lib/repo";
 import { isSha256 } from "@/lib/validate";
 
@@ -14,20 +15,6 @@ export const runtime = "nodejs";
 //
 // Headers mirror /api/asset: repo blobs are only ever text/plain (inline) or
 // opaque bytes (attachment), never anything a browser could script with.
-const CACHE = "public, max-age=31536000, immutable";
-const CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
-
-/** One satisfiable `bytes=start-end` range, else null (serve the whole file). */
-function parseRange(header: string | null, size: number): { start: number; end: number } | null {
-  const m = header?.match(/^bytes=(\d*)-(\d*)$/);
-  if (!m || size === 0) return null;
-  const [, a, b] = m;
-  if (a === "" && b === "") return null;
-  const start = a === "" ? Math.max(0, size - Number(b)) : Number(a);
-  const end = a !== "" && b !== "" ? Math.min(Number(b), size - 1) : size - 1;
-  if (start > end || start >= size) return null;
-  return { start, end };
-}
 
 export async function GET(
   request: NextRequest,
@@ -45,7 +32,7 @@ export async function GET(
   const [storeSha, , binary] = info;
 
   if (request.headers.get("if-none-match") === `"${oid}"`) {
-    return new Response(null, { status: 304, headers: { "Cache-Control": CACHE, ETag: `"${oid}"` } });
+    return new Response(null, { status: 304, headers: { "Cache-Control": IMMUTABLE_CACHE, ETag: `"${oid}"` } });
   }
 
   const size = await blobSize(storeSha);
@@ -55,26 +42,18 @@ export async function GET(
   }
 
   const name = request.nextUrl.searchParams.get("name") || oid;
-  const asciiName = name.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
   const headers: Record<string, string> = {
     "Content-Type": binary ? "application/octet-stream" : "text/plain; charset=utf-8",
-    "Content-Disposition": `${binary ? "attachment" : "inline"}; filename="${asciiName}"`,
-    "Cache-Control": CACHE,
+    "Content-Disposition": contentDisposition(name, !binary),
+    "Cache-Control": IMMUTABLE_CACHE,
     ETag: `"${oid}"`,
     "X-Content-Type-Options": "nosniff",
-    "Content-Security-Policy": CSP,
+    "Content-Security-Policy": SANDBOX_CSP,
     "Accept-Ranges": "bytes",
   };
 
   const range = parseRange(request.headers.get("range"), size);
   const stream = await openBlobStream(storeSha, range ?? undefined);
   if (!stream) return Response.json({ error: "blob bytes not in store" }, { status: 404 });
-  if (range) {
-    headers["Content-Range"] = `bytes ${range.start}-${range.end}/${size}`;
-    headers["Content-Length"] = String(range.end - range.start + 1);
-    return new Response(Readable.toWeb(stream) as ReadableStream, { status: 206, headers });
-  }
-
-  headers["Content-Length"] = String(size);
-  return new Response(Readable.toWeb(stream) as ReadableStream, { status: 200, headers });
+  return streamResponse(stream, size, range, headers);
 }

--- a/web/src/app/api/similarity/route.ts
+++ b/web/src/app/api/similarity/route.ts
@@ -50,7 +50,10 @@ export async function POST(request: NextRequest) {
     }
 
     return Response.json({ query: { sha256: q.sha256, name: q.name }, ...result, text_neighbors });
-  } catch {
+  } catch (e) {
+    // This path does embedding inference + multi-tier SQL; a silent 500 is very
+    // hard to diagnose in production, so log server-side (generic to the client).
+    console.error("similarity check failed:", e);
     return Response.json({ error: "internal error" }, { status: 500 });
   }
 }

--- a/web/src/app/api/submissions/[sha256]/route.ts
+++ b/web/src/app/api/submissions/[sha256]/route.ts
@@ -3,7 +3,7 @@ import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { submissionStatus, setSubmissionStatus } from "@/lib/queries";
 import { ingestRecord, refreshAudioIdf } from "@/lib/ingest";
-import { getModerator, moderationEnabled } from "@/lib/auth";
+import { requireModerator } from "@/lib/auth";
 import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
 import type { BuildRecord } from "@/lib/types";
@@ -23,11 +23,8 @@ export async function GET(_request: NextRequest, ctx: { params: Promise<{ sha256
 // POST /api/submissions/<sha256> { action: "accept" | "reject" } — moderate.
 // Accept ingests the stored record into the library, then marks it accepted.
 export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
-  if (!(await getModerator(request))) {
-    return moderationEnabled()
-      ? Response.json({ error: "unauthorized" }, { status: 401 })
-      : Response.json({ error: "moderation disabled (set MODERATION_TOKEN or WIKI_API_URL)" }, { status: 403 });
-  }
+  const denied = await requireModerator(request);
+  if (denied) return denied;
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
   let action: string | undefined;

--- a/web/src/app/api/submissions/route.ts
+++ b/web/src/app/api/submissions/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
 import { enqueueSubmission, listSubmissions } from "@/lib/queries";
-import { getModerator, moderationEnabled } from "@/lib/auth";
+import { requireModerator } from "@/lib/auth";
 import { MAX_BODY_BYTES, MAX_NICKNAME_LEN, validateBuildRecord } from "@/lib/validate";
 import { rateLimit, clientKey } from "@/lib/ratelimit";
 import type { BuildRecord } from "@/lib/types";
@@ -11,12 +11,8 @@ export const dynamic = "force-dynamic";
 
 // GET /api/submissions?status=queued — the moderation queue. Requires moderator auth.
 export async function GET(request: NextRequest) {
-  if (!moderationEnabled()) {
-    return Response.json({ error: "moderation disabled (set MODERATION_TOKEN or WIKI_API_URL)" }, { status: 403 });
-  }
-  if (!(await getModerator(request))) {
-    return Response.json({ error: "unauthorized" }, { status: 401 });
-  }
+  const denied = await requireModerator(request);
+  if (denied) return denied;
   const status = request.nextUrl.searchParams.get("status") ?? undefined;
   const items = await listSubmissions(getPool(), status);
   return Response.json({ submissions: items });

--- a/web/src/lib/assets.ts
+++ b/web/src/lib/assets.ts
@@ -2,11 +2,29 @@
 // Blobs are extracted by the desktop analyzer, shipped inside export bundles,
 // and stored by scripts/ingest.ts; the API routes stream them out by sha256.
 
+import { unstable_cache } from "next/cache";
 import { readBlobHead } from "./blobstore";
+import { getPool } from "./db";
 import { hexPreview } from "./hexdump";
 
 // Path helpers re-exported for the store-layout consumers (staging, tests).
 export { assetBlobPath, assetStagingPath, assetStoreDir } from "./blobstore";
+
+/** Serving metadata (stored path, mime, byte size) for one asset blob, or null
+ *  when the sha isn't a known asset. Immutable for a content hash, so the lookup
+ *  is cached — a gallery/poll burst for the same blob costs one query, not N.
+ *  Shared by every byte-serving asset route (raw, png, thumb, audio, video). */
+export const getAssetMeta = unstable_cache(
+  async (sha256: string): Promise<{ path: string; mime: string; size: number } | null> => {
+    const r = await getPool().query(
+      "SELECT path, mime, size::float8 AS size FROM build_asset WHERE sha256=$1 LIMIT 1",
+      [sha256]
+    );
+    return (r.rows[0] as { path: string; mime: string; size: number }) ?? null;
+  },
+  ["asset-meta"],
+  { revalidate: 3600 }
+);
 
 /** Public gateway URL for one blob when ASSET_PUBLIC_BASE points at a host
  *  serving the bucket's key layout directly (`<base>/<sha256[:2]>/<sha256>`),

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -13,7 +13,7 @@ export function moderationEnabled(): boolean {
 }
 
 /** Constant-time string compare (avoids timingSafeEqual's unequal-length throw). */
-function safeEqual(a: string | null | undefined, b: string): boolean {
+export function safeEqual(a: string | null | undefined, b: string): boolean {
   if (a == null) return false;
   const ab = Buffer.from(a, "utf8");
   const bb = Buffer.from(b, "utf8");
@@ -55,4 +55,17 @@ export async function getModeratorFromHeaders(h: Headers, method = "GET"): Promi
     return null;
   }
   return { name: user.name, via: "wiki" };
+}
+
+/** Gate a moderator-only route: null when the caller is a moderator, else the
+ *  error Response to return (401 when moderation is configured, 403 when it's
+ *  disabled entirely). Collapses the guard copy-pasted across the mod routes. */
+export async function requireModerator(request: NextRequest): Promise<Response | null> {
+  if (await getModerator(request)) return null;
+  return moderationEnabled()
+    ? Response.json({ error: "unauthorized" }, { status: 401 })
+    : Response.json(
+        { error: "moderation disabled (set MODERATION_TOKEN or WIKI_API_URL)" },
+        { status: 403 }
+      );
 }

--- a/web/src/lib/contrib.ts
+++ b/web/src/lib/contrib.ts
@@ -36,6 +36,32 @@ export interface ContributionTarget {
   visible: boolean;
 }
 
+/** Gate a contribute-to-build route: the caller must be a logged-in contributor
+ *  and the build must exist and be visible (or the caller a moderator). Returns
+ *  the resolved contributor + target, or the error Response to return. Collapses
+ *  the 401/404/403 preamble copy-pasted across notes/media-upload routes. */
+export async function requireContributor(
+  request: NextRequest,
+  pool: Pool,
+  sha256: string
+): Promise<
+  | { ok: true; contributor: Contributor; target: ContributionTarget }
+  | { ok: false; response: Response }
+> {
+  const contributor = await getContributor(request);
+  if (!contributor) {
+    return { ok: false, response: Response.json({ error: "log in to the wiki to contribute" }, { status: 401 }) };
+  }
+  const target = await contributionTarget(pool, sha256);
+  if (!target) {
+    return { ok: false, response: Response.json({ error: "not found" }, { status: 404 }) };
+  }
+  if (!target.visible && !contributor.moderator) {
+    return { ok: false, response: Response.json({ error: "this build is not open for contributions" }, { status: 403 }) };
+  }
+  return { ok: true, contributor, target };
+}
+
 /** The build a contribution targets: its display name (for revalidation) and
  *  whether the public can see it, or null when it doesn't exist. Writes to a
  *  hidden build require a moderator. */

--- a/web/src/lib/http.ts
+++ b/web/src/lib/http.ts
@@ -1,0 +1,52 @@
+// Shared HTTP-layer helpers for the byte-serving routes (asset, media, repo
+// blob, audio/video transcodes). These were copy-pasted per route and had begun
+// to drift — a single source keeps the cache/CSP contract and the range/stream
+// plumbing identical everywhere.
+
+import { Readable } from "node:stream";
+
+/** Content-addressed responses never change — cache for a year, immutable. */
+export const IMMUTABLE_CACHE = "public, max-age=31536000, immutable";
+
+/** Locked-down CSP for served blobs: no scripts, sandboxed, inline styles only
+ *  (SVG/PDF viewers). Applied with X-Content-Type-Options: nosniff. */
+export const SANDBOX_CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
+
+/** PDFs render in the browser's PDF viewer, which `sandbox` blocks (Chrome
+ *  treats a sandboxed response as plugin-forbidden and downloads instead).
+ *  Dropping the directive is safe for this type only: with nosniff the response
+ *  can never be reinterpreted as HTML, and script inside a PDF runs in the
+ *  viewer's isolated world, not against this origin. */
+export const PDF_CSP = "default-src 'none'; style-src 'unsafe-inline'";
+
+/** A Content-Disposition value with the filename collapsed to a quoted ASCII
+ *  form (non-ASCII and quote/backslash → underscore), so a hostile stored path
+ *  can't break out of the header. */
+export function contentDisposition(name: string, inline: boolean): string {
+  const ascii = name.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+  return `${inline ? "inline" : "attachment"}; filename="${ascii}"`;
+}
+
+/** Build the streaming Response for a (possibly ranged) blob read: 206 with
+ *  Content-Range when `range` is set, else 200, adding Content-Length either
+ *  way. `headers` is the fully-assembled base set (content-type, cache, CSP,
+ *  Accept-Ranges, ETag …); the caller opens `stream` for the same range. */
+export function streamResponse(
+  stream: Readable,
+  size: number,
+  range: { start: number; end: number } | null,
+  headers: Record<string, string>
+): Response {
+  const web = Readable.toWeb(stream) as ReadableStream;
+  if (range) {
+    return new Response(web, {
+      status: 206,
+      headers: {
+        ...headers,
+        "Content-Range": `bytes ${range.start}-${range.end}/${size}`,
+        "Content-Length": String(range.end - range.start + 1),
+      },
+    });
+  }
+  return new Response(web, { status: 200, headers: { ...headers, "Content-Length": String(size) } });
+}

--- a/web/tests/auth.test.ts
+++ b/web/tests/auth.test.ts
@@ -1,0 +1,15 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { safeEqual } from "../src/lib/auth";
+
+test("safeEqual matches only identical strings", () => {
+  assert.equal(safeEqual("secret-token", "secret-token"), true);
+  assert.equal(safeEqual("secret-token", "secret-tokeN"), false);
+});
+
+test("safeEqual handles null/undefined and unequal lengths without throwing", () => {
+  assert.equal(safeEqual(null, "x"), false);
+  assert.equal(safeEqual(undefined, "x"), false);
+  assert.equal(safeEqual("", "x"), false);
+  assert.equal(safeEqual("short", "longer-value"), false); // no timingSafeEqual length throw
+});

--- a/web/tests/range.test.ts
+++ b/web/tests/range.test.ts
@@ -1,0 +1,27 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseRange } from "../src/lib/range";
+
+test("parseRange: no header or empty file serves the whole thing (null)", () => {
+  assert.equal(parseRange(null, 1000), null);
+  assert.equal(parseRange("bytes=0-99", 0), null);
+  assert.equal(parseRange("bytes=-", 1000), null); // both ends empty
+});
+
+test("parseRange: explicit start/end is clamped to the file", () => {
+  assert.deepEqual(parseRange("bytes=0-99", 1000), { start: 0, end: 99 });
+  assert.deepEqual(parseRange("bytes=100-", 1000), { start: 100, end: 999 });
+  assert.deepEqual(parseRange("bytes=500-100000", 1000), { start: 500, end: 999 });
+});
+
+test("parseRange: suffix range counts back from the end and can't underflow", () => {
+  assert.deepEqual(parseRange("bytes=-100", 1000), { start: 900, end: 999 });
+  assert.deepEqual(parseRange("bytes=-5000", 1000), { start: 0, end: 999 });
+});
+
+test("parseRange: unsatisfiable or malformed ranges are null", () => {
+  assert.equal(parseRange("bytes=2000-3000", 1000), null); // start past EOF
+  assert.equal(parseRange("bytes=5-3", 1000), null); // start > end
+  assert.equal(parseRange("bytes=abc", 1000), null); // not digits
+  assert.equal(parseRange("0-99", 1000), null); // missing unit
+});

--- a/web/tests/ratelimit.test.ts
+++ b/web/tests/ratelimit.test.ts
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { NextRequest } from "next/server";
+import { rateLimit, rateLimitCheck, clientKey } from "../src/lib/ratelimit";
+
+// The limiter map is module-global, so each test uses a unique key.
+let n = 0;
+const uniq = () => `test-key-${n++}-${process.hrtime.bigint()}`;
+
+test("rateLimitCheck allows up to the limit, then blocks with a retry hint", () => {
+  const key = uniq();
+  assert.equal(rateLimitCheck(key, 3, 60_000).ok, true);
+  assert.equal(rateLimitCheck(key, 3, 60_000).ok, true);
+  assert.equal(rateLimitCheck(key, 3, 60_000).ok, true);
+  const blocked = rateLimitCheck(key, 3, 60_000);
+  assert.equal(blocked.ok, false);
+  assert.ok(blocked.retryAfterMs > 0 && blocked.retryAfterMs <= 60_000);
+});
+
+test("a fresh window (0ms) always allows", () => {
+  const key = uniq();
+  assert.equal(rateLimit(key, 1, 0), true);
+  assert.equal(rateLimit(key, 1, 0), true); // window already elapsed → reset
+});
+
+function reqWithXff(xff?: string): NextRequest {
+  return { headers: new Headers(xff ? { "x-forwarded-for": xff } : {}) } as unknown as NextRequest;
+}
+
+test("clientKey picks the hop counted from the right (unforgeable side)", () => {
+  const prev = process.env.TRUSTED_PROXY_HOPS;
+  try {
+    delete process.env.TRUSTED_PROXY_HOPS; // default 1 hop
+    assert.equal(clientKey(reqWithXff("1.1.1.1, 2.2.2.2, 3.3.3.3")), "3.3.3.3");
+
+    process.env.TRUSTED_PROXY_HOPS = "2";
+    assert.equal(clientKey(reqWithXff("1.1.1.1, 2.2.2.2, 3.3.3.3")), "2.2.2.2");
+
+    process.env.TRUSTED_PROXY_HOPS = "0"; // XFF distrusted entirely
+    assert.equal(clientKey(reqWithXff("1.1.1.1")), "unknown");
+  } finally {
+    if (prev === undefined) delete process.env.TRUSTED_PROXY_HOPS;
+    else process.env.TRUSTED_PROXY_HOPS = prev;
+  }
+});
+
+test("clientKey falls back to a constant when XFF is absent", () => {
+  const prev = process.env.TRUSTED_PROXY_HOPS;
+  try {
+    delete process.env.TRUSTED_PROXY_HOPS;
+    assert.equal(clientKey(reqWithXff()), "unknown");
+  } finally {
+    if (prev === undefined) delete process.env.TRUSTED_PROXY_HOPS;
+    else process.env.TRUSTED_PROXY_HOPS = prev;
+  }
+});

--- a/web/tests/validate.test.ts
+++ b/web/tests/validate.test.ts
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isSha256, validateBuildRecord } from "../src/lib/validate";
+
+const SHA = "a".repeat(64);
+
+test("isSha256 accepts only 64-char lowercase hex", () => {
+  assert.equal(isSha256(SHA), true);
+  assert.equal(isSha256("A".repeat(64)), false); // uppercase
+  assert.equal(isSha256("a".repeat(63)), false); // too short
+  assert.equal(isSha256("a".repeat(65)), false); // too long
+  assert.equal(isSha256("g".repeat(64)), false); // non-hex
+});
+
+test("validateBuildRecord rejects non-objects and bad image.sha256", () => {
+  assert.equal(validateBuildRecord(null).ok, false);
+  assert.equal(validateBuildRecord("x").ok, false);
+  assert.equal(validateBuildRecord({}).ok, false);
+  assert.equal(validateBuildRecord({ image: { sha256: "nope" } }).ok, false);
+});
+
+test("validateBuildRecord accepts a minimal valid record", () => {
+  const r = validateBuildRecord({ image: { sha256: SHA } });
+  assert.equal(r.ok, true);
+});
+
+test("validateBuildRecord walks the contents tree and type-checks arrays", () => {
+  const ok = validateBuildRecord({
+    image: { sha256: SHA },
+    contents: [{ type: "dir", children: [{ type: "file", name: "a" }] }],
+  });
+  assert.equal(ok.ok, true);
+
+  assert.equal(validateBuildRecord({ image: { sha256: SHA }, contents: "no" }).ok, false);
+  assert.equal(validateBuildRecord({ image: { sha256: SHA }, media: "no" }).ok, false);
+  assert.equal(validateBuildRecord({ image: { sha256: SHA }, assets: "no" }).ok, false);
+});
+
+test("validateBuildRecord enforces the media count cap", () => {
+  const media = Array.from({ length: 4097 }, () => ({ kind: "audio" }));
+  const r = validateBuildRecord({ image: { sha256: SHA }, media });
+  assert.equal(r.ok, false);
+});


### PR DESCRIPTION
Extract shared byte-serving helpers (streaming, cache/CSP, content-disposition, cached asset-meta) and requireModerator/requireContributor guards into lib/http, deleting the drifted parseRange copy. Adds unit tests for range/validate/ratelimit/auth and logs the silent similarity 500.