### PR TITLE
Dedupe web frontend

### DIFF
--- a/web/src/app/builds/BuildsBrowser.tsx
+++ b/web/src/app/builds/BuildsBrowser.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useTransition } from "react";
+import { humanSize } from "@/lib/format";
 import { usePathname, useRouter } from "next/navigation";
 import RowLink from "./RowLink";
 import MassApply from "@/components/MassApply";
@@ -8,18 +9,6 @@ import Select from "@/components/Select";
 import { useModerator } from "@/components/useModerator";
 import { buildHref } from "@/lib/slug";
 import type { BuildListItem, BuildSortKey } from "@/lib/queries";
-
-function humanSize(bytes?: number): string {
-  if (bytes == null) return "—";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  let v = Number(bytes);
-  let i = 0;
-  while (v >= 1024 && i < units.length - 1) {
-    v /= 1024;
-    i++;
-  }
-  return i === 0 ? `${v} B` : `${v.toFixed(1)} ${units[i]}`;
-}
 
 function formatDate(date: string | null): string {
   if (!date) return "—";

--- a/web/src/app/builds/[buildId]/AssetViewer.tsx
+++ b/web/src/app/builds/[buildId]/AssetViewer.tsx
@@ -5,6 +5,7 @@
 // once seen comes back from browser cache). ← → step through the list, Esc closes.
 
 import { useEffect, useState } from "react";
+import { humanSize } from "@/lib/format";
 import { hexDump } from "@/lib/hexdump";
 import SourceCode from "./SourceCode";
 
@@ -57,16 +58,7 @@ export function videoThumbSrc(a: ViewableAsset): string {
   return `${assetUrl(a)}/thumb`;
 }
 
-export function humanSize(bytes: number): string {
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  let v = bytes;
-  let i = 0;
-  while (v >= 1024 && i < units.length - 1) {
-    v /= 1024;
-    i++;
-  }
-  return i === 0 ? `${bytes} B` : `${v.toFixed(1)} ${units[i]}`;
-}
+export { humanSize };
 
 // Show at most this much decoded text — a 20MB DOM node makes the tab crawl.
 const TEXT_DISPLAY_CAP = 1_000_000;

--- a/web/src/app/builds/[buildId]/FileTree.tsx
+++ b/web/src/app/builds/[buildId]/FileTree.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import { humanSize } from "@/lib/format";
 import {
   collectDirPaths,
   findByPath,
@@ -13,18 +14,6 @@ import { useOpenAsset } from "./AssetViewerHost";
 
 // Chip label on viewable file rows, by asset kind.
 const KIND_TAG: Record<string, string> = { image: "img", audio: "aud", video: "vid", source: "src", text: "txt", binary: "hex" };
-
-function humanSize(bytes?: number): string {
-  if (bytes == null) return "—";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  let v = bytes;
-  let i = 0;
-  while (v >= 1024 && i < units.length - 1) {
-    v /= 1024;
-    i++;
-  }
-  return i === 0 ? `${bytes} B` : `${v.toFixed(1)} ${units[i]}`;
-}
 
 function formatDate(date?: string): string {
   if (!date) return "—";

--- a/web/src/app/builds/[buildId]/ModeratorTools.tsx
+++ b/web/src/app/builds/[buildId]/ModeratorTools.tsx
@@ -1,14 +1,8 @@
 "use client";
 
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-
-// The token never changes while the page is mounted (it's set on /moderate),
-// so there is nothing to subscribe to — the store only bridges the SSR/client
-// gap: the server snapshot renders nothing, hydration reveals the saved token.
-const noSubscribe = () => () => {};
-const clientToken = () => sessionStorage.getItem("prism-mod-token") ?? "";
-const serverToken = () => "";
+import { useModerator } from "@/components/useModerator";
 
 interface Props {
   sha256: string;
@@ -35,8 +29,7 @@ interface Props {
 // name+lot, so a router.refresh() after a save remounts it with fresh values.
 export default function ModeratorTools({ sha256, name, lot, lots, game, gameSystem, privateFlag, lotPrivate, skips }: Props) {
   const router = useRouter();
-  const token = useSyncExternalStore(noSubscribe, clientToken, serverToken);
-  const [wikiModerator, setWikiModerator] = useState(false);
+  const { moderator: visible, token } = useModerator();
   const [nameInput, setNameInput] = useState(name);
   const [lotInput, setLotInput] = useState(lot ?? "");
   const [gameInput, setGameInput] = useState(game ?? "");
@@ -45,22 +38,9 @@ export default function ModeratorTools({ sha256, name, lot, lots, game, gameSyst
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState("");
 
-  useEffect(() => {
-    if (token) return;
-    let cancelled = false;
-    fetch("/api/whoami", { cache: "no-store" })
-      .then((r) => r.json())
-      .then((w) => !cancelled && setWikiModerator(!!w.moderator))
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [token]);
-
   // Game suggestions come from the server as you type (there are thousands of
   // games — too many to embed like the lot list). Debounced; stale responses
   // are dropped so a slow early query can't overwrite a fresh one.
-  const visible = !!token || wikiModerator;
   useEffect(() => {
     if (!visible) return;
     let cancelled = false;

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from "react";
+import { humanSize } from "@/lib/format";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
@@ -33,18 +34,6 @@ export const runtime = "nodejs";
 export const revalidate = 3600;
 export function generateStaticParams(): Array<{ buildId: string }> {
   return [];
-}
-
-function humanSize(bytes?: number): string {
-  if (bytes == null) return "—";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  let v = bytes;
-  let i = 0;
-  while (v >= 1024 && i < units.length - 1) {
-    v /= 1024;
-    i++;
-  }
-  return i === 0 ? `${bytes} B` : `${v.toFixed(1)} ${units[i]}`;
 }
 
 function titleize(k: string): string {

--- a/web/src/app/builds/[buildId]/repo/[name]/RepoFileView.tsx
+++ b/web/src/app/builds/[buildId]/repo/[name]/RepoFileView.tsx
@@ -10,6 +10,7 @@
 // hunks), clicking through to that change's diff.
 
 import { Fragment, useEffect, useState } from "react";
+import { humanSize } from "@/lib/format";
 import { blameHunks, type BlameDto } from "@/lib/blame";
 import { splitLines } from "@/lib/linediff";
 import { formatCommitDate, type RepoLogEntryDto } from "@/lib/repo-manifest";
@@ -18,17 +19,6 @@ import type { LogState } from "./RepoViewer";
 
 // Same cap as the asset viewer: a 20MB DOM node makes the tab crawl.
 const TEXT_DISPLAY_CAP = 1_000_000;
-
-function humanSize(bytes: number): string {
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  let v = bytes;
-  let i = 0;
-  while (v >= 1024 && i < units.length - 1) {
-    v /= 1024;
-    i++;
-  }
-  return i === 0 ? `${bytes} B` : `${v.toFixed(1)} ${units[i]}`;
-}
 
 function TextBody({ url, path }: { url: string; path: string }) {
   const [state, setState] = useState<{ text: string; truncated: boolean } | "loading" | "error">("loading");

--- a/web/src/app/games/[slug]/GameBuilds.tsx
+++ b/web/src/app/games/[slug]/GameBuilds.tsx
@@ -5,24 +5,13 @@
 // mis-filed build to another game, clear it, or move builds between lots).
 
 import { useState } from "react";
+import { humanSize } from "@/lib/format";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import MassApply from "@/components/MassApply";
 import { useModerator } from "@/components/useModerator";
 import { buildHref } from "@/lib/slug";
 import type { BuildListItem } from "@/lib/queries";
-
-function humanSize(bytes?: number): string {
-  if (bytes == null) return "—";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  let v = Number(bytes);
-  let i = 0;
-  while (v >= 1024 && i < units.length - 1) {
-    v /= 1024;
-    i++;
-  }
-  return i === 0 ? `${v} B` : `${v.toFixed(1)} ${units[i]}`;
-}
 
 export default function GameBuilds({ builds }: { builds: BuildListItem[] }) {
   const router = useRouter();

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,0 +1,16 @@
+// Dependency-free display formatters shared by the build/asset/repo UIs. Kept
+// import-free so both server and client components can pull from one source
+// (this was copy-pasted into ~6 components and had begun to diverge).
+
+/** Human-readable byte size ("1.5 MB"), "—" for null/undefined. */
+export function humanSize(bytes?: number | null): string {
+  if (bytes == null) return "—";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let v = Number(bytes);
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return i === 0 ? `${v} B` : `${v.toFixed(1)} ${units[i]}`;
+}

--- a/web/src/lib/meta.ts
+++ b/web/src/lib/meta.ts
@@ -1,18 +1,9 @@
 // Shared strings for social-preview metadata (build pages + OG card images).
 
 import type { BuildMetaRow } from "./queries";
+import { humanSize } from "./format";
 
-export function humanSize(bytes?: number | null): string {
-  if (bytes == null) return "—";
-  const units = ["B", "KB", "MB", "GB", "TB"];
-  let v = Number(bytes);
-  let i = 0;
-  while (v >= 1024 && i < units.length - 1) {
-    v /= 1024;
-    i++;
-  }
-  return i === 0 ? `${bytes} B` : `${v.toFixed(1)} ${units[i]}`;
-}
+export { humanSize };
 
 /** The heading users see: the curated build name (renameable by moderators). */
 export function displayTitle(m: BuildMetaRow): string {


### PR DESCRIPTION
Consolidate the six copies of humanSize into a shared lib/format, and point ModeratorTools at the existing useModerator hook instead of re-implementing it.