### PR TITLE
Tidy rust

### DIFF
--- a/crates/prism-core/src/tga.rs
+++ b/crates/prism-core/src/tga.rs
@@ -74,7 +74,7 @@ fn decode(b: &[u8]) -> Result<Decoded, String> {
         if !matches!(cmap_bits, 15 | 16 | 24 | 32) {
             return Err(format!("unsupported TGA palette depth {cmap_bits}"));
         }
-        let entry_bytes = (cmap_bits as usize + 7) / 8;
+        let entry_bytes = (cmap_bits as usize).div_ceil(8);
         let end = off + cmap_len * entry_bytes;
         if end > b.len() {
             return Err("truncated TGA".into());
@@ -87,7 +87,7 @@ fn decode(b: &[u8]) -> Result<Decoded, String> {
         off = end;
     }
 
-    let bpp = (depth as usize + 7) / 8;
+    let bpp = (depth as usize).div_ceil(8);
     let count = (width * height) as usize;
 
     // Bound the up-front allocation: a valid stream must carry at least this many

--- a/crates/prism-win/src/main.rs
+++ b/crates/prism-win/src/main.rs
@@ -1211,10 +1211,11 @@ mod app {
             if !p.is_null() {
                 std::ptr::copy_nonoverlapping(wtext.as_ptr(), p as *mut u16, wtext.len());
                 let _ = GlobalUnlock(hmem);
-                // CF_UNICODETEXT = 13. On success the clipboard owns the memory.
-                if SetClipboardData(13u32, HANDLE(hmem.0)).is_err() {
-                    let _ = GlobalUnlock(hmem); // best-effort; free not exposed here
-                }
+                // CF_UNICODETEXT = 13. On success the clipboard takes ownership. On
+                // the rare failure the moveable global leaks — GlobalFree isn't in the
+                // enabled windows-crate features, and the old second GlobalUnlock here
+                // (the handle was already unlocked) neither freed it nor did anything.
+                let _ = SetClipboardData(13u32, HANDLE(hmem.0));
             }
         }
         let _ = CloseClipboard();


### PR DESCRIPTION
Switch the TGA byte-width calcs to div_ceil, and drop the no-op double-unlock on the clipboard failure path (GlobalFree isn't in the enabled windows-crate features). Stacked on #113.