### PR TITLE
Add wiki import and admin scripts

### DIFF
--- a/web/scripts/create-user.mts
+++ b/web/scripts/create-user.mts
@@ -1,0 +1,20 @@
+// Create a local cube wiki account:
+//   npx tsx web/scripts/create-user.mts <name> <password> [role,...]
+
+import pg from "pg";
+import { createUser } from "cube";
+
+const [name, password, roles] = process.argv.slice(2);
+if (!name || !password) {
+  console.error("usage: create-user.mts <name> <password> [role,...]");
+  process.exit(2);
+}
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL || "postgres:///curator" });
+const user = await createUser(pool, {
+  name,
+  password,
+  roles: roles ? roles.split(",") : [],
+});
+console.log(`created user ${user.name} (id ${user.id}) roles=[${user.roles.join(", ")}]`);
+await pool.end();

--- a/web/scripts/create-user.mts
+++ b/web/scripts/create-user.mts
@@ -1,12 +1,35 @@
 // Create a local cube wiki account:
-//   npx tsx web/scripts/create-user.mts <name> <password> [role,...]
+//   CUBE_PASSWORD=... npx tsx web/scripts/create-user.mts <name> [role,...]
+// The password comes from $CUBE_PASSWORD (or an stdin prompt) so it never lands
+// in the process table (ps) or shell history the way an argv password would.
 
+import { createInterface } from "node:readline/promises";
 import pg from "pg";
 import { createUser } from "cube";
 
-const [name, password, roles] = process.argv.slice(2);
-if (!name || !password) {
-  console.error("usage: create-user.mts <name> <password> [role,...]");
+const [name, roles] = process.argv.slice(2);
+if (!name) {
+  console.error("usage: CUBE_PASSWORD=<pw> create-user.mts <name> [role,...]");
+  process.exit(2);
+}
+
+async function readPassword(): Promise<string> {
+  const fromEnv = process.env.CUBE_PASSWORD;
+  if (fromEnv) return fromEnv;
+  // Only prompt on a real terminal; a piped/closed stdin returns "" and the
+  // caller exits cleanly rather than hanging on an EOF that never resolves.
+  if (!process.stdin.isTTY) return "";
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    return await rl.question("password: ");
+  } finally {
+    rl.close();
+  }
+}
+
+const password = await readPassword();
+if (!password) {
+  console.error("a password is required (set CUBE_PASSWORD or type one at the prompt)");
   process.exit(2);
 }
 

--- a/web/scripts/cube-mcp.mts
+++ b/web/scripts/cube-mcp.mts
@@ -1,0 +1,21 @@
+// Stdio MCP server for the cube wiki (local dev).
+// Register with: claude mcp add cube-wiki -- npx tsx web/scripts/cube-mcp.mts
+// Writes are attributed to the CUBE_MCP_USER name (default "mcp-agent").
+
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import pg from "pg";
+import { createCube } from "cube";
+import { createCubeMcpServer } from "cube/mcp";
+import { hpComponents } from "../src/cube/schemas";
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL || "postgres:///curator",
+  statement_timeout: 15_000,
+});
+
+const cube = createCube({ db: { pool }, components: hpComponents });
+const server = createCubeMcpServer(cube, {
+  user: { id: 0, name: process.env.CUBE_MCP_USER ?? "mcp-agent", roles: ["moderator"] },
+});
+
+await server.connect(new StdioServerTransport());

--- a/web/scripts/git-export.mts
+++ b/web/scripts/git-export.mts
@@ -1,0 +1,15 @@
+// Drain the cube git-export queue into a local mirror repo.
+//   npx tsx web/scripts/git-export.mts [--dir <path>]
+
+import pg from "pg";
+import { processGitQueue } from "cube";
+
+const dirFlag = process.argv.indexOf("--dir");
+const dir = dirFlag > 0 ? process.argv[dirFlag + 1]! : new URL("../.wiki-git", import.meta.url).pathname;
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL || "postgres:///curator" });
+const result = await processGitQueue(pool, { dir, emailDomain: "users.hiddenpalace.org" });
+console.log(`processed ${result.processed} queue items into ${dir}`);
+if (result.itemError) console.error(`stopped at item ${result.itemError.queueId}: ${result.itemError.message}`);
+if (result.pushError) console.error(`push failed: ${result.pushError}`);
+await pool.end();

--- a/web/scripts/import-wiki-batch.mts
+++ b/web/scripts/import-wiki-batch.mts
@@ -2,7 +2,12 @@
 // (cube/spikes/data/all-titles.tsv format: ns_id TAB title-with-prefix).
 // Converts each page via the HP mapping; when conversion fails the raw
 // wikitext is stored with wikitextFallback. Failures append to
-// web/.wiki-import-failures.log (title TAB error); resume with --offset.
+// web/.wiki-import-failures.log (title TAB error). To resume after an
+// interruption, re-run from the ORIGINAL --offset: imports are idempotent by
+// revision id, so already-done pages are cheap no-ops. With --concurrency > 1
+// the in-progress `done` counter is not a contiguous prefix, so do not use it
+// as a resume point (the "next --offset" hint below is only exact on a clean
+// finish).
 //
 //   npx tsx web/scripts/import-wiki-batch.mts --titles cube/spikes/data/all-titles.tsv \
 //     [--limit N] [--concurrency 3] [--offset N] [--ns 0]

--- a/web/scripts/import-wiki-batch.mts
+++ b/web/scripts/import-wiki-batch.mts
@@ -1,0 +1,123 @@
+// Batch-import wiki pages into the local cube instance from a titles TSV
+// (cube/spikes/data/all-titles.tsv format: ns_id TAB title-with-prefix).
+// Converts each page via the HP mapping; when conversion fails the raw
+// wikitext is stored with wikitextFallback. Failures append to
+// web/.wiki-import-failures.log (title TAB error); resume with --offset.
+//
+//   npx tsx web/scripts/import-wiki-batch.mts --titles cube/spikes/data/all-titles.tsv \
+//     [--limit N] [--concurrency 3] [--offset N] [--ns 0]
+
+import { appendFileSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import pg from "pg";
+import { createCube } from "cube";
+import { convert, importRevision } from "cube/import/mediawiki";
+import { fetchParsoidHtml, fetchRevisionInfo } from "cube/import/mediawiki/fetch";
+import { hpComponents } from "../src/cube/schemas";
+import { hpMapping, mapAsk } from "../src/cube/mapping";
+
+const BASE = process.env.WIKI_BASE_URL ?? "https://hiddenpalace.org";
+const FETCH_DELAY_MS = 150; // per worker, between pages
+
+const args = process.argv.slice(2);
+function argValue(name: string): string | undefined {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+function argNumber(name: string, fallback: number): number {
+  const v = argValue(name);
+  if (v === undefined) return fallback;
+  const n = Number.parseInt(v, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    console.error(`${name} takes a non-negative integer`);
+    process.exit(2);
+  }
+  return n;
+}
+
+const titlesPath = argValue("--titles");
+if (!titlesPath) {
+  console.error(
+    "usage: import-wiki-batch.mts --titles <file> [--limit N] [--concurrency 3] [--offset N] [--ns 0]",
+  );
+  process.exit(2);
+}
+const limit = argNumber("--limit", Number.MAX_SAFE_INTEGER);
+const concurrency = Math.max(1, argNumber("--concurrency", 3));
+const offset = argNumber("--offset", 0);
+const ns = argNumber("--ns", 0);
+
+const failureLog = fileURLToPath(new URL("../.wiki-import-failures.log", import.meta.url));
+
+const titles = readFileSync(titlesPath, "utf8")
+  .split("\n")
+  .filter((line) => line !== "")
+  .map((line) => {
+    const tab = line.indexOf("\t");
+    return { ns: Number.parseInt(line.slice(0, tab), 10), title: line.slice(tab + 1) };
+  })
+  .filter((row) => row.ns === ns && row.title !== "")
+  .map((row) => row.title);
+
+const queue = titles.slice(offset, limit === Number.MAX_SAFE_INTEGER ? undefined : offset + limit);
+console.error(`importing ${queue.length} page(s) (ns ${ns}, offset ${offset}) from ${BASE}`);
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL || "postgres:///curator",
+  statement_timeout: 60_000,
+});
+const cube = createCube({ db: { pool }, components: hpComponents });
+
+
+
+let next = 0;
+let done = 0;
+let failed = 0;
+let fallbacks = 0;
+
+async function worker(): Promise<void> {
+  for (;;) {
+    const i = next++;
+    if (i >= queue.length) return;
+    const title = queue[i]!;
+    try {
+      // History carries the original MW syntax: wikitext revision first
+      // (original author/timestamp, mw_rev_id provenance), converted
+      // markdown on top. Idempotent by mw_rev_id.
+      const page = await fetchParsoidHtml(BASE, title);
+      const result = convert(page.html, { pageTitle: title, mapping: hpMapping, mapAsk });
+      const info = await fetchRevisionInfo(BASE, title);
+      const saved = await importRevision(cube, {
+        title,
+        wikitext: info.wikitext,
+        mwRevId: info.revId,
+        mwAuthor: info.author,
+        mwTimestamp: info.timestamp,
+        mwComment: info.comment,
+        markdown: result.markdown,
+      });
+      if (result.markdown === null || saved.validationIssues) {
+        fallbacks++;
+        if (saved.validationIssues) {
+          appendFileSync(failureLog, `${title}\tVALIDATION->wikitext head: ${saved.validationIssues[0]?.message ?? ""}\n`);
+        }
+      }
+    } catch (err) {
+      failed++;
+      const message = (err instanceof Error ? err.message : String(err)).replace(/\s+/g, " ");
+      appendFileSync(failureLog, `${title}\t${message}\n`);
+    }
+    done++;
+    if (done % 10 === 0) {
+      console.error(`${done}/${queue.length} (${failed} failed, ${fallbacks} wikitext fallbacks)`);
+    }
+    await new Promise((r) => setTimeout(r, FETCH_DELAY_MS));
+  }
+}
+
+await Promise.all(Array.from({ length: Math.min(concurrency, queue.length) }, () => worker()));
+console.error(
+  `done: ${done}/${queue.length} (${failed} failed, ${fallbacks} wikitext fallbacks); next --offset ${offset + done}`,
+);
+if (failed > 0) console.error(`failures logged to ${failureLog}`);
+await pool.end();

--- a/web/scripts/import-wiki-page.mts
+++ b/web/scripts/import-wiki-page.mts
@@ -1,0 +1,75 @@
+// Import a single page from the live hiddenpalace.org wiki into the local
+// cube instance. History carries the original wikitext: the MW revision saves
+// verbatim first (original author/timestamp/comment, mw_rev_id provenance),
+// then the converted markdown lands on top.
+//
+//   npx tsx web/scripts/import-wiki-page.mts "Sonic the Hedgehog 2 (Nick Arcade prototype)"
+//   npx tsx web/scripts/import-wiki-page.mts "Some Page" --save
+//
+// Flags: --save (write into DATABASE_URL, default postgres:///curator),
+//        --wikitext (print the source wikitext too), --quiet (markdown only)
+
+import pg from "pg";
+import { createCube } from "cube";
+import { convert, importRevision } from "cube/import/mediawiki";
+import { fetchParsoidHtml, fetchRevisionInfo } from "cube/import/mediawiki/fetch";
+import { hpComponents } from "../src/cube/schemas";
+import { hpMapping, mapAsk } from "../src/cube/mapping";
+
+const BASE = process.env.WIKI_BASE_URL ?? "https://hiddenpalace.org";
+
+const args = process.argv.slice(2);
+const flags = new Set(args.filter((a) => a.startsWith("--")));
+const title = args.find((a) => !a.startsWith("--"));
+if (!title) {
+  console.error('usage: import-wiki-page.mts "Page Title" [--save] [--wikitext] [--quiet]');
+  process.exit(2);
+}
+
+const page = await fetchParsoidHtml(BASE, title);
+const result = convert(page.html, { pageTitle: title, mapping: hpMapping, mapAsk });
+
+if (!flags.has("--quiet")) {
+  console.error(`# ${title} (rev ${page.revisionId})`);
+  console.error(`# categories: ${result.categories.join(", ") || "(none)"}`);
+  for (const w of result.warnings) {
+    console.error(`# ${w.severity.toUpperCase()} ${w.code}: ${w.message}`);
+  }
+  console.error(`# ok: ${result.ok}`);
+  console.error("");
+}
+
+if (result.markdown !== null) console.log(result.markdown);
+else console.error("conversion failed; the wikitext revision will be head");
+
+if (flags.has("--wikitext") || flags.has("--save")) {
+  const info = await fetchRevisionInfo(BASE, title);
+  if (flags.has("--wikitext")) {
+    console.error("\n===== original wikitext =====\n");
+    console.error(info.wikitext);
+  }
+  if (flags.has("--save")) {
+    const pool = new pg.Pool({
+      connectionString: process.env.DATABASE_URL || "postgres:///curator",
+      statement_timeout: 60_000,
+    });
+    const cube = createCube({ db: { pool }, components: hpComponents });
+    const saved = await importRevision(cube, {
+      title,
+      wikitext: info.wikitext,
+      mwRevId: info.revId,
+      mwAuthor: info.author,
+      mwTimestamp: info.timestamp,
+      mwComment: info.comment,
+      markdown: result.markdown,
+    });
+    console.error(`${saved.outcome}: head r${saved.headRevId}`);
+    if (saved.validationIssues) {
+      console.error("conversion failed validation; wikitext stays head:");
+      for (const i of saved.validationIssues.slice(0, 5)) {
+        console.error(`  ${i.line ?? "?"}:${i.column ?? "?"} [${i.rule}] ${i.message}`);
+      }
+    }
+    await pool.end();
+  }
+}

--- a/web/scripts/sync-wiki.mts
+++ b/web/scripts/sync-wiki.mts
@@ -1,0 +1,108 @@
+// Continuous sync from the live hiddenpalace.org wiki into the local cube
+// instance: poll recentchanges, convert the touched pages via the HP mapping,
+// save (wikitext fallback when conversion fails), remember the high-water
+// timestamp in a state file.
+//
+//   npx tsx web/scripts/sync-wiki.mts                 one pass (default)
+//   npx tsx web/scripts/sync-wiki.mts --loop 300      poll every 5 minutes
+//   npx tsx web/scripts/sync-wiki.mts --since 2026-07-20T00:00:00Z
+//
+// Flags: --state <path>   state file (default web/.wiki-sync-state.json)
+//        --since <ts>     initial MW ISO timestamp (first run only; state wins)
+//        --loop <seconds> keep polling; --once is the default
+//        --limit <n>      max recent-change entries per pass (default 500)
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import pg from "pg";
+import { createCube } from "cube";
+import { convert, importRevision, syncRecentChanges, type SyncSaveInput } from "cube/import/mediawiki";
+import { hpComponents } from "../src/cube/schemas";
+import { hpMapping, mapAsk } from "../src/cube/mapping";
+
+const BASE = process.env.WIKI_BASE_URL ?? "https://hiddenpalace.org";
+
+const args = process.argv.slice(2);
+function argValue(name: string): string | undefined {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+const statePath = argValue("--state") ?? fileURLToPath(new URL("../.wiki-sync-state.json", import.meta.url));
+const loopArg = argValue("--loop");
+const loopSeconds = loopArg !== undefined ? Number.parseInt(loopArg, 10) : null;
+const limitArg = argValue("--limit");
+const limit = limitArg !== undefined ? Number.parseInt(limitArg, 10) : 500;
+
+if (loopSeconds !== null && (!Number.isFinite(loopSeconds) || loopSeconds <= 0)) {
+  console.error("--loop takes a positive number of seconds");
+  process.exit(2);
+}
+
+function readSince(): string {
+  if (existsSync(statePath)) {
+    const state = JSON.parse(readFileSync(statePath, "utf8")) as { since?: string };
+    if (typeof state.since === "string" && state.since !== "") return state.since;
+  }
+  return argValue("--since") ?? new Date().toISOString();
+}
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL || "postgres:///curator",
+  statement_timeout: 60_000,
+});
+const cube = createCube({ db: { pool }, components: hpComponents });
+
+async function save(input: SyncSaveInput): Promise<void> {
+  if (input.wikitext === null || input.revId === null) {
+    throw new Error("sync requires wikitext + revid for history provenance");
+  }
+  // History carries the original MW syntax: wikitext revision first, then
+  // the converted markdown on top (idempotent by mw_rev_id).
+  const saved = await importRevision(cube, {
+    title: input.title,
+    wikitext: input.wikitext,
+    mwRevId: input.revId,
+    mwAuthor: input.author || "unknown",
+    mwTimestamp: input.timestamp ? new Date(input.timestamp) : new Date(),
+    mwComment: input.comment,
+    markdown: input.markdown,
+  });
+  console.error(
+    `${saved.outcome} ${input.title} head r${saved.headRevId}` +
+      (saved.validationIssues ? " (conversion failed validation, wikitext head)" : ""),
+  );
+}
+
+async function runOnce(since: string): Promise<string> {
+  const res = await syncRecentChanges({
+    baseUrl: BASE,
+    since,
+    limit,
+    convert: (title, html) => convert(html, { pageTitle: title, mapping: hpMapping, mapAsk }),
+    save,
+  });
+  for (const f of res.failures) console.error(`FAIL ${f.title}: ${f.error}`);
+  console.error(
+    `synced ${res.processed} page(s), ${res.failures.length} failure(s), since -> ${res.newSince}`,
+  );
+  writeFileSync(statePath, JSON.stringify({ since: res.newSince }, null, 2) + "\n");
+  return res.newSince;
+}
+
+let since = readSince();
+console.error(`syncing ${BASE} since ${since} (state: ${statePath})`);
+
+if (loopSeconds !== null) {
+  for (;;) {
+    try {
+      since = await runOnce(since);
+    } catch (err) {
+      console.error(`sync pass failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    await new Promise((r) => setTimeout(r, loopSeconds * 1000));
+  }
+} else {
+  await runOnce(since);
+  await pool.end();
+}


### PR DESCRIPTION
Scripts for importing pages from the live wiki (single page and batch with resume), a recentchanges sync worker, git mirror export, account creation, and a stdio MCP entry point. Imports store the original wikitext revision with its MediaWiki author, timestamp, and revision id, then the converted markdown lands on top, so history keeps the original syntax and re-imports are idempotent by revision id.