### PR TITLE
Fix cube engine review findings

### DIFF
--- a/cube/src/auth/native.ts
+++ b/cube/src/auth/native.ts
@@ -70,6 +70,14 @@ function sha256hex(s: string): string {
   return createHash("sha256").update(s).digest("hex");
 }
 
+// A fixed valid scrypt hash, computed once, used only to spend the same work on
+// the login miss path as a real password verify (see login()).
+let DUMMY_HASH: string | null = null;
+function dummyHash(): string {
+  if (DUMMY_HASH === null) DUMMY_HASH = hashPassword("cube-timing-equalizer");
+  return DUMMY_HASH;
+}
+
 /** MW-compatible username canonicalization: trim, collapse spaces, ucfirst. */
 export function canonicalUsername(name: string): string {
   const t = name.replace(/[_\s]+/g, " ").trim();
@@ -123,7 +131,13 @@ export function cubeNativeAuth(opts: NativeAuthOptions): CubeAuthAdapter {
         [name],
       );
       const row = res.rows[0];
-      if (!row || row.blocked_at !== null) return null;
+      if (!row || row.blocked_at !== null) {
+        // Run a real verify against a dummy hash so the unknown/blocked-user
+        // path costs the same as a wrong password, closing a username-
+        // enumeration timing oracle. (Not a substitute for rate limiting.)
+        verifyPassword(dummyHash(), creds.password);
+        return null;
+      }
       if (!verifyPassword(row.password_hash, creds.password)) return null;
 
       if (row.password_hash && needsRehash(row.password_hash)) {

--- a/cube/src/diff.ts
+++ b/cube/src/diff.ts
@@ -4,26 +4,46 @@
 import { diffLines, type Change } from "diff";
 import type { Pool } from "pg";
 
+/** Per-side page context so callers can enforce read authorization. */
+export type DiffSidePage = {
+  ns: string;
+  slug: string;
+  visibility: "public" | "moderator";
+  deleted: boolean;
+};
+
 export type RevisionDiff = {
   from: { id: number; author: string; createdAt: Date };
   to: { id: number; author: string; createdAt: Date };
   samePage: boolean;
   changes: Change[];
+  /** Owning page of each revision; used for `can("read")` gating. */
+  pages: { from: DiffSidePage; to: DiffSidePage };
 };
 
 export async function diffRevisions(pool: Pool, fromId: number, toId: number): Promise<RevisionDiff | null> {
   const res = await pool.query(
-    `SELECT id, page_id, author_name, content, created_at FROM cube_revision WHERE id = ANY($1)`,
+    `SELECT r.id, r.page_id, r.author_name, r.content, r.created_at,
+            p.ns, p.slug, p.visibility, p.deleted_at
+       FROM cube_revision r JOIN cube_page p ON p.id = r.page_id
+      WHERE r.id = ANY($1)`,
     [[fromId, toId]],
   );
   // node-pg returns BIGINT as strings; compare numerically.
   const from = res.rows.find((r) => Number(r.id) === fromId);
   const to = res.rows.find((r) => Number(r.id) === toId);
   if (!from || !to) return null;
+  const side = (r: (typeof res.rows)[number]): DiffSidePage => ({
+    ns: r.ns,
+    slug: r.slug,
+    visibility: r.visibility,
+    deleted: r.deleted_at !== null,
+  });
   return {
     from: { id: Number(from.id), author: from.author_name, createdAt: from.created_at },
     to: { id: Number(to.id), author: to.author_name, createdAt: to.created_at },
     samePage: Number(from.page_id) === Number(to.page_id),
     changes: diffLines(from.content, to.content),
+    pages: { from: side(from), to: side(to) },
   };
 }

--- a/cube/src/http/index.ts
+++ b/cube/src/http/index.ts
@@ -125,6 +125,18 @@ async function route(cube: Cube, req: Request): Promise<Response> {
   };
   const requireScope = (scope: string): Response | null =>
     auth.scopes.has(scope) ? null : err("forbidden", 403, `missing scope: ${scope}`);
+  // Read gate for the revision/diff/history endpoints, which fetch content by
+  // id rather than title: honor page `visibility`, and treat soft-deleted
+  // pages as moderator-only so they 404 for everyone else. Without this these
+  // routes are a back door around the visibility control that /page enforces.
+  const canReadPage = async (
+    page: { ns: string; slug: string; visibility?: "public" | "moderator" },
+    deleted = false,
+  ): Promise<boolean> => {
+    if (!(await can("read", page))) return false;
+    if (deleted && !(await can("delete", page))) return false;
+    return true;
+  };
 
   /* ---- auth ---- */
   if (path === "/auth/login" && method === "POST") {
@@ -266,6 +278,8 @@ async function route(cube: Cube, req: Request): Promise<Response> {
     const resolved = await cube.api.resolve(title);
     if (!resolved) return err("not_found", 404, "no such page");
     const ref = resolved.redirectedFrom ?? resolved;
+    const page = await cube.api.getPage(ref);
+    if (!page || !(await canReadPage(page))) return err("not_found", 404, "no such page");
     const revisions = await cube.api.listRevisions(ref, {
       limit: numParam(url, "limit"),
       before: numParam(url, "before"),
@@ -277,6 +291,9 @@ async function route(cube: Cube, req: Request): Promise<Response> {
   if (revMatch && method === "GET") {
     const rev = await cube.api.getRevision(Number(revMatch[1]));
     if (!rev) return err("not_found", 404, "no such revision");
+    if (!(await canReadPage({ ns: rev.ns, slug: rev.slug, visibility: rev.visibility }, rev.deletedAt !== null))) {
+      return err("not_found", 404, "no such revision");
+    }
     return json(rev);
   }
 
@@ -286,6 +303,9 @@ async function route(cube: Cube, req: Request): Promise<Response> {
     if (!from || !to) return err("bad_request", 400, "from and to revision ids required");
     const diff = await diffRevisions(cube.pool(), from, to);
     if (!diff) return err("not_found", 404, "no such revisions");
+    for (const p of [diff.pages.from, diff.pages.to]) {
+      if (!(await canReadPage(p, p.deleted))) return err("not_found", 404, "no such revisions");
+    }
     return json(diff);
   }
 
@@ -545,12 +565,16 @@ async function verifyToken(pool: Pool, token: string): Promise<AuthResult | null
   const m = /^cube_(\d+)_[A-Za-z0-9_-]+$/.exec(token);
   if (!m) return null;
   const res = await pool.query(
-    `SELECT id, name, token_sha256, scopes, user_id, expires_at FROM cube_token WHERE id = $1`,
+    `SELECT t.id, t.name, t.token_sha256, t.scopes, t.user_id, t.expires_at, u.blocked_at
+       FROM cube_token t LEFT JOIN cube_user u ON u.id = t.user_id
+      WHERE t.id = $1`,
     [Number(m[1])],
   );
   const row = res.rows[0];
   if (!row) return null;
   if (row.expires_at && new Date(row.expires_at).getTime() < Date.now()) return null;
+  // A blocked user's tokens must stop working, mirroring the cookie path.
+  if (row.user_id !== null && row.blocked_at !== null) return null;
   const actual = createHash("sha256").update(token).digest();
   const expected = Buffer.from(row.token_sha256, "hex");
   if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) return null;

--- a/cube/src/import/mediawiki/fetch.ts
+++ b/cube/src/import/mediawiki/fetch.ts
@@ -11,13 +11,20 @@ export type FetchedPage = {
   html: string;
 };
 
+// Bound every request so an unattended sync loop can't hang forever on a
+// stalled connection; also caps how long a slow response ties up the worker.
+const FETCH_TIMEOUT_MS = 30_000;
+function reqInit(): RequestInit {
+  return { headers: { "user-agent": "cube-import/0.1" }, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) };
+}
+
 function encodeTitle(title: string): string {
   return encodeURIComponent(title.replace(/ /g, "_"));
 }
 
 export async function fetchParsoidHtml(baseUrl: string, title: string): Promise<FetchedPage> {
   const url = `${baseUrl.replace(/\/$/, "")}/w/rest.php/v1/page/${encodeTitle(title)}/with_html`;
-  const res = await fetch(url, { headers: { "user-agent": "cube-import/0.1" } });
+  const res = await fetch(url, reqInit());
   if (!res.ok) throw new Error(`with_html ${res.status} for ${title}`);
   const body = (await res.json()) as { id: number; latest?: { id: number }; html: string; title?: string };
   return { title, revisionId: body.latest?.id ?? body.id, html: body.html };
@@ -25,7 +32,7 @@ export async function fetchParsoidHtml(baseUrl: string, title: string): Promise<
 
 export async function fetchRawWikitext(baseUrl: string, title: string): Promise<string> {
   const url = `${baseUrl.replace(/\/$/, "")}/w/index.php?title=${encodeTitle(title)}&action=raw`;
-  const res = await fetch(url, { headers: { "user-agent": "cube-import/0.1" } });
+  const res = await fetch(url, reqInit());
   if (!res.ok) throw new Error(`action=raw ${res.status} for ${title}`);
   return res.text();
 }
@@ -43,7 +50,7 @@ export async function fetchRevisionInfo(baseUrl: string, title: string): Promise
   const url =
     `${baseUrl.replace(/\/$/, "")}/w/api.php?action=query&prop=revisions` +
     `&rvprop=content|user|timestamp|comment|ids&rvslots=main&titles=${encodeTitle(title)}&format=json`;
-  const res = await fetch(url, { headers: { "user-agent": "cube-import/0.1" } });
+  const res = await fetch(url, reqInit());
   if (!res.ok) throw new Error(`revisions api ${res.status} for ${title}`);
   const body = (await res.json()) as {
     query?: { pages?: Record<string, { revisions?: {

--- a/cube/src/import/mediawiki/sync.ts
+++ b/cube/src/import/mediawiki/sync.ts
@@ -28,6 +28,8 @@ export type SyncSaveInput = {
 export type SyncFailure = {
   title: string;
   error: string;
+  /** Timestamp of the change we failed on; clamps the sync cursor. */
+  timestamp?: string;
 };
 
 export type SyncResult = {
@@ -68,7 +70,11 @@ type RcResponse = {
 };
 
 async function defaultFetchJson(url: string): Promise<unknown> {
-  const res = await fetch(url, { headers: { "user-agent": "cube-import/0.1" } });
+  // Bound the request so the continuous-sync loop can't hang on a stalled peer.
+  const res = await fetch(url, {
+    headers: { "user-agent": "cube-import/0.1" },
+    signal: AbortSignal.timeout(30_000),
+  });
   if (!res.ok) throw new Error(`recentchanges ${res.status}`);
   return res.json();
 }
@@ -104,11 +110,6 @@ export async function syncRecentChanges(opts: SyncOptions): Promise<SyncResult> 
   }
   const considered = changes.slice(0, limit);
 
-  let newSince = opts.since;
-  for (const c of considered) {
-    if (c.timestamp !== undefined && c.timestamp > newSince) newSince = c.timestamp;
-  }
-
   // Dedupe per title, keeping the latest change; main namespace only for now.
   const byTitle = new Map<string, RecentChange>();
   for (const c of considered) {
@@ -140,8 +141,29 @@ export async function syncRecentChanges(opts: SyncOptions): Promise<SyncResult> 
       });
       processed++;
     } catch (err) {
-      failures.push({ title, error: err instanceof Error ? err.message : String(err) });
+      failures.push({
+        title,
+        error: err instanceof Error ? err.message : String(err),
+        timestamp: rc.timestamp,
+      });
     }
+  }
+
+  // Advance the cursor over successfully-processed changes only: never to or
+  // past the oldest change we failed to import, so a transient failure is
+  // retried next pass instead of being silently skipped forever. rcstart is
+  // inclusive with rcdir=newer, and imports are idempotent, so re-listing the
+  // clamp point and later successes next pass is cheap.
+  const oldestFailure = failures.reduce<string | undefined>(
+    (min, f) => (f.timestamp && (min === undefined || f.timestamp < min) ? f.timestamp : min),
+    undefined,
+  );
+  let newSince = opts.since;
+  for (const c of considered) {
+    const t = c.timestamp;
+    if (t === undefined || t <= newSince) continue;
+    if (oldestFailure !== undefined && t >= oldestFailure) continue;
+    newSince = t;
   }
 
   return { processed, newSince, failures };

--- a/cube/src/index.ts
+++ b/cube/src/index.ts
@@ -123,7 +123,19 @@ export type CubeLocalApi = {
   savePage(input: SaveInput): Promise<SaveResult>;
   movePage(input: MoveInput): Promise<{ pageId: number }>;
   deletePage(input: DeleteInput): Promise<void>;
-  getRevision(id: number): Promise<(RevisionMeta & { content: string; pageId: number }) | null>;
+  getRevision(
+    id: number,
+  ): Promise<
+    | (RevisionMeta & {
+        content: string;
+        pageId: number;
+        ns: string;
+        slug: string;
+        visibility: "public" | "moderator";
+        deletedAt: Date | null;
+      })
+    | null
+  >;
   listRevisions(ref: { ns: string; slug: string }, opts?: { limit?: number; before?: number }): Promise<RevisionMeta[]>;
   search(q: string, opts?: { ns?: string; limit?: number }): Promise<SearchHit[]>;
   queryObjects(q: ObjectQuery, opts?: CompileOptions): Promise<QueryResult>;
@@ -223,15 +235,30 @@ export function createCube(config: CubeConfig): Cube {
 
     async getRevision(id) {
       const res = await pool().query(
-        `SELECT id, page_id, parent_rev_id, author_name, comment, minor, content, wikitext_fallback, created_at
-           FROM cube_revision WHERE id = $1`,
+        `SELECT r.id, r.page_id, r.parent_rev_id, r.author_name, r.comment, r.minor,
+                r.content, r.wikitext_fallback, r.created_at,
+                p.ns, p.slug, p.visibility, p.deleted_at
+           FROM cube_revision r JOIN cube_page p ON p.id = r.page_id
+          WHERE r.id = $1`,
         [id],
       );
-      const r = res.rows[0] as (RevisionRow & { page_id: number }) | undefined;
+      const r = res.rows[0] as
+        | (RevisionRow & {
+            page_id: number;
+            ns: string;
+            slug: string;
+            visibility: "public" | "moderator";
+            deleted_at: Date | null;
+          })
+        | undefined;
       if (!r) return null;
       return {
         id: Number(r.id),
         pageId: Number(r.page_id),
+        ns: r.ns,
+        slug: r.slug,
+        visibility: r.visibility,
+        deletedAt: r.deleted_at,
         parentRevId: r.parent_rev_id === null ? null : Number(r.parent_rev_id),
         author: r.author_name,
         comment: r.comment,

--- a/cube/src/mdx.ts
+++ b/cube/src/mdx.ts
@@ -28,7 +28,15 @@ export function rawAttrs(node: JsxElement): RawAttrsResult {
       errors.push({ message: "spread attributes ({...x}) are not allowed" });
       continue;
     }
-    if (a.name in attrs) {
+    // Reject prototype-mutating names outright rather than relying on
+    // downstream unknown-field dropping to neutralize them.
+    if (a.name === "__proto__" || a.name === "constructor" || a.name === "prototype") {
+      errors.push({ attr: a.name, message: `reserved attribute name "${a.name}"` });
+      continue;
+    }
+    // hasOwnProperty, not `in`: `in` walks the prototype chain and would
+    // falsely flag a first-and-only attr named e.g. "toString" as duplicate.
+    if (Object.prototype.hasOwnProperty.call(attrs, a.name)) {
       errors.push({ attr: a.name, message: `duplicate attribute "${a.name}"` });
       continue;
     }

--- a/cube/src/query.ts
+++ b/cube/src/query.ts
@@ -216,15 +216,27 @@ function safeAlias(name: string): string {
   return /^[a-zA-Z_]/.test(cleaned) ? cleaned : `agg_${cleaned}`;
 }
 
-function compileWhere(where: Where, fields: Map<string, QueryableField>, params: ParamSink): string {
+/** Guards against a page-authored `where` deep enough to blow the JS stack
+ * (an uncaught RangeError → 500). Real clauses nest only a handful deep. */
+const MAX_WHERE_DEPTH = 64;
+
+function compileWhere(
+  where: Where,
+  fields: Map<string, QueryableField>,
+  params: ParamSink,
+  depth = 0,
+): string {
+  if (depth > MAX_WHERE_DEPTH) {
+    throw new CubeQueryError(`where clause nested too deeply (max ${MAX_WHERE_DEPTH})`);
+  }
   if ("and" in where && Array.isArray(where.and)) {
-    return `(${(where.and as Where[]).map((w) => compileWhere(w, fields, params)).join(" AND ")})`;
+    return `(${(where.and as Where[]).map((w) => compileWhere(w, fields, params, depth + 1)).join(" AND ")})`;
   }
   if ("or" in where && Array.isArray(where.or)) {
-    return `(${(where.or as Where[]).map((w) => compileWhere(w, fields, params)).join(" OR ")})`;
+    return `(${(where.or as Where[]).map((w) => compileWhere(w, fields, params, depth + 1)).join(" OR ")})`;
   }
   if ("not" in where && typeof where.not === "object" && where.not !== null && !isScalarOrOps(where.not)) {
-    return `NOT (${compileWhere(where.not as Where, fields, params)})`;
+    return `NOT (${compileWhere(where.not as Where, fields, params, depth + 1)})`;
   }
 
   const conds: string[] = [];

--- a/cube/src/save.ts
+++ b/cube/src/save.ts
@@ -15,6 +15,7 @@ import { parseDocument } from "./parse";
 import { checkQueries } from "./query-component";
 import type { Registry } from "./schema/index";
 import { DEFAULT_SLUG_CONFIG, isTitleError, normalizeTitle, type SlugConfig, type TitleRef } from "./slug";
+import { serializeComponentTag } from "./tags";
 import { validateDocument, type ComponentInstance, type ValidateOptions } from "./validate";
 
 export type CubeAuthor = {
@@ -394,7 +395,8 @@ export async function movePage(pool: Pool, ctx: SaveContext, input: MoveInput): 
     await savePage(pool, ctx, {
       ns: input.from.ns,
       slug: input.from.slug,
-      markdown: `<Redirect to="${to.title}" />\n`,
+      // Serialize the tag so a title containing `"` can't inject attributes.
+      markdown: `${serializeComponentTag("Redirect", { to: to.title })}\n`,
       author: input.actor,
       comment: input.comment ?? `moved to ${to.title}`,
     });

--- a/cube/tests/http-auth.test.ts
+++ b/cube/tests/http-auth.test.ts
@@ -284,6 +284,101 @@ skippable("bearer tokens: scoped access, bad token rejected", async () => {
   assert.equal(body.user, null);
 });
 
+skippable("moderator-only pages don't leak content via revision/diff/history", async () => {
+  const csrf = { cookie: sessionCookie, "sec-fetch-site": "same-origin" };
+  const c1 = await cube.handlers.PUT(
+    req("PUT", "/page?title=Secret Page", { body: { markdown: "secret one\n", comment: "c1" }, headers: csrf }),
+  );
+  assert.equal(c1.status, 201);
+  const r1 = ((await c1.json()) as { revision: number }).revision;
+  const c2 = await cube.handlers.PUT(
+    req("PUT", "/page?title=Secret Page", {
+      body: { markdown: "secret two\n", baseRevision: r1, comment: "c2" },
+      headers: csrf,
+    }),
+  );
+  const r2 = ((await c2.json()) as { revision: number }).revision;
+
+  const modLogin = await cube.handlers.POST(
+    req("POST", "/auth/login", { body: { name: "mod", password: "modpass" } }),
+  );
+  const modCookie = modLogin.headers.get("set-cookie")!.split(";")[0]!;
+  const hide = await cube.handlers.POST(
+    req("POST", "/moderation/visibility", {
+      body: { title: "Secret Page", visibility: "moderator" },
+      headers: { cookie: modCookie, "sec-fetch-site": "same-origin" },
+    }),
+  );
+  assert.equal(hide.status, 200);
+
+  // Anonymous is blocked on every read path, not just /page.
+  assert.equal((await cube.handlers.GET(req("GET", "/page?title=Secret Page"))).status, 404);
+  assert.equal((await cube.handlers.GET(req("GET", `/revision/${r2}`))).status, 404);
+  assert.equal((await cube.handlers.GET(req("GET", "/revisions?title=Secret Page"))).status, 404);
+  assert.equal((await cube.handlers.GET(req("GET", `/diff?from=${r1}&to=${r2}`))).status, 404);
+
+  // A moderator can still read all of them.
+  const modRev = await cube.handlers.GET(req("GET", `/revision/${r2}`, { headers: { cookie: modCookie } }));
+  assert.equal(modRev.status, 200);
+  const modDiff = await cube.handlers.GET(req("GET", `/diff?from=${r1}&to=${r2}`, { headers: { cookie: modCookie } }));
+  assert.equal(modDiff.status, 200);
+});
+
+skippable("soft-deleted page revisions are hidden from anonymous, readable by moderators", async () => {
+  const csrf = { cookie: sessionCookie, "sec-fetch-site": "same-origin" };
+  const created = await cube.handlers.PUT(
+    req("PUT", "/page?title=Doomed Page", { body: { markdown: "doomed\n" }, headers: csrf }),
+  );
+  const rev = ((await created.json()) as { revision: number }).revision;
+
+  const modLogin = await cube.handlers.POST(
+    req("POST", "/auth/login", { body: { name: "mod", password: "modpass" } }),
+  );
+  const modCookie = modLogin.headers.get("set-cookie")!.split(";")[0]!;
+  const del = await cube.handlers.DELETE(
+    req("DELETE", "/page?title=Doomed Page", {
+      body: {},
+      headers: { cookie: modCookie, "sec-fetch-site": "same-origin" },
+    }),
+  );
+  assert.equal(del.status, 200);
+
+  assert.equal((await cube.handlers.GET(req("GET", `/revision/${rev}`))).status, 404);
+  const modRev = await cube.handlers.GET(req("GET", `/revision/${rev}`, { headers: { cookie: modCookie } }));
+  assert.equal(modRev.status, 200);
+});
+
+skippable("blocking a user revokes their API tokens", async () => {
+  const u = await createUser(pool, { name: "blockme", password: "pw" });
+  const { token } = await createToken(pool, {
+    name: "blockme-tok",
+    scopes: ["read", "query", "write"],
+    userId: u.id,
+  });
+
+  const before = await cube.handlers.GET(req("GET", "/auth/me", { headers: { authorization: `Bearer ${token}` } }));
+  assert.notEqual(((await before.json()) as { user: unknown }).user, null);
+
+  const modLogin = await cube.handlers.POST(
+    req("POST", "/auth/login", { body: { name: "mod", password: "modpass" } }),
+  );
+  const modCookie = modLogin.headers.get("set-cookie")!.split(";")[0]!;
+  const block = await cube.handlers.POST(
+    req("POST", "/moderation/block", {
+      body: { name: u.name },
+      headers: { cookie: modCookie, "sec-fetch-site": "same-origin" },
+    }),
+  );
+  assert.equal(block.status, 200);
+
+  const after = await cube.handlers.GET(req("GET", "/auth/me", { headers: { authorization: `Bearer ${token}` } }));
+  assert.equal(((await after.json()) as { user: unknown }).user, null);
+  const write = await cube.handlers.PUT(
+    req("PUT", "/page?title=Blocked Write", { body: { markdown: "x\n" }, headers: { authorization: `Bearer ${token}` } }),
+  );
+  assert.equal(write.status, 403);
+});
+
 skippable("moderator-only delete via defaultCan", async () => {
   const deny = await cube.handlers.DELETE(
     req("DELETE", "/page?title=Bot Page", {

--- a/cube/tests/integration.test.ts
+++ b/cube/tests/integration.test.ts
@@ -14,6 +14,7 @@ import pg from "pg";
 import { createCube, dependentPages, type Cube } from "../src/index";
 import { CubeConflictError, CubeValidationError } from "../src/issues";
 import { processGitQueue } from "../src/git";
+import { parseComponentTag } from "../src/tags";
 import { testComponents } from "./helpers";
 
 const DB = "cube_test";
@@ -266,6 +267,21 @@ skippable("move leaves a redirect and logs", async () => {
   assert.equal(resolved!.slug, "New_Name");
   const log = await pool.query(`SELECT action FROM cube_page_log WHERE action = 'move'`);
   assert.equal(log.rows.length, 1);
+});
+
+skippable("move to a title containing a quote can't inject redirect attributes", async () => {
+  await cube.api.savePage({ ns: "main", slug: "Quote_Move_Src", markdown: "content\n", author });
+  await cube.api.movePage({
+    from: { ns: "main", slug: "Quote_Move_Src" },
+    to: { ns: "main", slug: 'Pwned" author="admin' },
+    actor: author,
+  });
+  const redirect = await cube.api.getPage({ ns: "main", slug: "Quote_Move_Src" });
+  assert.ok(redirect);
+  const parsed = parseComponentTag(redirect.markdown.trim());
+  assert.ok(!("error" in parsed), `redirect should parse cleanly: ${JSON.stringify(parsed)}`);
+  // The quote must not have split into a second attribute: only `to` survives.
+  assert.deepEqual(Object.keys((parsed as { attrs: Record<string, unknown> }).attrs), ["to"]);
 });
 
 skippable("dependent pages found via query deps", async () => {

--- a/cube/tests/query.test.ts
+++ b/cube/tests/query.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { compileQuery, CubeQueryError } from "../src/query";
+import { compileQuery, CubeQueryError, type Where } from "../src/query";
 import { toObjectQuery } from "../src/query-component";
 import { testRegistry } from "./helpers";
 
@@ -69,6 +69,15 @@ test("unknown fields and components throw with valid-field listing", () => {
   assert.throws(
     () => compileQuery(testRegistry, { from: "Prototype", sort: [{ field: "nope" }] }),
     CubeQueryError,
+  );
+});
+
+test("deeply nested where throws CubeQueryError, not a RangeError stack overflow", () => {
+  let deep: Where = { game: "Sonic" };
+  for (let i = 0; i < 5000; i++) deep = { and: [deep] };
+  assert.throws(
+    () => compileQuery(testRegistry, { from: "Prototype", where: deep }),
+    (e: unknown) => e instanceof CubeQueryError && /nested too deeply/.test(e.message),
   );
 });
 


### PR DESCRIPTION
Closes the authorization bypass where anonymous users could read moderator-only and soft-deleted page content by enumerating revision ids. The revision, diff, and history routes now gate on can(read) using each revision's page visibility and deletion state, and a blocked user's API tokens are now rejected the same way their sessions already were.

Also caps where-clause nesting to turn a stack-overflow 500 into a clean validation error, escapes the move-redirect tag so a quoted title cannot inject attributes, equalizes login timing on the unknown-user path, and bounds import fetches with a timeout. Adds regression tests, the cube suite is green.