### PR TITLE
Fix cube wiki mount review findings

### DIFF
--- a/web/src/app/[...slug]/page.tsx
+++ b/web/src/app/[...slug]/page.tsx
@@ -27,14 +27,20 @@ type Props = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
-function titleFromParams(slug: string[]): string {
-  return slug.map((s) => decodeURIComponent(s)).join("/");
+function titleFromParams(slug: string[]): string | null {
+  try {
+    return slug.map((s) => decodeURIComponent(s)).join("/");
+  } catch {
+    return null; // malformed percent-encoding (e.g. "%zz")
+  }
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   if (RESERVED.has(slug[0] ?? "")) return {};
-  const ref = normalizeTitle(titleFromParams(slug), getCube().slug);
+  const title = titleFromParams(slug);
+  if (title === null) return {};
+  const ref = normalizeTitle(title, getCube().slug);
   if (isTitleError(ref)) return {};
   return { title: `${ref.title} - Hidden Palace` };
 }
@@ -45,6 +51,7 @@ export default async function WikiPage({ params, searchParams }: Props) {
 
   const cube = getCube();
   const title = titleFromParams(slug);
+  if (title === null) notFound();
   const ref = normalizeTitle(title, cube.slug);
   if (isTitleError(ref)) notFound();
 

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -9,7 +9,10 @@ import { useRouter, useSearchParams } from "next/navigation";
 function LoginForm() {
   const router = useRouter();
   const params = useSearchParams();
-  const next = params.get("next") ?? "/";
+  // Only same-site relative paths: a single leading slash but not "//" (which
+  // is protocol-relative and would redirect off-site). Blocks open-redirect.
+  const nextParam = params.get("next") ?? "/";
+  const next = nextParam.startsWith("/") && !nextParam.startsWith("//") ? nextParam : "/";
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);

--- a/web/src/cube/registry.tsx
+++ b/web/src/cube/registry.tsx
@@ -270,8 +270,10 @@ function DownloadView({ attrs, data }: ComponentViewProps) {
   const a = attrs as { file?: string; external?: unknown; raw?: string; title?: string };
   const d = (data ?? {}) as Partial<DownloadData>;
   const label = a.title ?? a.file ?? "file";
+  // Only http(s) mirror URLs: `external` is a page-authored json attribute, so
+  // an unfiltered href here would allow javascript:/data: XSS in an <a>.
   const external = (Array.isArray(a.external) ? a.external : []).filter(
-    (u): u is string => typeof u === "string" && u !== "",
+    (u): u is string => typeof u === "string" && /^https?:\/\//i.test(u),
   );
 
   return (


### PR DESCRIPTION
Filters the Download component's external mirror URLs to http(s) only, so a page-authored javascript: or data: URL can no longer run script through the infobox link (stored XSS).

Also restricts the login next parameter to same-site relative paths, which blocks an open redirect, and returns 404 instead of a 500 when a title has malformed percent-encoding.