### PR TITLE
Harden cube wiki admin scripts

### DIFF
--- a/web/scripts/create-user.mts
+++ b/web/scripts/create-user.mts
@@ -1,12 +1,35 @@
 // Create a local cube wiki account:
-//   npx tsx web/scripts/create-user.mts <name> <password> [role,...]
+//   CUBE_PASSWORD=... npx tsx web/scripts/create-user.mts <name> [role,...]
+// The password comes from $CUBE_PASSWORD (or an stdin prompt) so it never lands
+// in the process table (ps) or shell history the way an argv password would.
 
+import { createInterface } from "node:readline/promises";
 import pg from "pg";
 import { createUser } from "cube";
 
-const [name, password, roles] = process.argv.slice(2);
-if (!name || !password) {
-  console.error("usage: create-user.mts <name> <password> [role,...]");
+const [name, roles] = process.argv.slice(2);
+if (!name) {
+  console.error("usage: CUBE_PASSWORD=<pw> create-user.mts <name> [role,...]");
+  process.exit(2);
+}
+
+async function readPassword(): Promise<string> {
+  const fromEnv = process.env.CUBE_PASSWORD;
+  if (fromEnv) return fromEnv;
+  // Only prompt on a real terminal; a piped/closed stdin returns "" and the
+  // caller exits cleanly rather than hanging on an EOF that never resolves.
+  if (!process.stdin.isTTY) return "";
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    return await rl.question("password: ");
+  } finally {
+    rl.close();
+  }
+}
+
+const password = await readPassword();
+if (!password) {
+  console.error("a password is required (set CUBE_PASSWORD or type one at the prompt)");
   process.exit(2);
 }
 

--- a/web/scripts/import-wiki-batch.mts
+++ b/web/scripts/import-wiki-batch.mts
@@ -2,7 +2,12 @@
 // (cube/spikes/data/all-titles.tsv format: ns_id TAB title-with-prefix).
 // Converts each page via the HP mapping; when conversion fails the raw
 // wikitext is stored with wikitextFallback. Failures append to
-// web/.wiki-import-failures.log (title TAB error); resume with --offset.
+// web/.wiki-import-failures.log (title TAB error). To resume after an
+// interruption, re-run from the ORIGINAL --offset: imports are idempotent by
+// revision id, so already-done pages are cheap no-ops. With --concurrency > 1
+// the in-progress `done` counter is not a contiguous prefix, so do not use it
+// as a resume point (the "next --offset" hint below is only exact on a clean
+// finish).
 //
 //   npx tsx web/scripts/import-wiki-batch.mts --titles cube/spikes/data/all-titles.tsv \
 //     [--limit N] [--concurrency 3] [--offset N] [--ns 0]


### PR DESCRIPTION
create-user now reads the password from CUBE_PASSWORD or an interactive prompt instead of a command-line argument, so it no longer leaks into the process table or shell history.

Also documents that batch-import resume should use the original --offset, since imports are idempotent by revision id and the live progress counter is not a safe resume point under concurrency.