### PR TITLE
Physical photo labels and thumbnails

### DIFF
--- a/web/db/migrations/011-media-label.sql
+++ b/web/db/migrations/011-media-label.sql
@@ -1,0 +1,11 @@
+-- Physical-media photos get a label: front, back, or other. Nullable —
+-- non-physical kinds and photos uploaded before this migration stay NULL
+-- (the UI shows those as "other"). The OG card prefers label='front'.
+--
+-- Additive only: build_media is PROD-ONLY USER DATA (see 006-user-media.sql).
+--
+-- Idempotent, safe to re-run. Apply to every prism DB:
+--   psql -d <db> -f db/migrations/011-media-label.sql
+
+ALTER TABLE build_media ADD COLUMN IF NOT EXISTS label TEXT
+    CHECK (label IN ('front','back','other'));

--- a/web/db/schema.sql
+++ b/web/db/schema.sql
@@ -227,6 +227,7 @@ CREATE TABLE build_media (
     content_type  TEXT NOT NULL,          -- sniffed server-side, not the client's claim
     size          BIGINT NOT NULL,
     author        TEXT NOT NULL,          -- wiki username
+    label         TEXT CHECK (label IN ('front','back','other')),  -- physical photos only; NULL elsewhere
     created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE (build_sha256, kind, sha256)
 );

--- a/web/src/app/api/build/[sha256]/media/[id]/route.ts
+++ b/web/src/app/api/build/[sha256]/media/[id]/route.ts
@@ -1,36 +1,86 @@
 import type { NextRequest } from "next/server";
-import { getContributor, contributionTarget, revalidateBuildPages } from "@/lib/contrib";
+import {
+  getContributor,
+  contributionTarget,
+  revalidateBuildPages,
+  type ContributionTarget,
+  type Contributor,
+} from "@/lib/contrib";
 import { getPool } from "@/lib/db";
-import { deleteMedia, getMediaById } from "@/lib/media";
+import { deleteMedia, getMediaById, isMediaLabel, mediaView, updateMediaLabel, type BuildMediaRow } from "@/lib/media";
 import { isSha256 } from "@/lib/validate";
+import type { Pool } from "pg";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+// Shared gate for both verbs: the entry must exist and the caller must be its
+// uploader or a moderator.
+async function requireOwnMedia(
+  request: NextRequest,
+  sha256: string,
+  id: string
+): Promise<
+  | { ok: true; pool: Pool; target: ContributionTarget; contributor: Contributor; row: BuildMediaRow }
+  | { ok: false; response: Response }
+> {
+  const fail = (status: number, error: string) => ({
+    ok: false as const,
+    response: Response.json({ error }, { status }),
+  });
+  if (!isSha256(sha256)) return fail(400, "invalid sha256");
+  const mediaId = Number(id);
+  if (!Number.isInteger(mediaId) || mediaId <= 0) return fail(400, "invalid id");
+
+  const contributor = await getContributor(request);
+  if (!contributor) return fail(401, "log in to the wiki first");
+  const pool = getPool();
+  const target = await contributionTarget(pool, sha256);
+  if (!target) return fail(404, "not found");
+
+  const row = await getMediaById(pool, sha256, mediaId);
+  if (!row) return fail(404, "not found");
+  if (row.author !== contributor.name && !contributor.moderator) {
+    return fail(403, "only the uploader or a moderator can change this");
+  }
+  return { ok: true, pool, target, contributor, row };
+}
+
+// PATCH /api/build/<sha256>/media/<id> { label }: relabel one physical photo
+// (front/back/other), by its own author or a moderator.
+export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha256: string; id: string }> }) {
+  const { sha256, id } = await ctx.params;
+  const gate = await requireOwnMedia(request, sha256, id);
+  if (!gate.ok) return gate.response;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  if (!isMediaLabel(body.label)) {
+    return Response.json({ error: "label must be front, back, or other" }, { status: 400 });
+  }
+  if (gate.row.kind !== "physical") {
+    return Response.json({ error: "only physical photos take a label" }, { status: 400 });
+  }
+
+  const row = await updateMediaLabel(gate.pool, sha256, gate.row.id, body.label);
+  if (!row) return Response.json({ error: "not found" }, { status: 404 });
+  revalidateBuildPages(sha256, gate.target.name);
+  return Response.json({ media: mediaView(row) });
+}
 
 // DELETE /api/build/<sha256>/media/<id>: remove one media entry, by its own
 // author or a moderator. The blob stays in the store (content-addressed and
 // possibly shared); only the record goes.
 export async function DELETE(request: NextRequest, ctx: { params: Promise<{ sha256: string; id: string }> }) {
   const { sha256, id } = await ctx.params;
-  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
-  const mediaId = Number(id);
-  if (!Number.isInteger(mediaId) || mediaId <= 0) {
-    return Response.json({ error: "invalid id" }, { status: 400 });
-  }
+  const gate = await requireOwnMedia(request, sha256, id);
+  if (!gate.ok) return gate.response;
 
-  const contributor = await getContributor(request);
-  if (!contributor) return Response.json({ error: "log in to the wiki first" }, { status: 401 });
-  const pool = getPool();
-  const target = await contributionTarget(pool, sha256);
-  if (!target) return Response.json({ error: "not found" }, { status: 404 });
-
-  const row = await getMediaById(pool, sha256, mediaId);
-  if (!row) return Response.json({ error: "not found" }, { status: 404 });
-  if (row.author !== contributor.name && !contributor.moderator) {
-    return Response.json({ error: "only the uploader or a moderator can remove this" }, { status: 403 });
-  }
-
-  await deleteMedia(pool, sha256, mediaId);
-  revalidateBuildPages(sha256, target.name);
+  await deleteMedia(gate.pool, sha256, gate.row.id);
+  revalidateBuildPages(sha256, gate.target.name);
   return Response.json({ deleted: true });
 }

--- a/web/src/app/api/build/[sha256]/media/upload/[token]/route.ts
+++ b/web/src/app/api/build/[sha256]/media/upload/[token]/route.ts
@@ -8,6 +8,7 @@ import {
   MEDIA_NS,
   dropMediaSession,
   hashFile,
+  inferMediaLabel,
   insertMedia,
   isMediaToken,
   mediaStagingPath,
@@ -143,6 +144,7 @@ export async function PUT(
     content_type: session.contentType,
     size: session.size,
     author: session.author,
+    label: session.kind === "physical" ? (session.label ?? inferMediaLabel(session.filename)) : null,
   });
   revalidateBuildPages(sha256, target.name);
   return Response.json({ done: true, media: mediaView(row) });

--- a/web/src/app/api/build/[sha256]/media/upload/route.ts
+++ b/web/src/app/api/build/[sha256]/media/upload/route.ts
@@ -4,6 +4,7 @@ import { requireContributor } from "@/lib/contrib";
 import {
   createMediaSession,
   isMediaKind,
+  isMediaLabel,
   kindMaxBytes,
   MAX_FILENAME_LEN,
   newMediaToken,
@@ -19,9 +20,10 @@ export const dynamic = "force-dynamic";
 const CREATE_LIMIT = 60;
 const CREATE_WINDOW_MS = 3600_000;
 
-// POST /api/build/<sha256>/media/upload { kind, filename, size }: open a
-// chunked upload session for one media file, for any logged-in wiki user who
-// can see the build. Returns { token }; the client PUTs chunks to
+// POST /api/build/<sha256>/media/upload { kind, filename, size, label? }:
+// open a chunked upload session for one media file, for any logged-in wiki
+// user who can see the build. label (front/back/other) applies to physical
+// photos only and defaults to other. Returns { token }; the client PUTs chunks to
 // ./upload/<token>?offset=N until the claimed size is reached, at which point
 // the server sniffs, stores, and records the file (see the token route).
 export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
@@ -51,6 +53,16 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
   if (!isMediaKind(kind)) {
     return Response.json({ error: "kind must be screenshot, video, or physical" }, { status: 400 });
   }
+  let label;
+  if (body.label !== undefined) {
+    if (kind !== "physical") {
+      return Response.json({ error: "only physical photos take a label" }, { status: 400 });
+    }
+    if (!isMediaLabel(body.label)) {
+      return Response.json({ error: "label must be front, back, or other" }, { status: 400 });
+    }
+    label = body.label;
+  }
   const size = body.size;
   if (typeof size !== "number" || !Number.isInteger(size) || size <= 0) {
     return Response.json({ error: "size must be a positive integer" }, { status: 400 });
@@ -71,6 +83,6 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
       .slice(0, MAX_FILENAME_LEN) || "upload";
 
   const token = newMediaToken();
-  await createMediaSession(token, { build: sha256, kind, filename, size, author: contributor.name });
+  await createMediaSession(token, { build: sha256, kind, filename, size, author: contributor.name, label });
   return Response.json({ token });
 }

--- a/web/src/app/api/media/[sha256]/thumb/route.ts
+++ b/web/src/app/api/media/[sha256]/thumb/route.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import type { NextRequest } from "next/server";
+import { getPool } from "@/lib/db";
+import { ensurePhotoScale, isPhotoScaleWidth } from "@/lib/ffmpeg";
+import { IMMUTABLE_CACHE, SANDBOX_CSP, streamResponse } from "@/lib/http";
+import { MEDIA_NS, mediaContentType, mediaUrl } from "@/lib/media";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// GET /api/media/<sha256>/thumb?w=<500|1000> — a scaled-down JPEG (default
+// ≤1000px wide) of one image media blob, from the same ffmpeg cache the OG
+// card draws on. Camera photos and scans run to many MB; inline previews
+// shouldn't. Content-addressed, so responses cache hard.
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+  const wParam = request.nextUrl.searchParams.get("w");
+  const width = wParam === null ? 1000 : Number(wParam);
+  if (!isPhotoScaleWidth(width)) return Response.json({ error: "w must be 500 or 1000" }, { status: 400 });
+
+  const contentType = await mediaContentType(getPool(), sha256);
+  if (!contentType) return Response.json({ error: "not found" }, { status: 404 });
+  if (!contentType.startsWith("image/")) {
+    return Response.json({ error: `no thumbnail for ${contentType}` }, { status: 415 });
+  }
+
+  // The browser already holds an immutable copy: never re-send the bytes.
+  const etag = `"${sha256}-photothumb-${width}"`;
+  if (request.headers.get("if-none-match") === etag) {
+    return new Response(null, {
+      status: 304,
+      headers: { "Cache-Control": IMMUTABLE_CACHE, ETag: etag },
+    });
+  }
+
+  let scaled: string;
+  try {
+    scaled = await ensurePhotoScale(sha256, MEDIA_NS, width);
+  } catch {
+    // No usable ffmpeg or undecodable bytes — the original still renders.
+    return Response.redirect(new URL(mediaUrl(sha256, contentType), request.url), 307);
+  }
+  const stat = await fsp.stat(scaled);
+  const stream = fs.createReadStream(scaled);
+  return streamResponse(stream, stat.size, null, {
+    "Content-Type": "image/jpeg",
+    "Cache-Control": IMMUTABLE_CACHE,
+    ETag: etag,
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": SANDBOX_CSP,
+  });
+}

--- a/web/src/app/builds/[buildId]/MediaSection.tsx
+++ b/web/src/app/builds/[buildId]/MediaSection.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import type { BuildMediaView, MediaKind, SkipFlags } from "@/lib/media";
+import type { BuildMediaView, MediaKind, MediaLabel, SkipFlags } from "@/lib/media";
 
 interface Viewer {
   name?: string;
@@ -133,6 +133,21 @@ export default function MediaSection({ sha256, items, skips }: Props) {
     router.refresh();
   }
 
+  async function relabel(id: number, label: MediaLabel) {
+    setNote("");
+    const res = await fetch(`/api/build/${sha256}/media/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ label }),
+    });
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      setNote(`Error: ${j.error ?? res.statusText}`);
+      return;
+    }
+    router.refresh();
+  }
+
   const total = items.length;
   return (
     <section className="mt-8">
@@ -185,15 +200,23 @@ export default function MediaSection({ sha256, items, skips }: Props) {
                   {mine.map((m) => (
                     <figure key={m.id}>
                       <a href={m.url} target="_blank" rel="noreferrer">
+                        {/* Physical photos are multi-MB scans; draw the cell from the
+                            server-scaled thumb (2x the cell, lanczos) instead of making
+                            the browser downsample the original. */}
                         {/* eslint-disable-next-line @next/next/no-img-element */}
                         <img
-                          src={m.url}
+                          src={s.kind === "physical" ? `/api/media/${m.sha256}/thumb?w=500` : m.url}
                           alt={m.filename}
                           loading="lazy"
-                          className="h-36 w-full rounded-md border border-neutral-200 object-cover dark:border-neutral-800"
+                          className={`${s.kind === "physical" ? "aspect-square" : "h-36"} w-full rounded-md border border-neutral-200 object-cover dark:border-neutral-800`}
                         />
                       </a>
-                      <Caption item={m} viewer={viewer} onDelete={() => remove(m.id)} />
+                      <Caption
+                        item={m}
+                        viewer={viewer}
+                        onDelete={() => remove(m.id)}
+                        onLabel={s.kind === "physical" ? (label) => relabel(m.id, label) : undefined}
+                      />
                     </figure>
                   ))}
                 </div>
@@ -267,23 +290,52 @@ function AddButton({
   );
 }
 
+// Options hardcoded (not imported from lib/media, whose value exports drag
+// node builtins into the client bundle). Kept in sync with MEDIA_LABELS.
+const LABELS: Array<{ value: MediaLabel; text: string }> = [
+  { value: "front", text: "Front" },
+  { value: "back", text: "Back" },
+  { value: "other", text: "Other" },
+];
+
 function Caption({
   item,
   viewer,
   onDelete,
+  onLabel,
 }: {
   item: BuildMediaView;
   viewer: Viewer | null;
   onDelete: () => void;
+  /** Physical photos only: change the front/back/other label. */
+  onLabel?: (label: MediaLabel) => void;
 }) {
-  const canDelete = !!viewer && (viewer.moderator || (!!viewer.name && viewer.name === item.author));
+  const canEdit = !!viewer && (viewer.moderator || (!!viewer.name && viewer.name === item.author));
+  const label = item.label ?? "other";
   return (
     <figcaption className="mt-1 flex items-baseline gap-2 text-xs text-neutral-500">
+      {onLabel &&
+        (canEdit ? (
+          <select
+            value={label}
+            onChange={(e) => onLabel(e.target.value as MediaLabel)}
+            title="What the photo shows"
+            className="shrink-0 rounded border border-neutral-200 bg-transparent px-1 dark:border-neutral-800"
+          >
+            {LABELS.map((l) => (
+              <option key={l.value} value={l.value}>
+                {l.text}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span className="shrink-0">{LABELS.find((l) => l.value === label)?.text}</span>
+        ))}
       <span className="min-w-0 truncate" title={item.filename}>
         {item.author}
       </span>
       <span className="shrink-0 text-neutral-400">{item.created_at.slice(0, 10)}</span>
-      {canDelete && (
+      {canEdit && (
         <button onClick={onDelete} title="Remove" className="shrink-0 text-neutral-400 hover:text-red-500">
           ×
         </button>

--- a/web/src/app/builds/[buildId]/opengraph-image.tsx
+++ b/web/src/app/builds/[buildId]/opengraph-image.tsx
@@ -2,14 +2,18 @@
 // satori via next/og. Next's file convention wires it into <meta> for this
 // segment and everything below it, so asset deep links inherit it too.
 //
-// Dark info card: wordmark, title, fact chips, short id — plus a screenshot
-// pane when the build has a PNG/JPEG/BMP/TGA/TIFF asset whose bytes are in the
-// blob store (largest first: big files are screenshots, tiny ones are icons/textures).
+// Dark info card: wordmark, title, fact chips, short id — plus an image pane.
+// A physical-media photo labeled "front" wins (first by upload order); without
+// one the pane shows a PNG/JPEG/BMP/TGA/TIFF asset whose bytes are in the blob
+// store (largest first: big files are screenshots, tiny ones are icons/textures).
 
+import fsp from "node:fs/promises";
 import { ImageResponse } from "next/og";
 import { readBlob } from "@/lib/blobstore";
 import { getPool } from "@/lib/db";
+import { ensurePhotoScale } from "@/lib/ffmpeg";
 import { pngConvertible, toPng } from "@/lib/imgpng";
+import { MEDIA_NS } from "@/lib/media";
 import { buildFacts, displayTitle } from "@/lib/meta";
 import { getBuildMeta, resolveBuild, type BuildMetaRow } from "@/lib/queries";
 import { parseBuildParam, SHORT_SHA_LEN } from "@/lib/slug";
@@ -21,6 +25,42 @@ export const contentType = "image/png";
 
 // Satori decodes the screenshot in-process — skip pathological blobs.
 const MAX_SHOT_BYTES = 8_000_000;
+
+// Photos over this go through the cached ffmpeg downscale instead of being
+// inlined whole — camera shots and scans routinely blow past what's worth
+// pushing through satori for a 480px pane.
+const PHOTO_DIRECT_MAX_BYTES = 1_000_000;
+
+// The first front-labeled photo in upload order, else the first physical
+// photo of any label — a contributed photo identifies the build better than
+// the largest-asset heuristic, and far better than an imageless card.
+// Oversized photos (and webp, which the card renderer can't decode) are
+// served as scaled JPEGs via ffmpeg; a candidate that can't be served falls
+// through to the next, then to findScreenshot.
+async function findFrontPhoto(sha256: string): Promise<string | null> {
+  const r = await getPool().query(
+    `SELECT sha256, content_type, size::float8 AS size FROM build_media
+     WHERE build_sha256=$1 AND kind='physical'
+       AND content_type IN ('image/png','image/jpeg','image/gif','image/webp')
+     ORDER BY (label IS NOT DISTINCT FROM 'front') DESC, created_at, id LIMIT 4`,
+    [sha256]
+  );
+  for (const row of r.rows as Array<{ sha256: string; content_type: string; size: number }>) {
+    try {
+      if (row.size > PHOTO_DIRECT_MAX_BYTES || row.content_type === "image/webp") {
+        const scaled = await ensurePhotoScale(row.sha256, MEDIA_NS);
+        const bytes = await fsp.readFile(scaled);
+        return `data:image/jpeg;base64,${bytes.toString("base64")}`;
+      }
+      const bytes = await readBlob(row.sha256, MEDIA_NS);
+      if (bytes === null) continue;
+      return `data:${row.content_type};base64,${bytes.toString("base64")}`;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
 
 async function findScreenshot(sha256: string): Promise<string | null> {
   const r = await getPool().query(
@@ -123,7 +163,7 @@ function Card({ meta, shot }: { meta: BuildMetaRow; shot: string | null }) {
           <img
             src={shot}
             alt=""
-            style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }}
+            style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain", borderRadius: 12 }}
           />
         </div>
       )}
@@ -150,7 +190,7 @@ export default async function OgImage({ params }: { params: Promise<{ buildId: s
   const meta = resolved && (await getBuildMeta(pool, resolved.sha256));
   if (!meta) return new Response("not found", { status: 404 });
 
-  const shot = await findScreenshot(meta.sha256);
+  const shot = (await findFrontPhoto(meta.sha256)) ?? (await findScreenshot(meta.sha256));
   try {
     return await render(meta, shot);
   } catch {

--- a/web/src/app/builds/[buildId]/page.tsx
+++ b/web/src/app/builds/[buildId]/page.tsx
@@ -167,6 +167,12 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
   const filteredContentHash = build.record.composites?.filtered_content_hash;
   const discTitle = build.record.info?.title as string | undefined;
 
+  // Small identity shot beside the hashes: the front physical photo when one
+  // is labeled, else the first physical photo (same order the gallery uses).
+  const mediaItems = media.map(mediaView);
+  const photos = mediaItems.filter((m) => m.kind === "physical");
+  const previewPhoto = photos.find((m) => m.label === "front") ?? photos[0];
+
   return (
     <main className="mx-auto max-w-none px-4 py-10 sm:px-8">
       {/* One lightbox for the whole page (gallery + file tree); it rewrites the
@@ -174,9 +180,13 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
       <AssetViewerHost assets={assets} buildHref={href} returnHref={href}>
       <Link href="/builds" className="text-sm text-neutral-500 hover:underline">&larr; All builds</Link>
 
+      {/* Header block with the photo as a right column: flush with the title,
+          spanning title, chips, and hashes. */}
+      <div className="mt-3 flex items-start gap-10">
+      <div className="min-w-0">
       {/* The name column is the display identity everywhere (lists, search, rename);
           the disc's own title stays visible as a subtitle when it differs. */}
-      <h1 className="mt-3 text-2xl font-semibold tracking-tight">{build.name}</h1>
+      <h1 className="text-2xl font-semibold tracking-tight">{build.name}</h1>
       {discTitle && discTitle !== build.name && (
         <p className="mt-1 text-sm text-neutral-500">{discTitle}</p>
       )}
@@ -218,6 +228,18 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
           <Hash label="Filtered content hash" value={filteredContentHash} />
         )}
       </dl>
+      </div>
+      {previewPhoto && (
+        <a href={previewPhoto.url} target="_blank" rel="noreferrer" className="shrink-0" title={previewPhoto.filename}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`/api/media/${previewPhoto.sha256}/thumb?w=500`}
+            alt={previewPhoto.filename}
+            className="h-44 w-44 rounded-md border border-neutral-200 object-cover dark:border-neutral-800"
+          />
+        </a>
+      )}
+      </div>
 
       <ModeratorTools
         key={`${build.name}\0${build.lot ?? ""}\0${build.game ?? ""}\0${build.game_system ?? ""}\0${build.private}\0${lotPrivate}\0${JSON.stringify(skips)}`}
@@ -301,7 +323,7 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
         </section>
       )}
 
-      <MediaSection sha256={sha256} items={media.map(mediaView)} skips={skips} />
+      <MediaSection sha256={sha256} items={mediaItems} skips={skips} />
 
       <NotesSection sha256={sha256} notes={notes} skipped={skips.skip_notes} />
 

--- a/web/src/lib/blobstore.ts
+++ b/web/src/lib/blobstore.ts
@@ -292,10 +292,10 @@ export async function openBlobStream(
 
 /** A whole blob in memory, or null when it is missing from the store.
  *  Callers cap sizes (convert/preview paths); don't hand this a DVD image. */
-export async function readBlob(sha256: string): Promise<Buffer | null> {
+export async function readBlob(sha256: string, ns = ""): Promise<Buffer | null> {
   if (s3Enabled()) {
     try {
-      const r = await s3().send(new GetObjectCommand({ Bucket: s3Bucket(), Key: s3Key(sha256) }));
+      const r = await s3().send(new GetObjectCommand({ Bucket: s3Bucket(), Key: s3Key(sha256, ns) }));
       return Buffer.from(await r.Body!.transformToByteArray());
     } catch (err) {
       if (isMissing(err)) return null;
@@ -303,7 +303,7 @@ export async function readBlob(sha256: string): Promise<Buffer | null> {
     }
   }
   try {
-    return await fsp.readFile(assetBlobPath(sha256));
+    return await fsp.readFile(assetBlobPath(sha256, ns));
   } catch {
     return null;
   }
@@ -434,14 +434,15 @@ export async function storeBlobBytes(sha256: string, data: Uint8Array): Promise<
  *  file it can seek). Returns null when the blob is missing from the store. */
 export async function withBlobFile<T>(
   sha256: string,
-  fn: (localPath: string) => Promise<T>
+  fn: (localPath: string) => Promise<T>,
+  ns = ""
 ): Promise<T | null> {
   if (!s3Enabled()) {
-    const p = assetBlobPath(sha256);
+    const p = assetBlobPath(sha256, ns);
     if (!fs.existsSync(p)) return null;
     return fn(p);
   }
-  const stream = await openBlobStream(sha256);
+  const stream = await openBlobStream(sha256, undefined, ns);
   if (!stream) return null;
   const dir = path.join(assetStoreDir(), ".fetch");
   await fsp.mkdir(dir, { recursive: true });

--- a/web/src/lib/ffmpeg.ts
+++ b/web/src/lib/ffmpeg.ts
@@ -393,3 +393,72 @@ export async function extractStill(input: string, out: string): Promise<string> 
     await rm(tmp, { force: true });
   }
 }
+
+// One scaled photo per (blob, width) at a time, same reason as transcodes.
+const photoScalesInFlight = new Map<string, Promise<string>>();
+
+/** Widths the photo scale cache will produce: 500 for gallery/preview thumbs
+ *  (2x the largest cell they draw into), 1000 for the OG card pane. */
+export const PHOTO_SCALE_WIDTHS = [500, 1000] as const;
+export type PhotoScaleWidth = (typeof PHOTO_SCALE_WIDTHS)[number];
+
+export function isPhotoScaleWidth(v: number): v is PhotoScaleWidth {
+  return (PHOTO_SCALE_WIDTHS as readonly number[]).includes(v);
+}
+
+export function photoScalePath(sha256: string, width: PhotoScaleWidth): string {
+  return join(assetStoreDir(), ".thumb", `${sha256}.photo-${width}.jpg`);
+}
+
+/**
+ * A cached scaled-down JPEG (≤`width`px wide) of a stored photo, produced on
+ * first use. The OG card inlines photos and satori decodes them in-process,
+ * and the browser makes jaggies of a 3000px scan crammed into a 200px cell —
+ * multi-MB camera shots get shrunk once, out of process, with a real
+ * resampler here. Throws when ffmpeg is missing, the blob is absent, or the
+ * bytes don't decode.
+ */
+export async function ensurePhotoScale(sha256: string, ns = "", width: PhotoScaleWidth = 1000): Promise<string> {
+  const out = photoScalePath(sha256, width);
+  if (await nonEmpty(out)) return out;
+  const key = `${sha256}:${width}`;
+  let job = photoScalesInFlight.get(key);
+  if (!job) {
+    job = scalePhoto(sha256, ns, out, width).finally(() => photoScalesInFlight.delete(key));
+    photoScalesInFlight.set(key, job);
+  }
+  return job;
+}
+
+async function scalePhoto(sha256: string, ns: string, out: string, width: PhotoScaleWidth): Promise<string> {
+  const result = await withBlobFile(sha256, (input) => scaleStill(input, out, width), ns);
+  if (result === null) throw new Error("blob missing from store");
+  return result;
+}
+
+/** Re-encode a local image as a JPEG capped at `width`px wide (never
+ *  upscaled; animations contribute their first frame) into `out`. Lanczos
+ *  resampling: these are photos headed for thumbnails, sharpness wins. */
+async function scaleStill(input: string, out: string, width: PhotoScaleWidth): Promise<string> {
+  await mkdir(dirname(out), { recursive: true });
+  const tmp = `${out}.${randomBytes(4).toString("hex")}.part`;
+  try {
+    await execFileP(
+      FFMPEG_BIN,
+      [
+        "-hide_banner", "-loglevel", "error", "-y",
+        "-i", input,
+        "-frames:v", "1",
+        "-vf", `scale=trunc(min(iw\\,${width})/2)*2:-2:flags=lanczos`,
+        "-c:v", "mjpeg", "-q:v", "4", "-f", "image2",
+        tmp,
+      ],
+      { timeout: THUMB_TIMEOUT_MS, maxBuffer: 4_000_000 }
+    );
+    if ((await stat(tmp)).size === 0) throw new Error("empty scaled photo");
+    await rename(tmp, out);
+    return out;
+  } finally {
+    await rm(tmp, { force: true });
+  }
+}

--- a/web/src/lib/media.ts
+++ b/web/src/lib/media.ts
@@ -23,6 +23,24 @@ export function isMediaKind(v: unknown): v is MediaKind {
   return typeof v === "string" && (MEDIA_KINDS as readonly string[]).includes(v);
 }
 
+/** What a physical-media photo shows. NULL in the DB (pre-label uploads)
+ *  reads as "other". The OG card prefers the first 'front' photo. */
+export const MEDIA_LABELS = ["front", "back", "other"] as const;
+export type MediaLabel = (typeof MEDIA_LABELS)[number];
+
+export function isMediaLabel(v: unknown): v is MediaLabel {
+  return typeof v === "string" && (MEDIA_LABELS as readonly string[]).includes(v);
+}
+
+/** Guess a physical photo's label from its filename — uploads arrive named
+ *  "… Front.png" / "… Back.png" far more often than anyone touches the label
+ *  selector afterward. An explicit label always wins over this. */
+export function inferMediaLabel(filename: string): MediaLabel {
+  if (/(^|[^a-z])front([^a-z]|$)/i.test(filename)) return "front";
+  if (/(^|[^a-z])back([^a-z]|$)/i.test(filename)) return "back";
+  return "other";
+}
+
 /** Upload size caps. Images stay modest; videos get room for real captures. */
 export const IMAGE_MAX_BYTES = 25 * 1024 * 1024;
 export const VIDEO_MAX_BYTES = 512 * 1024 * 1024;
@@ -87,6 +105,8 @@ export interface MediaSession {
   filename: string;
   size: number;
   author: string;
+  /** Physical photos only. */
+  label?: MediaLabel;
   /** Sniffed at the first chunk; absent until then. */
   contentType?: string;
 }
@@ -170,6 +190,8 @@ export interface BuildMediaRow {
   content_type: string;
   size: number;
   author: string;
+  /** Physical photos only; NULL rows predate labels and read as "other". */
+  label: MediaLabel | null;
   created_at: string;
 }
 
@@ -211,7 +233,7 @@ export const NO_SKIPS: SkipFlags = {
 };
 
 const MEDIA_COLS =
-  "id::int AS id, build_sha256, kind, sha256, poster_sha256, filename, content_type, size::float8 AS size, author, created_at::text AS created_at";
+  "id::int AS id, build_sha256, kind, sha256, poster_sha256, filename, content_type, size::float8 AS size, author, label, created_at::text AS created_at";
 
 const NOTE_COLS = "id::int AS id, build_sha256, body, author, created_at::text AS created_at, edited_at::text AS edited_at";
 
@@ -244,14 +266,15 @@ export async function insertMedia(
     content_type: string;
     size: number;
     author: string;
+    label: MediaLabel | null;
   }
 ): Promise<BuildMediaRow> {
   const r = await pool.query(
-    `INSERT INTO build_media (build_sha256, kind, sha256, poster_sha256, filename, content_type, size, author)
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+    `INSERT INTO build_media (build_sha256, kind, sha256, poster_sha256, filename, content_type, size, author, label)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
      ON CONFLICT (build_sha256, kind, sha256) DO NOTHING
      RETURNING ${MEDIA_COLS}`,
-    [m.build_sha256, m.kind, m.sha256, m.poster_sha256, m.filename, m.content_type, m.size, m.author]
+    [m.build_sha256, m.kind, m.sha256, m.poster_sha256, m.filename, m.content_type, m.size, m.author, m.label]
   );
   if (r.rows[0]) return r.rows[0] as BuildMediaRow;
   const existing = await pool.query(
@@ -259,6 +282,21 @@ export async function insertMedia(
     [m.build_sha256, m.kind, m.sha256]
   );
   return existing.rows[0] as BuildMediaRow;
+}
+
+/** Relabel one physical photo; returns the updated row, or null when the id
+ *  is missing or not a physical photo. */
+export async function updateMediaLabel(
+  pool: Pool,
+  buildSha: string,
+  id: number,
+  label: MediaLabel
+): Promise<BuildMediaRow | null> {
+  const r = await pool.query(
+    `UPDATE build_media SET label=$3 WHERE build_sha256=$1 AND id=$2 AND kind='physical' RETURNING ${MEDIA_COLS}`,
+    [buildSha, id, label]
+  );
+  return (r.rows[0] as BuildMediaRow) ?? null;
 }
 
 export async function deleteMedia(pool: Pool, buildSha: string, id: number): Promise<boolean> {

--- a/web/tests/media.test.ts
+++ b/web/tests/media.test.ts
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { inferMediaLabel, isMediaKind, isMediaLabel, sniffMedia } from "../src/lib/media";
+
+test("inferMediaLabel reads the front/back convention out of filenames", () => {
+  assert.equal(inferMediaLabel("Earthworm Jim Front.png"), "front");
+  assert.equal(inferMediaLabel("Earthworm Jim Sega Genesis ROM Image Back.png"), "back");
+  assert.equal(inferMediaLabel("front.jpg"), "front");
+  assert.equal(inferMediaLabel("FRONT COVER.png"), "front");
+  assert.equal(inferMediaLabel("disc_front_scan.png"), "front");
+  assert.equal(inferMediaLabel("back-of-case.jpg"), "back");
+});
+
+test("inferMediaLabel does not fire inside larger words", () => {
+  assert.equal(inferMediaLabel("backyard.png"), "other");
+  assert.equal(inferMediaLabel("frontier-demo.png"), "other");
+  assert.equal(inferMediaLabel("IMG_2041.jpg"), "other");
+});
+
+test("inferMediaLabel prefers front when a name carries both words", () => {
+  assert.equal(inferMediaLabel("front and back.png"), "front");
+});
+
+test("media kind and label guards accept only known values", () => {
+  assert.equal(isMediaKind("physical"), true);
+  assert.equal(isMediaKind("photo"), false);
+  assert.equal(isMediaLabel("front"), true);
+  assert.equal(isMediaLabel("side"), false);
+  assert.equal(isMediaLabel(null), false);
+});
+
+test("sniffMedia identifies the accepted containers by magic bytes", () => {
+  const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0]);
+  assert.deepEqual(sniffMedia(png), { contentType: "image/png", video: false });
+  const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  assert.deepEqual(sniffMedia(jpeg), { contentType: "image/jpeg", video: false });
+  assert.equal(sniffMedia(Buffer.from("not an image at all!")), null);
+});


### PR DESCRIPTION
Physical media photos get a front, back, or other label (nullable column via migration 011). Uploads infer the label from the usual "... Front.png" filenames, the uploader or a moderator can change it from the gallery, and the gallery cells are now square.

The build OG card prefers the first front photo over the extracted screenshot, and the page header shows the photo beside the title and hashes. Both draw from a new /api/media/[sha]/thumb route that caches ffmpeg lanczos downscales at 500px and 1000px, so browsers stop resampling multi-MB scans. Already deployed to hpwiki with the migration applied.