### PR TITLE
Remove external site references from cube tests

### DIFF
--- a/cube/tests/import-extract.test.ts
+++ b/cube/tests/import-extract.test.ts
@@ -32,7 +32,7 @@ function findByName(
 test("sonic fixture: transclusions, extensions, categories", { skip: !HAVE_FIXTURES && "parsoid fixtures not present" }, () => {
   const result = extractHtml(loadFixtureHtml("sonic2_nick_arcade"));
 
-  // Prototype, Download, Tcrf link, filelist, Prototype Footer.
+  // Prototype, Download, an external-wiki link, filelist, Prototype Footer.
   assert.equal(result.transclusions.length, 5);
 
   const proto = findByName(result, "Prototype");

--- a/cube/tests/render.test.ts
+++ b/cube/tests/render.test.ts
@@ -59,16 +59,16 @@ test("markdown basics render", async () => {
 
 test("wiki links: existing, red, labeled, interwiki", async () => {
   const { html } = await render(
-    "See [[Existing Page]] and [[Missing|the missing one]] and [[tcrf:Proto:Sonic 2]].\n",
+    "See [[Existing Page]] and [[Missing|the missing one]] and [[example:Proto:Sonic 2]].\n",
     {
-      interwiki: { tcrf: "https://tcrf.net/$1" },
+      interwiki: { example: "https://example.org/$1" },
       resolveLinks: async (refs) =>
         new Map(refs.map((r) => [`${r.ns}:${r.slug}`, r.slug === "Existing_Page"])),
     },
   );
   assert.match(html, /<a href="\/Existing_Page">Existing Page<\/a>/);
   assert.match(html, /<a href="\/Missing" className="cube-redlink">the missing one<\/a>/);
-  assert.match(html, /<a href="https:\/\/tcrf\.net\/Proto:Sonic_2" className="cube-interwiki">/);
+  assert.match(html, /<a href="https:\/\/example\.org\/Proto:Sonic_2" className="cube-interwiki">/);
 });
 
 test("raw html renders escaped as text, not elements", async () => {


### PR DESCRIPTION
Two cube test files still named an external wiki site, one in a comment listing the fixture's templates and one in the interwiki round-trip test. These predate the current branch work and were left out of the PR #121 review fixes to keep that diff in scope.

The interwiki test now uses a neutral example prefix (example maps to https://example.org/$1) across the markdown input, the config, and the asserted href, so prefix lookup, placeholder substitution, and slugging stay covered exactly as before. Full cube suite passes (197 pass, 4 fixture-gated skips) and tsc --noEmit is clean.