### PR TITLE
Run the app as two slots behind nginx

### DIFF
--- a/.github/workflows/deploy-hpwiki.yml
+++ b/.github/workflows/deploy-hpwiki.yml
@@ -31,8 +31,6 @@ jobs:
     env:
       APP: /home/thedrx/curator-web
       PORT: "6800"
-      SESSION: deploy
-      BOT_SESSION: bot
 
     steps:
       - uses: actions/checkout@v4
@@ -67,89 +65,63 @@ jobs:
       # source, plus the exact node_modules npm installed here. Syncing the
       # modules is what keeps the app dir from drifting into a hand-curated
       # state. .env.local and asset-store are the server's own and must never
-      # be deleted (see the never-wipe rules in the deploy skill).
+      # be deleted (see the never-wipe rules in the deploy skill). .next-* are
+      # the slots' build directories and belong to the box.
+      #
+      # node_modules lands additively here: both slots are still serving the
+      # OLD build and can still lazily require a file that this install would
+      # have deleted. The prune pass runs after the swap, once nothing is
+      # running the old code.
       - name: sync tree into the app dir
         run: |
           rsync -a --delete \
-            --exclude node_modules --exclude .next --exclude .git \
+            --exclude node_modules --exclude '.next*' --exclude .git \
             --exclude tsconfig.tsbuildinfo --exclude .env.local \
             --exclude asset-store \
             hp-web/ "$APP"/
+          rsync -a --exclude /cube node_modules/ "$APP"/node_modules/
+          rsync -a --exclude node_modules cube/ "$APP"/node_modules/cube/
+
+      # The swap itself: build into .next-stage while both slots keep serving
+      # their own build directory, then move them onto it one at a time,
+      # checking each is answering (including a real database round trip)
+      # before the other is touched. A slot that will not come up goes back on
+      # its previous build and the deploy stops there, with the other slot
+      # still serving. The site does not go down for any of this.
+      #
+      # The procedure lives in the app tree (hp-web/deploy/slots.sh), shared
+      # with the manual deploy and the watchdog cron, and holds a lock so no
+      # two of them can restart the same slot at once.
+      - name: build and roll the slots
+        run: |
+          "$APP/deploy/slots.sh" deploy
+          echo "BUILD_ID=$(cat "$APP/.next-stage/BUILD_ID")" >> "$GITHUB_ENV"
+
+      # Now that no process is running the old build, drop whatever this
+      # install removed from node_modules.
+      - name: prune node_modules
+        run: |
           rsync -a --delete --exclude /cube node_modules/ "$APP"/node_modules/
           rsync -a --delete --exclude node_modules cube/ "$APP"/node_modules/cube/
 
-      - name: build, restart, verify
-        run: |
-          set -euo pipefail
-
-          start_app() {
-            tmux kill-session -t "$SESSION" 2>/dev/null || true
-            tmux new-session -d -s "$SESSION"
-            tmux send-keys -t "$SESSION" \
-              "export PATH=\$HOME/node22/bin:\$PATH; cd $APP; npx next start -p $PORT 2>&1 | tee ~/server.log" C-m
-            # if/fi rather than `grep && break`: a failing && compound under
-            # set -e would abort the script on the first not-yet-bound poll.
-            for _ in $(seq 1 15); do
-              if ss -ltn | grep -q ":$PORT"; then break; fi
-              sleep 1
-            done
-          }
-
-          verify() {
-            ss -ltn | grep -q ":$PORT" || return 1
-            # / alone can answer 200 with Postgres down, /builds cannot.
-            for path in / /builds; do
-              code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:$PORT$path")
-              echo "  GET $path -> $code"
-              [ "$code" = 200 ] || return 1
-            done
-          }
-
-          # Hardlink copy, so keeping a rollback build costs no disk. The
-          # source tree is already the new code at this point, so a rollback
-          # leaves the tree ahead of the running build until the next green
-          # deploy. That is deliberate: serving beats matching.
-          rm -rf "$APP/.next.prev"
-          if [ -d "$APP/.next" ]; then cp -al "$APP/.next" "$APP/.next.prev"; fi
-
-          rollback() {
-            echo "::error::deploy failed, restoring the previous build"
-            rm -rf "$APP/.next"
-            if [ -d "$APP/.next.prev" ]; then mv "$APP/.next.prev" "$APP/.next"; fi
-            start_app
-            verify || echo "::error::rollback did not come up cleanly, check ~/server.log"
-            exit 1
-          }
-          trap rollback ERR
-
-          # next build rewrites .next, so the server has to be down for it.
-          # This is the only window where the site is unavailable (seconds).
-          tmux kill-session -t "$SESSION" 2>/dev/null || true
-          ( cd "$APP" && npm run build )
-          start_app
-          verify
-
-          trap - ERR
-          rm -rf "$APP/.next.prev"
-          echo "BUILD_ID=$(cat "$APP/.next/BUILD_ID")" >> "$GITHUB_ENV"
-
-      # The Discord bot runs the same tree, so it needs restarting too. Only
+      # The Discord bot runs the same tree, so it needs restarting too, and
+      # unlike the app it stays a single process (one gateway session). Only
       # where a DISCORD_TOKEN is configured, and a failure here does not roll
       # the site back: the app is already up and verified.
       - name: restart the discord bot
         continue-on-error: true
         run: |
+          "$APP/deploy/slots.sh" restart-bot
+
+      # End to end, through the port hiddenpalace.org actually talks to.
+      - name: verify the front door
+        run: |
           set -euo pipefail
-          grep -q '^DISCORD_TOKEN=' "$APP/.env.local" || { echo "no DISCORD_TOKEN, skipped"; exit 0; }
-          tmux kill-session -t "$BOT_SESSION" 2>/dev/null || true
-          tmux new-session -d -s "$BOT_SESSION"
-          tmux send-keys -t "$BOT_SESSION" \
-            "export PATH=\$HOME/node22/bin:\$PATH; cd $APP; npm run bot 2>&1 | tee ~/bot.log" C-m
-          for _ in $(seq 1 20); do
-            if grep -q 'logged in as' ~/bot.log 2>/dev/null; then break; fi
-            sleep 1
+          for path in /healthz / /builds; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 60 "http://localhost:$PORT$path")
+            echo "  GET $path -> $code"
+            [ "$code" = 200 ] || exit 1
           done
-          grep -m1 'logged in as' ~/bot.log || { echo "bot did not log in:"; tail -5 ~/bot.log; exit 1; }
 
       - name: summary
         if: always()

--- a/hp-web/.gitignore
+++ b/hp-web/.gitignore
@@ -15,6 +15,8 @@
 
 # next.js
 /.next/
+# the production slots' build directories (deploy/slots.sh)
+/.next-*/
 /out/
 
 # production

--- a/hp-web/deploy/nginx.conf
+++ b/hp-web/deploy/nginx.conf
@@ -1,0 +1,142 @@
+# Front door for the hp-web app on hpwiki.
+#
+# The box's root-owned nginx proxies hiddenpalace.org to :6800, so :6800 is the
+# contract and whatever holds it has to behave exactly like the `next start`
+# that used to. What this buys: the app itself now runs as two slots on :6801
+# and :6802, so a deploy rebuilds and restarts them one at a time and the site
+# never goes dark, and a slot that dies takes its own traffic out of rotation
+# instead of taking the site with it.
+#
+# Runs unprivileged, as the app's own user:
+#   nginx -p ~/proxy -c ~/curator-web/deploy/nginx.conf -e logs/error.log
+# Every path below is relative to that prefix, so nothing here needs root and
+# nothing writes outside the home directory. deploy/slots.sh runs exactly that.
+
+worker_processes 2;
+error_log logs/error.log warn;
+pid run/nginx.pid;
+
+# Raise the workers to the hard fd limit (4096 on this box; no root needed to
+# go from the 1024 soft limit up to it). Each proxied request costs two
+# descriptors, client side and slot side, so worker_connections stays under
+# half of that rather than warning at every start that it cannot honour it.
+worker_rlimit_nofile 4096;
+
+events {
+  worker_connections 1536;
+}
+
+http {
+  access_log off;     # the nginx in front of this one already logs every request
+  server_tokens off;
+  default_type text/plain;
+
+  # Unprivileged: every scratch path stays inside the prefix.
+  client_body_temp_path temp/client_body;
+  proxy_temp_path temp/proxy;
+  fastcgi_temp_path temp/fastcgi;
+  uwsgi_temp_path temp/uwsgi;
+  scgi_temp_path temp/scgi;
+
+  # No mime.types include: this server only proxies, and an upstream's
+  # Content-Type passes through untouched.
+
+  # least_conn, not round robin: a request here is anywhere between a 2ms JSON
+  # reply and a multi-minute file stream, so open connections track real load
+  # far better than request count does.
+  upstream app {
+    least_conn;
+    server 127.0.0.1:6801 max_fails=1 fail_timeout=5s;
+    server 127.0.0.1:6802 max_fails=1 fail_timeout=5s;
+    keepalive 32;
+  }
+
+  # The same two slots, but one asset always lands on the same slot while both
+  # are up. Transcodes dedupe per process (the inFlight map in lib/ffmpeg.ts),
+  # so spreading one asset's requests across slots would start ffmpeg twice on
+  # the same DVD VOB: an hour of CPU, run twice, for one file. Media upload
+  # chunks pin for the same reason, one session appending in one process.
+  upstream app_pinned {
+    hash $pin consistent;
+    server 127.0.0.1:6801 max_fails=1 fail_timeout=5s;
+    server 127.0.0.1:6802 max_fails=1 fail_timeout=5s;
+    keepalive 32;
+  }
+
+  # What to pin on: the asset sha256, or the upload token, so that every URL
+  # underneath one of them hashes alike (/video and /video/status are different
+  # URIs for the same transcode). The patterns are quoted because nginx's own
+  # parser would otherwise take the {64} braces for a block.
+  map $uri $pin {
+    default                                                   $uri;
+    "~^/api/asset/([0-9a-f]{64})"                             $1;
+    "~^/api/build/[0-9a-f]{64}/media/upload/([A-Za-z0-9_-]+)" $1;
+  }
+
+  # Keepalive to the slots needs an empty Connection header and a WebSocket
+  # upgrade needs "upgrade": this map is the one form that serves both.
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ""      "";
+  }
+
+  server {
+    # Same bind as the `next start` this replaces (all interfaces, firewalled
+    # off-box); the slots themselves listen on loopback only, so the front door
+    # is the only way in.
+    listen 6800 backlog=4096;
+    server_name _;
+
+    # The outer nginx caps request size and absorbs slow clients already. A
+    # second, lower limit here would only break 32MiB media chunk PUTs.
+    client_max_body_size 0;
+    client_body_timeout 300s;
+
+    # Pass the forwarded-for chain through EXACTLY as received. lib/ratelimit.ts
+    # counts hops from the right (TRUSTED_PROXY_HOPS, default 1), so appending
+    # our own 127.0.0.1 would shift that count by one and drop every visitor
+    # into a single shared rate-limit bucket.
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header X-Real-IP $http_x_real_ip;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_http_version 1.1;
+
+    # Stream both ways: the outer nginx is already buffering for slow clients,
+    # and this hop sits between it and Range requests for multi-GB video.
+    proxy_buffering off;
+    proxy_request_buffering off;
+
+    # A slot that is restarting refuses connections; fail over in 2s instead of
+    # sitting in a connect timeout. Reads stay generous, since some queries and
+    # file streams legitimately run for minutes.
+    proxy_connect_timeout 2s;
+    proxy_send_timeout 300s;
+    proxy_read_timeout 300s;
+
+    # The failover itself, and the reason a rolling deploy is seamless: while
+    # one slot is down its share of requests is retried on the other. nginx
+    # only retries a non-idempotent request when `non_idempotent` is listed,
+    # which it deliberately is not here: a POST that already reached a slot
+    # must never be replayed against the other one.
+    proxy_next_upstream error timeout http_502 http_503 http_504;
+    proxy_next_upstream_tries 2;
+    proxy_next_upstream_timeout 10s;
+
+    # Front-door liveness, answered without touching a slot, so the watchdog
+    # can tell "nginx is gone" from "both slots are gone".
+    location = /healthz {
+      return 200 "ok\n";
+    }
+
+    location ~ "^/api/(asset/[0-9a-f]{64}|build/[0-9a-f]{64}/media/upload)/" {
+      proxy_pass http://app_pinned;
+    }
+
+    location / {
+      proxy_pass http://app;
+    }
+  }
+}

--- a/hp-web/deploy/slots.sh
+++ b/hp-web/deploy/slots.sh
@@ -1,0 +1,493 @@
+#!/usr/bin/env bash
+# Two app slots behind one port, so the site survives both deploys and crashes.
+#
+# Layout on the box:
+#
+#   nginx  :6800          deploy/nginx.conf, unprivileged, prefix ~/proxy
+#     |- slot a  127.0.0.1:6801   .next-a   tmux app-a   ~/app-a.log
+#     '- slot b  127.0.0.1:6802   .next-b   tmux app-b   ~/app-b.log
+#
+# Both slots run the same checkout (~/curator-web) out of their own build
+# directory, and that is what makes a rolling deploy possible: `next build`
+# rewrites its dist dir in place, so a shared one would pull the ground out
+# from under a running server. (That is why the single-process deploy this
+# replaces had to stop the site to build.) A deploy here builds into
+# .next-stage while both slots keep serving, then swaps one slot at a time,
+# checking after each that it came back before touching the other.
+#
+# This script is the only thing that starts or stops an app process. The
+# self-hosted runner (.github/workflows/deploy-hpwiki.yml), the manual deploy
+# script and the watchdog cron all call it, and every mutating subcommand holds
+# ~/.hp-web-deploy.lock, so two of them can never restart the same slot at the
+# same moment.
+#
+#   slots.sh status              what is up, and which build each slot serves
+#   slots.sh build               build into .next-stage (slots keep serving)
+#   slots.sh rolling             swap both slots onto the staged build
+#   slots.sh deploy              build + rolling
+#   slots.sh restart             restart both slots on the build they have
+#   slots.sh start|stop <a|b>    one slot, as-is (no swap)
+#   slots.sh restart-bot         the Discord bot (single instance by nature)
+#   slots.sh proxy <cmd>         start|stop|reload|test the front door
+#   slots.sh boot                post-reboot bring-up: db, slots, proxy, bot
+#   slots.sh watchdog            cron: restart whatever is not answering
+#   slots.sh bootstrap           first-time cutover from the old :6800 server
+set -euo pipefail
+
+# .../curator-web/deploy/slots.sh -> the app directory is one level up.
+APP="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SELF="$APP/deploy/slots.sh"
+# node is user-local here; the sbin fallbacks are for ss and nginx, which a
+# non-interactive ssh or cron shell does not always have on PATH.
+export PATH="$HOME/node22/bin:$PATH:/usr/sbin:/sbin"
+
+SLOTS="a b"
+FRONT_PORT="${FRONT_PORT:-6800}"
+PROXY_PREFIX="${PROXY_PREFIX:-$HOME/proxy}"
+LOCK="${LOCK:-$HOME/.hp-web-deploy.lock}"
+STAGE="$APP/.next-stage"
+BOT_SESSION=bot
+# Postgres lives in a user-local data dir on this box and is not
+# reboot-persistent; overridable for a host that puts it elsewhere.
+PGPORT="${PGPORT:-5432}"
+PG_BIN="${PG_BIN:-/usr/bin}"
+PGDATA_DIR="${PGDATA_DIR:-$HOME/pgdata}"
+
+say() { printf '\n=== %s ===\n' "$*"; }
+stamp() { date -Is; }
+
+slot_port() {
+  case "$1" in
+    a) echo 6801 ;;
+    b) echo 6802 ;;
+    *) echo "unknown slot '$1' (want a or b)" >&2; return 2 ;;
+  esac
+}
+other_slot() { case "$1" in a) echo b ;; b) echo a ;; esac; }
+slot_dist() { echo "$APP/.next-$1"; }
+slot_session() { echo "app-$1"; }
+slot_log() { echo "$HOME/app-$1.log"; }
+
+# ---- process plumbing -------------------------------------------------------
+
+port_listening() { ss -ltn "sport = :$1" 2>/dev/null | grep -q LISTEN; }
+listener_pid() { ss -ltnp "sport = :$1" 2>/dev/null | grep -o 'pid=[0-9]*' | head -1 | cut -d= -f2; }
+
+wait_port_free() {
+  local port="$1" secs="${2:-15}" i
+  for ((i = 0; i < secs; i++)); do
+    port_listening "$port" || return 0
+    sleep 1
+  done
+  ! port_listening "$port"
+}
+
+# A slot is healthy when /api/health answers 200, which it only does after a
+# real round trip to Postgres. `/` alone renders fine with the database down.
+slot_healthy() {
+  local port
+  port="$(slot_port "$1")"
+  curl -fsS --max-time 10 -o /dev/null "http://127.0.0.1:$port/api/health" 2>/dev/null
+}
+
+wait_healthy() {
+  local slot="$1" secs="${2:-60}" i
+  for ((i = 0; i < secs; i++)); do
+    slot_healthy "$slot" && return 0
+    sleep 1
+  done
+  return 1
+}
+
+# The fuller check a deploy runs before it trusts a freshly swapped slot: the
+# database probe, the home page, and a page that reads the corpus.
+verify_slot() {
+  local slot="$1" port path code
+  port="$(slot_port "$slot")"
+  for path in /api/health / /builds; do
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 60 "http://127.0.0.1:$port$path" || true)"
+    printf '  slot %s  %-12s -> %s\n' "$slot" "$path" "$code"
+    [ "$code" = 200 ] || return 1
+  done
+}
+
+slot_build_id() {
+  curl -fsS --max-time 5 "http://127.0.0.1:$(slot_port "$1")/api/health" 2>/dev/null |
+    grep -o '"build":"[^"]*"' | cut -d'"' -f4
+}
+
+start_slot() {
+  local slot="$1" port peer sess dist
+  port="$(slot_port "$slot")"
+  peer="$(slot_port "$(other_slot "$slot")")"
+  sess="$(slot_session "$slot")"
+  dist=".next-$slot"
+  if [ ! -d "$APP/$dist" ]; then
+    echo "slot $slot: no $dist to run, build and swap first" >&2
+    return 1
+  fi
+  tmux kill-session -t "$sess" 2>/dev/null || true
+  wait_port_free "$port" 15 || { echo "slot $slot: :$port is still held" >&2; return 1; }
+  say "start slot $slot on :$port ($dist)"
+  tmux new-session -d -s "$sess"
+  # PEER_ORIGIN points at the other slot: a cache bust on one has to reach the
+  # other or the two disagree for an hour (see src/lib/revalidate.ts).
+  tmux send-keys -t "$sess" \
+    "export PATH=\$HOME/node22/bin:\$PATH NEXT_DIST_DIR=$dist APP_SLOT=$slot PEER_ORIGIN=http://127.0.0.1:$peer; cd $APP; npx next start -H 127.0.0.1 -p $port 2>&1 | tee $(slot_log "$slot")" C-m
+  if ! wait_healthy "$slot" 90; then
+    echo "slot $slot did not answer /api/health:" >&2
+    tail -5 "$(slot_log "$slot")" >&2 || true
+    return 1
+  fi
+}
+
+stop_slot() {
+  local slot="$1" port sess pid
+  port="$(slot_port "$slot")"
+  sess="$(slot_session "$slot")"
+  pid="$(listener_pid "$port" || true)"
+  if [ -n "$pid" ]; then
+    # SIGTERM first so next stops accepting and finishes what it is already
+    # serving; killing the tmux session outright would cut downloads in half.
+    kill -TERM "$pid" 2>/dev/null || true
+    wait_port_free "$port" 20 || true
+  fi
+  tmux kill-session -t "$sess" 2>/dev/null || true
+  wait_port_free "$port" 10
+}
+
+# ---- postgres, bot ----------------------------------------------------------
+
+ensure_db() {
+  PATH="$PG_BIN:$PATH" pg_ctl -D "$PGDATA_DIR" status >/dev/null 2>&1 && return 0
+  echo "$(stamp) postgres is down, starting it"
+  PATH="$PG_BIN:$PATH" pg_ctl -D "$PGDATA_DIR" -l "$PGDATA_DIR/server.log" -o "-p $PGPORT" start
+}
+
+# The Discord bot holds one gateway session, so unlike the app it must stay a
+# single process: it gets restarted, never doubled.
+restart_bot() {
+  if ! grep -q '^DISCORD_TOKEN=' "$APP/.env.local" 2>/dev/null; then
+    echo "bot: no DISCORD_TOKEN in .env.local, skipped"
+    return 0
+  fi
+  say "(re)start the discord bot"
+  tmux kill-session -t "$BOT_SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$BOT_SESSION"
+  tmux send-keys -t "$BOT_SESSION" \
+    "export PATH=\$HOME/node22/bin:\$PATH; cd $APP; npm run bot 2>&1 | tee $HOME/bot.log" C-m
+  local i
+  for ((i = 0; i < 20; i++)); do
+    grep -q 'logged in as' "$HOME/bot.log" 2>/dev/null && break
+    sleep 1
+  done
+  grep -m1 'logged in as' "$HOME/bot.log" 2>/dev/null ||
+    { echo "bot did not log in:"; tail -5 "$HOME/bot.log"; return 1; }
+}
+
+# ---- front door -------------------------------------------------------------
+
+nginx_at() { nginx -p "$PROXY_PREFIX" -c "$APP/deploy/nginx.conf" -e logs/error.log "$@"; }
+proxy_running() {
+  local pidfile="$PROXY_PREFIX/run/nginx.pid"
+  [ -s "$pidfile" ] && kill -0 "$(cat "$pidfile")" 2>/dev/null
+}
+front_ok() { curl -fsS --max-time 5 -o /dev/null "http://127.0.0.1:$FRONT_PORT/healthz" 2>/dev/null; }
+
+proxy_start() {
+  mkdir -p "$PROXY_PREFIX/logs" "$PROXY_PREFIX/run" "$PROXY_PREFIX/temp"
+  if proxy_running; then echo "proxy: already running"; return 0; fi
+  nginx_at -t
+  nginx_at
+  local i
+  for ((i = 0; i < 10; i++)); do
+    front_ok && { echo "proxy: up on :$FRONT_PORT"; return 0; }
+    sleep 1
+  done
+  echo "proxy did not come up:" >&2
+  tail -5 "$PROXY_PREFIX/logs/error.log" >&2 || true
+  return 1
+}
+
+# A reload picks up a config change without dropping a connection: old workers
+# finish what they are serving. Deploys run this so a shipped nginx.conf
+# actually takes effect.
+proxy_reload() {
+  if ! proxy_running; then proxy_start; return; fi
+  nginx_at -t
+  nginx_at -s reload
+  echo "proxy: reloaded"
+}
+
+proxy_stop() {
+  proxy_running || { echo "proxy: not running"; return 0; }
+  nginx_at -s quit
+  wait_port_free "$FRONT_PORT" 15
+  echo "proxy: stopped"
+}
+
+# ---- the rolling swap -------------------------------------------------------
+
+# Give every slot the staged build's client assets before anything restarts.
+# Halfway through a deploy the two slots serve different builds, and a browser
+# holding a page from one asks for that build's /_next/static files, which the
+# load balancer may well route to the other slot. The names are content
+# hashed, so seeding only ever adds files, and both builds stay answerable
+# whichever slot takes the request.
+seed_static() {
+  local slot dist
+  for slot in $SLOTS; do
+    dist="$(slot_dist "$slot")"
+    [ -d "$dist/static" ] || continue
+    cp -aln "$STAGE/static/." "$dist/static/" 2>/dev/null || true
+  done
+}
+
+# Point one slot at the staged build and restart it, keeping the build it was
+# running as .next-<slot>.prev so a slot that will not come back can be put
+# back the way it was.
+swap_slot() {
+  local slot="$1" dist prev
+  dist="$(slot_dist "$slot")"
+  prev="$dist.prev"
+  [ -d "$STAGE" ] || { echo "no $STAGE, run '$SELF build' first" >&2; return 1; }
+
+  rm -rf "$prev"
+  if [ -d "$dist" ]; then cp -al "$dist" "$prev"; fi
+
+  stop_slot "$slot"
+  rm -rf "$dist"
+  # Hardlinks: a full build directory costs no extra disk this way.
+  cp -al "$STAGE" "$dist"
+  # The build cache belongs to the builder. Dropping the slot's copy also stops
+  # its runtime ISR writes from landing on inodes shared with .next-stage.
+  rm -rf "$dist/cache"
+  mkdir -p "$dist/static"
+  if [ -d "$prev/static" ]; then cp -aln "$prev/static/." "$dist/static/" 2>/dev/null || true; fi
+
+  if start_slot "$slot" && verify_slot "$slot"; then return 0; fi
+
+  echo "::error::slot $slot did not come up on the new build, restoring its previous one" >&2
+  stop_slot "$slot"
+  rm -rf "$dist"
+  if [ -d "$prev" ]; then cp -al "$prev" "$dist"; fi
+  if start_slot "$slot" && verify_slot "$slot"; then
+    echo "slot $slot is back on its previous build" >&2
+  else
+    echo "::error::slot $slot is DOWN after the rollback, see $(slot_log "$slot")" >&2
+  fi
+  return 1
+}
+
+build() {
+  say "build -> .next-stage (both slots keep serving)"
+  (cd "$APP" && NEXT_DIST_DIR=.next-stage npm run build)
+}
+
+rolling() {
+  local slot other
+  ensure_db
+  [ -d "$STAGE" ] || { echo "no $STAGE, run '$SELF build' first" >&2; exit 1; }
+  seed_static
+  for slot in $SLOTS; do
+    other="$(other_slot "$slot")"
+    # Never take a slot down while the other one is not serving.
+    if ! slot_healthy "$other"; then
+      echo "slot $other is not answering; bringing it up before touching slot $slot"
+      start_slot "$other" || true
+      if ! slot_healthy "$other"; then
+        # Deploying is still the right move (the fix may be in this very
+        # build), but say plainly that this one will be a hard restart.
+        echo "::warning::slot $other is down, so swapping slot $slot briefly takes the site with it"
+      fi
+    fi
+    say "swap slot $slot"
+    swap_slot "$slot" || exit 1
+  done
+  # Picks up a shipped nginx.conf; starts the front door if it is not running.
+  proxy_reload
+}
+
+deploy() {
+  build
+  rolling
+}
+
+# Restart both slots on the builds they already have, one at a time. What to
+# reach for after an .env.local change or a wedged process, when nothing needs
+# rebuilding.
+restart_slots() {
+  local slot other
+  ensure_db
+  for slot in $SLOTS; do
+    other="$(other_slot "$slot")"
+    slot_healthy "$other" ||
+      echo "::warning::slot $other is down, so restarting slot $slot briefly takes the site with it"
+    stop_slot "$slot"
+    start_slot "$slot"
+    verify_slot "$slot"
+  done
+  proxy_reload
+}
+
+# ---- watchdog, boot, bootstrap ---------------------------------------------
+
+# Cron, once a minute. Silent unless it acts, so ~/watchdog.log stays readable.
+# It takes the same lock as a deploy and simply skips a tick when one is
+# running, rather than fighting it for a slot.
+watchdog() {
+  local slot
+  ensure_db
+  for slot in $SLOTS; do
+    if ! slot_healthy "$slot"; then
+      echo "$(stamp) slot $slot is not answering, restarting it"
+      start_slot "$slot" || echo "$(stamp) slot $slot failed to restart"
+    fi
+  done
+  if ! front_ok; then
+    echo "$(stamp) front door :$FRONT_PORT is down, starting the proxy"
+    proxy_start || echo "$(stamp) proxy failed to start"
+  fi
+  if ! tmux has-session -t "$BOT_SESSION" 2>/dev/null; then
+    echo "$(stamp) discord bot session is gone, restarting it"
+    restart_bot || echo "$(stamp) bot failed to restart"
+  fi
+}
+
+# Everything, in dependency order. The @reboot crontab entry runs this.
+boot() {
+  local slot
+  ensure_db
+  for slot in $SLOTS; do
+    slot_healthy "$slot" || start_slot "$slot" || echo "$(stamp) slot $slot failed to start"
+  done
+  proxy_start || true
+  tmux has-session -t "$BOT_SESSION" 2>/dev/null || restart_bot || true
+}
+
+CRON_MARK="deploy/slots.sh"
+
+install_cron() {
+  say "crontab entries"
+  local existing add=""
+  existing="$(crontab -l 2>/dev/null || true)"
+  # Append only. This box's crontab is managed by DirectAdmin and carries the
+  # MediaWiki sitemap job and the Actions runner's own @reboot line.
+  grep -qF "$CRON_MARK boot" <<<"$existing" ||
+    add="$add@reboot $SELF boot >> \$HOME/watchdog.log 2>&1"$'\n'
+  grep -qF "$CRON_MARK watchdog" <<<"$existing" ||
+    add="$add*/1 * * * * $SELF watchdog >> \$HOME/watchdog.log 2>&1"$'\n'
+  if [ -z "$add" ]; then echo "  already installed"; return 0; fi
+  printf '%s\n%s' "$existing" "$add" | crontab -
+  printf '  added:\n%s' "$add" | sed 's/^/  /'
+}
+
+# First-time cutover from the single :6800 server to the two-slot layout.
+# Re-runnable. The only unavailable moment in the whole change is between
+# stopping that old server and nginx taking the port, about a second.
+bootstrap() {
+  local slot dist
+  ensure_db
+  mkdir -p "$PROXY_PREFIX/logs" "$PROXY_PREFIX/run" "$PROXY_PREFIX/temp"
+
+  [ -d "$STAGE" ] || build
+  for slot in $SLOTS; do
+    dist="$(slot_dist "$slot")"
+    if [ ! -d "$dist" ]; then
+      say "seed slot $slot from the staged build"
+      cp -al "$STAGE" "$dist"
+      rm -rf "$dist/cache"
+    fi
+    slot_healthy "$slot" || start_slot "$slot"
+    verify_slot "$slot"
+  done
+
+  # Both slots are serving; now hand :6800 over to nginx.
+  if tmux has-session -t deploy 2>/dev/null; then
+    say "retire the old single-process server (tmux 'deploy')"
+    tmux kill-session -t deploy
+    wait_port_free "$FRONT_PORT" 20 || true
+  fi
+  proxy_start
+  say "verify through the front door"
+  local path code
+  for path in /healthz / /builds; do
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 60 "http://127.0.0.1:$FRONT_PORT$path" || true)"
+    printf '  :%s  %-10s -> %s\n' "$FRONT_PORT" "$path" "$code"
+    [ "$code" = 200 ] || { echo "front door is not serving $path" >&2; return 1; }
+  done
+  install_cron
+}
+
+status() {
+  local slot port
+  printf 'app dir     : %s\n' "$APP"
+  printf 'front :%s  : %s\n' "$FRONT_PORT" "$(front_ok && echo UP || echo DOWN)"
+  for slot in $SLOTS; do
+    port="$(slot_port "$slot")"
+    printf 'slot %s :%s  : %-4s  build %s\n' \
+      "$slot" "$port" "$(slot_healthy "$slot" && echo UP || echo DOWN)" \
+      "$(slot_build_id "$slot" || echo '?')"
+  done
+  printf 'staged build: %s\n' "$(cat "$STAGE/BUILD_ID" 2>/dev/null || echo '(none)')"
+  printf 'postgres :%s: %s\n' "$PGPORT" "$(port_listening "$PGPORT" && echo UP || echo DOWN)"
+  printf 'tmux        : %s\n' "$(tmux ls 2>/dev/null | cut -d: -f1 | tr '\n' ' ')"
+}
+
+CMD="${1:-status}"
+shift || true
+
+# One deploy at a time. The manual deploy, the runner and the watchdog all come
+# through here, and the lock is what keeps two of them from restarting the same
+# slot at the same moment. Read-only subcommands do not need it; the watchdog
+# skips its tick instead of queueing behind a deploy (-E 0 = a busy lock is not
+# an error).
+#
+# -o is load bearing: without it the lock's file descriptor is inherited by
+# every process this script starts, and the daemons among them (nginx, and the
+# tmux server when none is running yet) then hold the lock for as long as they
+# live, which wedged the first deploy after the cutover until nginx was
+# restarted. With -o the descriptor is closed before the command runs, so only
+# flock itself holds it.
+if [ "${HP_WEB_SLOTS_LOCKED:-}" != 1 ]; then
+  case "$CMD" in
+    status | help | -h | --help) ;;
+    watchdog)
+      exec flock -o -n -E 0 "$LOCK" env HP_WEB_SLOTS_LOCKED=1 "$SELF" "$CMD" "$@"
+      ;;
+    *)
+      exec flock -o -w 1800 "$LOCK" env HP_WEB_SLOTS_LOCKED=1 "$SELF" "$CMD" "$@"
+      ;;
+  esac
+fi
+
+case "$CMD" in
+  status) status ;;
+  build) build ;;
+  rolling) rolling ;;
+  deploy) deploy ;;
+  restart) restart_slots ;;
+  start) start_slot "${1:?usage: start <a|b>}" ;;
+  stop) stop_slot "${1:?usage: stop <a|b>}" ;;
+  swap) swap_slot "${1:?usage: swap <a|b>}" ;;
+  restart-bot) restart_bot ;;
+  start-db) ensure_db ;;
+  proxy)
+    case "${1:-status}" in
+      start) proxy_start ;;
+      stop) proxy_stop ;;
+      reload) proxy_reload ;;
+      test) nginx_at -t ;;
+      status) front_ok && echo "proxy: up" || { echo "proxy: down"; exit 1; } ;;
+      *) echo "usage: $SELF proxy {start|stop|reload|test|status}" >&2; exit 2 ;;
+    esac
+    ;;
+  boot) boot ;;
+  watchdog) watchdog ;;
+  bootstrap) bootstrap ;;
+  install-cron) install_cron ;;
+  *)
+    echo "usage: $SELF {status|build|rolling|deploy|restart|start <a|b>|stop <a|b>|swap <a|b>|restart-bot|start-db|proxy <cmd>|boot|watchdog|bootstrap|install-cron}" >&2
+    exit 2
+    ;;
+esac

--- a/hp-web/next.config.ts
+++ b/hp-web/next.config.ts
@@ -15,6 +15,12 @@ const SECURITY_HEADERS = [
 ];
 
 const nextConfig: NextConfig = {
+  // Which build directory this process uses. Production serves the app from
+  // two slots off one checkout (.next-a and .next-b, see deploy/slots.sh), so
+  // a deploy can rebuild and swap one while the other keeps serving; each slot
+  // sets NEXT_DIST_DIR for both its build and its `next start`. Unset in dev
+  // and CI, which keep writing plain .next.
+  distDir: process.env.NEXT_DIST_DIR || ".next",
   // cube ships TS/TSX source with "use client" directives (workspace package).
   transpilePackages: ["cube"],
   // Keep file tracing rooted at the workspace, not misdetected via lockfiles.

--- a/hp-web/src/app/api/build/[sha256]/route.ts
+++ b/hp-web/src/app/api/build/[sha256]/route.ts
@@ -1,9 +1,9 @@
 import type { NextRequest } from "next/server";
-import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { deriveQueryFeatures } from "@/lib/fingerprint";
 import { getBuild, findSimilar, findByEmbeddingOf, getLotBuilds, updateBuildMeta, setLotPrivate, setBuildGame } from "@/lib/queries";
 import { getModerator, requireModerator } from "@/lib/auth";
+import { revalidateEverywhere } from "@/lib/revalidate";
 import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
 
@@ -139,7 +139,6 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
   // section on every sibling page (in the lot joined and the one left), so
   // refresh those too — including private siblings, whose pages stay
   // reachable by direct URL.
-  revalidatePath("/builds");
   const touched = new Set([
     buildHref(sha256, prev.name),
     buildHref(sha256, fields.name ?? prev.name),
@@ -155,10 +154,12 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
   for (const lot of lotsTouched) {
     for (const b of await getLotBuilds(pool, lot, true)) touched.add(buildHref(b.sha256, b.name));
   }
+  const paths = new Set(["/builds"]);
   for (const path of touched) {
-    revalidatePath(path);
-    revalidatePath(`${path}/assets`);
+    paths.add(path);
+    paths.add(`${path}/assets`);
   }
+  revalidateEverywhere(paths);
   return Response.json({
     sha256,
     name: fields.name ?? prev.name,

--- a/hp-web/src/app/api/builds/route.ts
+++ b/hp-web/src/app/api/builds/route.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from "next/server";
-import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { bulkUpdateBuilds } from "@/lib/queries";
 import { requireModerator } from "@/lib/auth";
+import { revalidateEverywhere } from "@/lib/revalidate";
 import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
 
@@ -72,13 +72,14 @@ export async function POST(request: NextRequest) {
 
   // Build pages are ISR-cached; surface the new chips now. The game pages
   // themselves are dynamic and need no revalidation.
-  revalidatePath("/builds");
+  const touched = new Set(["/builds"]);
   for (const b of updated) {
     for (const path of [buildHref(b.sha256, b.name), `/builds/${b.sha256}`]) {
-      revalidatePath(path);
-      revalidatePath(`${path}/assets`);
+      touched.add(path);
+      touched.add(`${path}/assets`);
     }
   }
+  revalidateEverywhere(touched);
 
   return Response.json({
     updated: updated.length,

--- a/hp-web/src/app/api/health/route.ts
+++ b/hp-web/src/app/api/health/route.ts
@@ -1,0 +1,47 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getPool } from "@/lib/db";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// GET /api/health: what the :6800 front door, the deploy swap and the
+// watchdog cron ask before they trust an app slot. The database round trip is
+// the point: `/` renders fine with Postgres down, so a slot that cannot reach
+// it has to fail this check rather than keep taking a share of the traffic.
+
+// The build this process serves, so a rolling deploy can be watched landing
+// one slot at a time. Read once, since a running server never changes build.
+let buildId: Promise<string | null> | undefined;
+
+function readBuildId(): Promise<string | null> {
+  buildId ??= readFile(join(process.cwd(), process.env.NEXT_DIST_DIR || ".next", "BUILD_ID"), "utf8")
+    .then((s) => s.trim())
+    .catch(() => null);
+  return buildId;
+}
+
+// Long enough to ride out a busy pool, short enough that a wedged database
+// fails the check instead of hanging the caller that is deciding whether to
+// take this slot out of rotation.
+const DB_TIMEOUT_MS = 5_000;
+
+async function dbUp(): Promise<boolean> {
+  try {
+    await Promise.race([
+      getPool().query("SELECT 1"),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("db timeout")), DB_TIMEOUT_MS)),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function GET() {
+  const [build, db] = await Promise.all([readBuildId(), dbUp()]);
+  return Response.json(
+    { ok: db, slot: process.env.APP_SLOT ?? null, build, db: db ? "up" : "down" },
+    { status: db ? 200 : 503, headers: { "Cache-Control": "no-store" } }
+  );
+}

--- a/hp-web/src/app/api/refresh/route.ts
+++ b/hp-web/src/app/api/refresh/route.ts
@@ -1,19 +1,33 @@
 import { timingSafeEqual } from "node:crypto";
-import { revalidatePath, revalidateTag } from "next/cache";
 import { getPool } from "@/lib/db";
+import {
+  PEER_HEADER,
+  isRevalidatePath,
+  isRevalidateTag,
+  revalidateEverywhere,
+} from "@/lib/revalidate";
 import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
 
 export const runtime = "nodejs";
 
-// POST /api/refresh { sha256s: [...] } — bust the caches of re-ingested builds:
-// each build's ISR page (canonical path, bare-sha redirect, assets subpage),
-// its tagged tree cache, and the /builds listing. The moderation endpoints
-// revalidate what they touch on their own; this is for scripts/ingest.ts,
-// whose record updates otherwise sit behind the hour-long caches.
+// POST /api/refresh: bust caches. Two shapes, and one request may carry both:
+//
+//   { sha256s: [...] }         re-ingested builds: each one's ISR page
+//                              (canonical path, bare-sha redirect, assets
+//                              subpage), its tagged tree cache, and the
+//                              /builds listing. For scripts/ingest.ts, whose
+//                              record updates otherwise sit behind the
+//                              hour-long caches; the moderation endpoints
+//                              revalidate what they touch on their own.
+//   { paths: [...], tags: [] } exactly these. This is how one app slot mirrors
+//                              a revalidation to the other (lib/revalidate.ts),
+//                              which has to name paths no build sha implies,
+//                              the pre-rename slug of a renamed build, say.
 //
 // Gated by REFRESH_TOKEN from the environment (x-refresh-token header) and
-// disabled when the variable is unset.
+// disabled when the variable is unset. A request that is itself a mirror
+// (PEER_HEADER) is not mirrored onward, so two slots cannot ping-pong.
 export async function POST(request: Request) {
   const token = process.env.REFRESH_TOKEN;
   if (!token) return Response.json({ error: "not found" }, { status: 404 });
@@ -23,30 +37,38 @@ export async function POST(request: Request) {
     return Response.json({ error: "forbidden" }, { status: 403 });
   }
 
-  let body: { sha256s?: unknown };
+  const require = { error: "require { sha256s: [...] } or { paths: [...] }" };
+  let body: { sha256s?: unknown; paths?: unknown; tags?: unknown };
   try {
     body = await request.json();
   } catch {
-    return Response.json({ error: "require { sha256s: [...] }" }, { status: 400 });
+    return Response.json(require, { status: 400 });
   }
   const shas = Array.isArray(body.sha256s)
     ? [...new Set(body.sha256s.filter((s): s is string => typeof s === "string" && isSha256(s)))]
     : [];
-  if (shas.length === 0) {
-    return Response.json({ error: "require { sha256s: [...] }" }, { status: 400 });
+  const paths = new Set(Array.isArray(body.paths) ? body.paths.filter(isRevalidatePath) : []);
+  const tags = new Set(Array.isArray(body.tags) ? body.tags.filter(isRevalidateTag) : []);
+  if (shas.length === 0 && paths.size === 0 && tags.size === 0) {
+    return Response.json(require, { status: 400 });
   }
 
-  const named = (await getPool().query("SELECT sha256, name FROM builds WHERE sha256 = ANY($1)", [
-    shas,
-  ])) as { rows: { sha256: string; name: string }[] };
-
-  revalidatePath("/builds");
-  for (const { sha256, name } of named.rows) {
-    const href = buildHref(sha256, name);
-    revalidatePath(href);
-    revalidatePath(`${href}/assets`);
-    revalidatePath(`/builds/${sha256}`);
-    revalidateTag(`build-tree:${sha256}`, "max");
+  let refreshed = 0;
+  if (shas.length > 0) {
+    const named = (await getPool().query("SELECT sha256, name FROM builds WHERE sha256 = ANY($1)", [
+      shas,
+    ])) as { rows: { sha256: string; name: string }[] };
+    refreshed = named.rows.length;
+    paths.add("/builds");
+    for (const { sha256, name } of named.rows) {
+      const href = buildHref(sha256, name);
+      paths.add(href);
+      paths.add(`${href}/assets`);
+      paths.add(`/builds/${sha256}`);
+      tags.add(`build-tree:${sha256}`);
+    }
   }
-  return Response.json({ refreshed: named.rows.length });
+
+  revalidateEverywhere(paths, tags, { mirror: request.headers.get(PEER_HEADER) !== "1" });
+  return Response.json({ refreshed, revalidated: paths.size });
 }

--- a/hp-web/src/app/api/submissions/[sha256]/route.ts
+++ b/hp-web/src/app/api/submissions/[sha256]/route.ts
@@ -1,9 +1,9 @@
 import type { NextRequest } from "next/server";
-import { revalidatePath } from "next/cache";
 import { getPool } from "@/lib/db";
 import { submissionStatus, setSubmissionStatus } from "@/lib/queries";
 import { ingestRecord, refreshAudioIdf } from "@/lib/ingest";
 import { requireModerator } from "@/lib/auth";
+import { revalidateEverywhere } from "@/lib/revalidate";
 import { buildHref } from "@/lib/slug";
 import { isSha256 } from "@/lib/validate";
 import type { BuildRecord } from "@/lib/types";
@@ -114,8 +114,6 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
   // The canonical slug path is what everything links to; the bare-sha path
   // serves a cached redirect, so refresh both (plus the assets subpage).
   const canonical = buildHref(sha256, name);
-  revalidatePath(canonical);
-  revalidatePath(`${canonical}/assets`);
-  revalidatePath(`/builds/${sha256}`);
+  revalidateEverywhere([canonical, `${canonical}/assets`, `/builds/${sha256}`]);
   return Response.json({ sha256, status: "accepted", kind });
 }

--- a/hp-web/src/cube/cube.ts
+++ b/hp-web/src/cube/cube.ts
@@ -2,9 +2,9 @@
 // mirroring lib/db.ts getPool(). Server-only.
 
 import { join } from "node:path";
-import { revalidatePath } from "next/cache";
 import { createCube, cubeNativeAuth, localDirStorage, type Cube } from "cube";
 import { getPool } from "@/lib/db";
+import { revalidateEverywhere } from "@/lib/revalidate";
 import { hpComponents } from "./schemas";
 
 let instance: Cube | undefined;
@@ -30,14 +30,16 @@ export function getCube(): Cube {
       },
       onInvalidate: (tags, pages) => {
         // Wiki pages live at root; revalidate the edited page and every page
-        // whose queries depend on the changed objects.
+        // whose queries depend on the changed objects, on both app slots.
+        const paths = new Set<string>();
         for (const tag of tags) {
           const m = /^cube:page:main:(.+)$/.exec(tag);
-          if (m) revalidatePath(`/${m[1]}`);
+          if (m) paths.add(`/${m[1]}`);
         }
         for (const p of pages) {
-          revalidatePath(p.ns === "main" ? `/${p.slug}` : `/${nsPrefix(p.ns)}:${p.slug}`);
+          paths.add(p.ns === "main" ? `/${p.slug}` : `/${nsPrefix(p.ns)}:${p.slug}`);
         }
+        revalidateEverywhere(paths);
       },
     });
   }

--- a/hp-web/src/lib/contrib.ts
+++ b/hp-web/src/lib/contrib.ts
@@ -3,10 +3,10 @@
 // (wiki group or shared token) can also touch private builds and other
 // people's contributions.
 
-import { revalidatePath } from "next/cache";
 import type { NextRequest } from "next/server";
 import type { Pool } from "pg";
 import { getModerator } from "./auth";
+import { revalidateEverywhere } from "./revalidate";
 import { buildHref } from "./slug";
 import { wikiUserFromCookies } from "./wiki-auth";
 
@@ -74,8 +74,8 @@ export async function contributionTarget(pool: Pool, sha256: string): Promise<Co
   return (r.rows[0] as ContributionTarget) ?? null;
 }
 
-/** Surface a contribution on the ISR-cached build page right away. */
+/** Surface a contribution on the ISR-cached build page right away, on every
+ *  app slot (see lib/revalidate.ts). */
 export function revalidateBuildPages(sha256: string, name: string): void {
-  revalidatePath(buildHref(sha256, name));
-  revalidatePath(`/builds/${sha256}`);
+  revalidateEverywhere([buildHref(sha256, name), `/builds/${sha256}`]);
 }

--- a/hp-web/src/lib/revalidate.ts
+++ b/hp-web/src/lib/revalidate.ts
@@ -1,0 +1,100 @@
+// Cache busting that reaches every app process.
+//
+// Production serves the app from two slots behind the :6800 front door (see
+// deploy/slots.sh), and each slot has its own ISR cache. next/cache's
+// revalidatePath only clears the cache of the process that ran it, so an edit
+// handled by slot A would leave slot B serving the stale build page for the
+// rest of its hour (`export const revalidate = 3600`). The page would flip
+// between old and new depending on which slot answered. Mutation routes
+// therefore bust caches through revalidateEverywhere, which revalidates
+// locally and mirrors the same paths to the sibling slot.
+//
+// The sibling's origin comes from PEER_ORIGIN, set per slot by the deploy
+// script. Unset (dev, a single instance, tests) this is exactly a local
+// revalidate. The mirrored request goes straight to the sibling's port rather
+// than back through the load balancer, which could route it right back here,
+// is authenticated with the REFRESH_TOKEN that /api/refresh already takes, and
+// carries PEER_HEADER so the receiving side does not mirror it back again.
+
+import { revalidatePath, revalidateTag } from "next/cache";
+
+/** Marks a mirrored revalidation, so the receiving slot does not bounce it back. */
+export const PEER_HEADER = "x-peer-revalidate";
+
+const PEER_TIMEOUT_MS = 5_000;
+
+/** A path this app would revalidate: absolute, single-line, no host or scheme. */
+export function isRevalidatePath(v: unknown): v is string {
+  return (
+    typeof v === "string" &&
+    v.length > 0 &&
+    v.length <= 512 &&
+    v.startsWith("/") &&
+    !v.startsWith("//") &&
+    !/\s/.test(v)
+  );
+}
+
+/** A cache tag this app would revalidate, e.g. `build-tree:<sha256>`. */
+export function isRevalidateTag(v: unknown): v is string {
+  return typeof v === "string" && /^[\w.:-]{1,128}$/.test(v);
+}
+
+/**
+ * The request that mirrors these cache busts to the sibling slot, or null when
+ * there is no sibling configured, no token to authenticate with, or nothing to
+ * send. Split out from the sending so it can be tested without a request scope.
+ */
+export function peerRevalidateRequest(
+  paths: string[],
+  tags: string[],
+  env: Record<string, string | undefined> = process.env
+): { url: string; init: RequestInit } | null {
+  const origin = env.PEER_ORIGIN?.replace(/\/+$/, "");
+  const token = env.REFRESH_TOKEN;
+  if (!origin || !token) return null;
+  if (paths.length === 0 && tags.length === 0) return null;
+  return {
+    url: `${origin}/api/refresh`,
+    init: {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-refresh-token": token,
+        [PEER_HEADER]: "1",
+      },
+      body: JSON.stringify({ paths, tags }),
+      signal: AbortSignal.timeout(PEER_TIMEOUT_MS),
+      cache: "no-store",
+    },
+  };
+}
+
+/**
+ * Revalidate these paths and tags on this process and on the sibling slot.
+ * Pass `mirror: false` when already handling a mirrored request, so two slots
+ * cannot bounce one bust back and forth.
+ */
+export function revalidateEverywhere(
+  paths: Iterable<string>,
+  tags: Iterable<string> = [],
+  opts: { mirror?: boolean } = {}
+): void {
+  const p = [...new Set(paths)];
+  const t = [...new Set(tags)];
+  for (const path of p) revalidatePath(path);
+  for (const tag of t) revalidateTag(tag, "max");
+
+  if (opts.mirror === false) return;
+  const req = peerRevalidateRequest(p, t);
+  if (!req) return;
+  // Fire and forget: the mutation this follows has already succeeded, and a
+  // sibling that cannot be reached right now is a stale page for a while, not
+  // a failed request for the caller. Logged so it is not silent.
+  void fetch(req.url, req.init).then(
+    (r) => {
+      if (!r.ok) console.warn(`peer revalidate: ${req.url} -> ${r.status}`);
+    },
+    (err) => console.warn("peer revalidate failed:", err)
+  );
+}

--- a/hp-web/tests/revalidate.test.ts
+++ b/hp-web/tests/revalidate.test.ts
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  PEER_HEADER,
+  isRevalidatePath,
+  isRevalidateTag,
+  peerRevalidateRequest,
+} from "../src/lib/revalidate";
+
+const ENV = { PEER_ORIGIN: "http://127.0.0.1:6802", REFRESH_TOKEN: "s3cret" };
+
+test("peerRevalidateRequest posts the paths to the sibling's refresh endpoint", () => {
+  const req = peerRevalidateRequest(["/builds", "/builds/foo"], ["build-tree:abc"], ENV);
+  assert.ok(req);
+  assert.equal(req.url, "http://127.0.0.1:6802/api/refresh");
+  assert.equal(req.init.method, "POST");
+  const headers = req.init.headers as Record<string, string>;
+  assert.equal(headers["x-refresh-token"], "s3cret");
+  assert.equal(headers[PEER_HEADER], "1"); // receiver must not mirror it back
+  assert.deepEqual(JSON.parse(req.init.body as string), {
+    paths: ["/builds", "/builds/foo"],
+    tags: ["build-tree:abc"],
+  });
+});
+
+test("peerRevalidateRequest tolerates a trailing slash on PEER_ORIGIN", () => {
+  const req = peerRevalidateRequest(["/builds"], [], { ...ENV, PEER_ORIGIN: "http://127.0.0.1:6802/" });
+  assert.equal(req?.url, "http://127.0.0.1:6802/api/refresh");
+});
+
+test("peerRevalidateRequest is null with no sibling, no token, or nothing to send", () => {
+  assert.equal(peerRevalidateRequest(["/builds"], [], { REFRESH_TOKEN: "s3cret" }), null);
+  assert.equal(peerRevalidateRequest(["/builds"], [], { PEER_ORIGIN: ENV.PEER_ORIGIN }), null);
+  assert.equal(peerRevalidateRequest([], [], ENV), null);
+});
+
+test("isRevalidatePath takes app paths and rejects anything host-shaped", () => {
+  assert.equal(isRevalidatePath("/builds"), true);
+  assert.equal(isRevalidatePath("/builds/sonic-the-hedgehog--genesis/assets"), true);
+  assert.equal(isRevalidatePath("builds"), false);
+  assert.equal(isRevalidatePath("//evil.example.com/"), false);
+  assert.equal(isRevalidatePath("http://evil.example.com/"), false);
+  assert.equal(isRevalidatePath("/builds\n/other"), false);
+  assert.equal(isRevalidatePath("/" + "x".repeat(600)), false);
+  assert.equal(isRevalidatePath(""), false);
+  assert.equal(isRevalidatePath(42), false);
+});
+
+test("isRevalidateTag takes the app's tag shape only", () => {
+  assert.equal(isRevalidateTag("build-tree:8ab3"), true);
+  assert.equal(isRevalidateTag("build tree"), false);
+  assert.equal(isRevalidateTag(""), false);
+  assert.equal(isRevalidateTag("x".repeat(129)), false);
+  assert.equal(isRevalidateTag(null), false);
+});


### PR DESCRIPTION
The app now runs as two processes on 6801 and 6802 behind an unprivileged nginx on 6800, each with its own build directory. A deploy builds into .next-stage while both keep serving, then swaps them one at a time and verifies each one (health, home page, builds listing) before touching the other, so a deploy no longer takes the site down.

Running two processes needs a few things to stay correct: ISR cache busts are mirrored to the sibling slot, asset and media upload requests are pinned by consistent hash so one transcode cannot run twice, and the forwarded-for chain is passed through untouched so the rate limiter still sees real clients. This is already live on hpwiki (bootstrapped and measured at 3082 of 3082 requests answering 200 through a full rolling deploy), so it should land before the next push to main, or the old workflow will fail trying to bind 6800.