### PR TITLE
Make media uploads resumable and reliable

### DIFF
--- a/hp-web/src/app/api/build/[sha256]/media/[id]/route.ts
+++ b/hp-web/src/app/api/build/[sha256]/media/[id]/route.ts
@@ -68,7 +68,7 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
 
   const row = await updateMediaLabel(gate.pool, sha256, gate.row.id, body.label);
   if (!row) return Response.json({ error: "not found" }, { status: 404 });
-  revalidateBuildPages(sha256, gate.target.name);
+  await revalidateBuildPages(sha256, gate.target.name);
   return Response.json({ media: mediaView(row) });
 }
 
@@ -81,6 +81,6 @@ export async function DELETE(request: NextRequest, ctx: { params: Promise<{ sha2
   if (!gate.ok) return gate.response;
 
   await deleteMedia(gate.pool, sha256, gate.row.id);
-  revalidateBuildPages(sha256, gate.target.name);
+  await revalidateBuildPages(sha256, gate.target.name);
   return Response.json({ deleted: true });
 }

--- a/hp-web/src/app/api/build/[sha256]/media/upload/[token]/route.ts
+++ b/hp-web/src/app/api/build/[sha256]/media/upload/[token]/route.ts
@@ -7,6 +7,7 @@ import { extractStill } from "@/lib/ffmpeg";
 import {
   MEDIA_NS,
   dropMediaSession,
+  finishMediaSession,
   hashFile,
   inferMediaLabel,
   insertMedia,
@@ -16,6 +17,7 @@ import {
   readMediaSession,
   sniffMedia,
   updateMediaSession,
+  withMediaSession,
 } from "@/lib/media";
 import { isSha256 } from "@/lib/validate";
 
@@ -32,6 +34,12 @@ const MAX_CHUNK_BYTES = 32 * 1024 * 1024;
 // resume. When the staged bytes reach the claimed size the file is hashed,
 // stored under the media/ namespace (with a poster still for videos), and
 // recorded; the response carries { done: true, media }.
+//
+// Every step here is safe to repeat, because the client retries: an offset the
+// server has already consumed answers 409 with the truth, and a session whose
+// row already exists replays { done: true } rather than 404-ing bytes that did
+// in fact land. One token is served one request at a time (withMediaSession),
+// so a retry arriving alongside the request it is retrying queues behind it.
 export async function PUT(
   request: NextRequest,
   ctx: { params: Promise<{ sha256: string; token: string }> }
@@ -45,10 +53,49 @@ export async function PUT(
   if (!gate.ok) return gate.response;
   const { target } = gate;
 
+  const offset = Number(request.nextUrl.searchParams.get("offset") ?? "0");
+
+  // Advisory pre-check, before the body is pulled over the wire. A resume, or
+  // a retry of a chunk that did land, is answered from what is already on disk:
+  // making a client push 8MB only to be told 409 is the wrong move on exactly
+  // the flaky connections this protocol exists for. Racy by nature (no lock
+  // yet), so it only ever short-circuits. The binding checks are in append().
+  const known = await readMediaSession(token);
+  if (known && known.build === sha256) {
+    if (known.done) return Response.json({ done: true, media: known.done });
+    const st = await fsp.stat(mediaStagingPath(token)).catch(() => null);
+    if (st && st.size < known.size && offset !== st.size) {
+      return Response.json({ offset: st.size }, { status: 409 });
+    }
+  }
+
+  // Read the body outside the lock: it streams from the client, and holding
+  // the token while it arrives would serialise a retry behind the very request
+  // it is meant to overtake. A client that stalls mid-body would wedge its own
+  // rescue for the whole client_body_timeout.
+  const declared = Number(request.headers.get("content-length") ?? "0");
+  if (declared > MAX_CHUNK_BYTES) {
+    return Response.json({ error: "chunk too large" }, { status: 413 });
+  }
+  const chunk = Buffer.from(await request.arrayBuffer());
+
+  return withMediaSession(token, () => append(pool, sha256, token, target, chunk, offset));
+}
+
+async function append(
+  pool: ReturnType<typeof getPool>,
+  sha256: string,
+  token: string,
+  target: { name: string },
+  chunk: Buffer,
+  offset: number
+): Promise<Response> {
   const session = await readMediaSession(token);
   if (!session || session.build !== sha256) {
     return Response.json({ error: "no such upload session" }, { status: 404 });
   }
+  // Already finalised: hand back the same row this session produced.
+  if (session.done) return Response.json({ done: true, media: session.done });
   const staging = mediaStagingPath(token);
   const st = await fsp.stat(staging).catch(() => null);
   if (!st) return Response.json({ error: "no such upload session" }, { status: 404 });
@@ -59,17 +106,11 @@ export async function PUT(
   }
 
   if (staged < session.size) {
-    const offset = Number(request.nextUrl.searchParams.get("offset") ?? "0");
     if (!Number.isInteger(offset) || offset < 0) {
       return Response.json({ error: "invalid offset" }, { status: 400 });
     }
     if (offset !== staged) return Response.json({ offset: staged }, { status: 409 });
 
-    const declared = Number(request.headers.get("content-length") ?? "0");
-    if (declared > MAX_CHUNK_BYTES) {
-      return Response.json({ error: "chunk too large" }, { status: 413 });
-    }
-    const chunk = Buffer.from(await request.arrayBuffer());
     if (!chunk.length) return Response.json({ error: "empty chunk" }, { status: 400 });
     if (chunk.length > MAX_CHUNK_BYTES) {
       return Response.json({ error: "chunk too large" }, { status: 413 });
@@ -118,8 +159,8 @@ export async function PUT(
   }
   const blobSha = await hashFile(staging);
 
-  let poster: string | null = null;
-  if (session.contentType.startsWith("video/")) {
+  let poster = session.poster ?? null;
+  if (session.poster === undefined && session.contentType.startsWith("video/")) {
     const posterTmp = `${staging}.poster.jpg`;
     try {
       await extractStill(staging, posterTmp);
@@ -130,10 +171,19 @@ export async function PUT(
       await fsp.rm(posterTmp, { force: true });
       poster = null;
     }
+    // Remember the verdict either way, so a retried finalize does not run
+    // ffmpeg over a multi-hundred-MB capture again.
+    session.poster = poster;
+    await updateMediaSession(token, session);
   }
 
-  await storeBlobFromFile(blobSha, staging, { ns: MEDIA_NS });
-  await dropMediaSession(token);
+  // keepSource: the staged bytes stay put until the row exists. Storing is
+  // content-addressed and idempotent, so a retry after a failed insert redoes
+  // it for free, whereas consuming the file here would strand an upload whose
+  // blob landed but whose insert did not, with nothing left to retry from.
+  // Costs the local backend a copy where it used to rename (the s3 backend
+  // this runs on in production streams the file and never consumed it anyway).
+  await storeBlobFromFile(blobSha, staging, { ns: MEDIA_NS, keepSource: true });
 
   const row = await insertMedia(pool, {
     build_sha256: sha256,
@@ -146,6 +196,10 @@ export async function PUT(
     author: session.author,
     label: session.kind === "physical" ? (session.label ?? inferMediaLabel(session.filename)) : null,
   });
-  revalidateBuildPages(sha256, target.name);
-  return Response.json({ done: true, media: mediaView(row) });
+  const media = mediaView(row);
+  await finishMediaSession(token, session, media);
+  // Awaited: the client refreshes the build page the moment it reads this, and
+  // that refresh can land on either slot.
+  await revalidateBuildPages(sha256, target.name);
+  return Response.json({ done: true, media });
 }

--- a/hp-web/src/app/api/build/[sha256]/media/upload/route.ts
+++ b/hp-web/src/app/api/build/[sha256]/media/upload/route.ts
@@ -16,8 +16,11 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 // Uploads per contributor per hour. Generous for a photo session of one
-// build, tight enough to stop a script hosing the bucket.
-const CREATE_LIMIT = 60;
+// build, tight enough to stop a script hosing the bucket. A real session is a
+// disc's worth of screenshots plus front/back/media scans, and a retried file
+// spends another slot, so this sits well above what one sitting needs: the
+// client cannot recover from a 429 the way it recovers from a dropped chunk.
+const CREATE_LIMIT = 240;
 const CREATE_WINDOW_MS = 3600_000;
 
 // POST /api/build/<sha256>/media/upload { kind, filename, size, label? }:

--- a/hp-web/src/app/api/build/[sha256]/notes/[id]/route.ts
+++ b/hp-web/src/app/api/build/[sha256]/notes/[id]/route.ts
@@ -57,7 +57,7 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
 
   const note = await updateNote(getPool(), r.sha256, r.noteId, body);
   if (!note) return Response.json({ error: "not found" }, { status: 404 });
-  revalidateBuildPages(r.sha256, r.name);
+  await revalidateBuildPages(r.sha256, r.name);
   return Response.json({ note });
 }
 
@@ -66,6 +66,6 @@ export async function DELETE(request: NextRequest, ctx: { params: Promise<{ sha2
   const r = await resolveNote(request, ctx);
   if (!r.ok) return r.response;
   await deleteNote(getPool(), r.sha256, r.noteId);
-  revalidateBuildPages(r.sha256, r.name);
+  await revalidateBuildPages(r.sha256, r.name);
   return Response.json({ deleted: true });
 }

--- a/hp-web/src/app/api/build/[sha256]/notes/route.ts
+++ b/hp-web/src/app/api/build/[sha256]/notes/route.ts
@@ -43,6 +43,6 @@ export async function POST(request: NextRequest, ctx: { params: Promise<{ sha256
   }
 
   const note = await insertNote(pool, sha256, body, contributor.name);
-  revalidateBuildPages(sha256, target.name);
+  await revalidateBuildPages(sha256, target.name);
   return Response.json({ note });
 }

--- a/hp-web/src/app/api/build/[sha256]/skip/route.ts
+++ b/hp-web/src/app/api/build/[sha256]/skip/route.ts
@@ -48,6 +48,6 @@ export async function PATCH(request: NextRequest, ctx: { params: Promise<{ sha25
   if (!target) return Response.json({ error: "not found" }, { status: 404 });
 
   const saved = await upsertSkip(pool, sha256, flags);
-  revalidateBuildPages(sha256, target.name);
+  await revalidateBuildPages(sha256, target.name);
   return Response.json({ sha256, ...saved });
 }

--- a/hp-web/src/app/builds/[buildId]/MediaSection.tsx
+++ b/hp-web/src/app/builds/[buildId]/MediaSection.tsx
@@ -13,7 +13,21 @@ interface Upload {
   key: number;
   label: string;
   pct: number;
+  /** Waiting for a slot in the upload window. */
+  queued: boolean;
+  /** Set while backing off between attempts, e.g. "retrying 2/6". */
+  retry?: string;
   error?: string;
+}
+
+/** What a failed upload needs to pick up where it stopped. The token is kept
+ *  because the session on the server still holds the bytes already sent: a
+ *  retry resumes at that offset instead of re-uploading from zero. */
+interface Job {
+  key: number;
+  file: File;
+  kind: MediaKind;
+  token?: string;
 }
 
 interface Props {
@@ -23,6 +37,79 @@ interface Props {
 }
 
 const CHUNK = 8 * 1024 * 1024;
+
+// How many files upload at once. The bottleneck is one person's uplink, so a
+// wider window does not finish the batch sooner. It just makes every file
+// slower and every request likelier to sit past a proxy timeout. Picking 20
+// photos used to start 20 streams at once, which is where "flaky with several
+// files" came from.
+const CONCURRENCY = 3;
+
+// Every request in this protocol is safe to repeat: a chunk the server already
+// has answers 409 with the true offset, and a session whose row exists replays
+// its reply. So a dropped connection, a rate-limit reply, or a slot restarting
+// mid-deploy is worth waiting out rather than losing the file for.
+const MAX_ATTEMPTS = 6;
+const RETRY_BASE_MS = 700;
+const RETRY_CAP_MS = 15_000;
+const RETRYABLE = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+// One refresh once the batch settles, not one per file: concurrent refreshes
+// race, and the loser can be an older payload that drops just-uploaded items
+// back off the page.
+const REFRESH_DEBOUNCE_MS = 800;
+
+// A 409 moves the client to whatever the server actually holds, in either
+// direction (a chunk that never landed rewinds it). That makes a plain
+// monotonic check the wrong guard, so a run of them with no chunk accepted in
+// between is what counts as going nowhere.
+const MAX_STALLS = 5;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** An upload that stopped. `resumable` false means the server rejected the
+ *  file outright (format, size, permission) and dropped the session with it,
+ *  so there is nothing left to offer to resume. */
+class UploadError extends Error {
+  constructor(
+    message: string,
+    readonly resumable: boolean
+  ) {
+    super(message);
+  }
+}
+
+function retryDelay(attempt: number, retryAfter: string | null): number {
+  const ra = Number(retryAfter);
+  if (Number.isFinite(ra) && ra > 0) return Math.min(ra * 1000, 60_000);
+  // Jittered, so files that tripped the same limit together do not all come
+  // back in lockstep and trip it again.
+  return Math.min(RETRY_BASE_MS * 2 ** attempt, RETRY_CAP_MS) * (0.5 + Math.random());
+}
+
+/** fetch that rides out the failures the resume protocol exists to absorb.
+ *  Returns the first reply that is not a transient failure (and the last one
+ *  when the attempts run out, so the caller reports the server's own error),
+ *  throws only when the request could not be made at all. */
+async function sendWithRetry(
+  url: string,
+  init: RequestInit,
+  onRetry: (note: string) => void
+): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    const last = attempt + 1 >= MAX_ATTEMPTS;
+    try {
+      const res = await fetch(url, init);
+      if (!RETRYABLE.has(res.status) || last) return res;
+      onRetry(`retrying ${attempt + 2}/${MAX_ATTEMPTS}`);
+      await sleep(retryDelay(attempt, res.headers.get("retry-after")));
+    } catch (e) {
+      if (last) throw e instanceof Error ? e : new Error(String(e));
+      onRetry(`retrying ${attempt + 2}/${MAX_ATTEMPTS}`);
+      await sleep(retryDelay(attempt, null));
+    }
+  }
+}
 
 const SECTIONS: Array<{
   kind: MediaKind;
@@ -61,12 +148,22 @@ const SECTIONS: Array<{
 // Community media gallery + uploader. Uploads go in 8MB chunks (the chunk
 // route resumes on 409), so even long captures pass the proxy body limit.
 // Gating here is cosmetic: the routes re-check the wiki session server-side.
+//
+// A finished file is drawn from the row the upload itself returned, not from a
+// re-render of the page. The build page is ISR-cached and served by either app
+// slot, so waiting on a refresh to see your own upload is a race the uploader
+// used to lose often enough that a hard reload was the reliable way to see it.
 export default function MediaSection({ sha256, items, skips }: Props) {
   const router = useRouter();
   const [viewer, setViewer] = useState<Viewer | null>(null);
   const [uploads, setUploads] = useState<Upload[]>([]);
+  const [added, setAdded] = useState<BuildMediaView[]>([]);
   const [note, setNote] = useState("");
   const nextKey = useRef(1);
+  const queue = useRef<Job[]>([]);
+  const failed = useRef(new Map<number, Job>());
+  const running = useRef(0);
+  const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -79,47 +176,129 @@ export default function MediaSection({ sha256, items, skips }: Props) {
     };
   }, []);
 
+  useEffect(() => () => void (refreshTimer.current && clearTimeout(refreshTimer.current)), []);
+
   const loggedIn = !!viewer?.name || !!viewer?.moderator;
 
   const patchUpload = (key: number, patch: Partial<Upload>) =>
     setUploads((u) => u.map((x) => (x.key === key ? { ...x, ...patch } : x)));
 
-  async function uploadFile(file: File, kind: MediaKind) {
-    const key = nextKey.current++;
-    setUploads((u) => [...u, { key, label: file.name, pct: 0 }]);
-    try {
-      const create = await fetch(`/api/build/${sha256}/media/upload`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ kind, filename: file.name, size: file.size }),
+  function scheduleRefresh() {
+    if (refreshTimer.current) clearTimeout(refreshTimer.current);
+    refreshTimer.current = setTimeout(() => {
+      refreshTimer.current = null;
+      router.refresh();
+    }, REFRESH_DEBOUNCE_MS);
+  }
+
+  function enqueue(jobs: Job[]) {
+    queue.current.push(...jobs);
+    pump();
+  }
+
+  function pump() {
+    while (running.current < CONCURRENCY && queue.current.length > 0) {
+      const job = queue.current.shift()!;
+      running.current++;
+      patchUpload(job.key, { queued: false });
+      void runJob(job).finally(() => {
+        running.current--;
+        pump();
       });
-      const cj = await create.json().catch(() => ({}));
-      if (!create.ok) throw new Error(cj.error ?? create.statusText);
+    }
+  }
+
+  async function runJob(job: Job) {
+    const { key, file, kind } = job;
+    const onRetry = (retry: string) => patchUpload(key, { retry });
+    try {
+      let token = job.token;
+      if (!token) {
+        // A create that succeeded but whose reply was lost is retried here and
+        // opens a second session. The orphan holds no bytes and the reaper
+        // clears it. Losing the file instead would be the worse trade.
+        const create = await sendWithRetry(
+          `/api/build/${sha256}/media/upload`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ kind, filename: file.name, size: file.size }),
+          },
+          onRetry
+        );
+        const cj = await create.json().catch(() => ({}));
+        if (!create.ok) throw new UploadError(cj.error ?? create.statusText, create.status >= 500);
+        token = cj.token as string;
+        job.token = token; // a later retry resumes this session
+      }
 
       let offset = 0;
       let stalls = 0;
+      let media: BuildMediaView | undefined;
       for (;;) {
+        patchUpload(key, { retry: undefined });
         const end = Math.min(offset + CHUNK, file.size);
-        const res = await fetch(`/api/build/${sha256}/media/upload/${cj.token}?offset=${offset}`, {
-          method: "PUT",
-          body: file.slice(offset, end),
-        });
+        const res = await sendWithRetry(
+          `/api/build/${sha256}/media/upload/${token}?offset=${offset}`,
+          { method: "PUT", body: file.slice(offset, end) },
+          onRetry
+        );
         const j = await res.json().catch(() => ({}));
         if (res.status === 409 && typeof j.offset === "number") {
-          if (++stalls > 3 && j.offset <= offset) throw new Error("upload stalled");
+          if (++stalls > MAX_STALLS) throw new UploadError("upload stalled", true);
           offset = j.offset;
+          patchUpload(key, { pct: offset / file.size });
           continue;
         }
-        if (!res.ok) throw new Error(j.error ?? res.statusText);
-        if (j.done) break;
+        if (!res.ok) {
+          // Resumable only if the session survived: a 4xx here is the server
+          // refusing the file itself, and it drops the session saying so.
+          throw new UploadError(j.error ?? res.statusText, res.status >= 500 || res.status === 429);
+        }
+        stalls = 0;
+        if (j.done) {
+          media = j.media as BuildMediaView | undefined;
+          break;
+        }
         offset = typeof j.offset === "number" ? j.offset : end;
         patchUpload(key, { pct: offset / file.size });
       }
+      // Finalised without a row: nothing to draw, and resuming is right, because
+      // the session replays its answer once it has one.
+      if (!media) throw new UploadError("upload finished without a record", true);
+
+      failed.current.delete(key);
       setUploads((u) => u.filter((x) => x.key !== key));
-      router.refresh();
+      setAdded((a) => (a.some((m) => m.id === media.id) ? a : [...a, media]));
+      scheduleRefresh();
     } catch (e) {
-      patchUpload(key, { error: e instanceof Error ? e.message : String(e) });
+      if (!(e instanceof UploadError) || e.resumable) failed.current.set(key, job);
+      patchUpload(key, { retry: undefined, error: e instanceof Error ? e.message : String(e) });
     }
+  }
+
+  function start(files: File[], kind: MediaKind) {
+    const jobs: Job[] = [];
+    const rows: Upload[] = [];
+    for (const file of files) {
+      const key = nextKey.current++;
+      if (file.size === 0) {
+        rows.push({ key, label: file.name, pct: 0, queued: false, error: "file is empty" });
+        continue;
+      }
+      jobs.push({ key, file, kind });
+      rows.push({ key, label: file.name, pct: 0, queued: true });
+    }
+    setUploads((u) => [...u, ...rows]);
+    enqueue(jobs);
+  }
+
+  function retryUpload(key: number) {
+    const job = failed.current.get(key);
+    if (!job) return;
+    failed.current.delete(key);
+    patchUpload(key, { error: undefined, retry: undefined, queued: true });
+    enqueue([job]);
   }
 
   async function remove(id: number) {
@@ -130,6 +309,7 @@ export default function MediaSection({ sha256, items, skips }: Props) {
       setNote(`Error: ${j.error ?? res.statusText}`);
       return;
     }
+    setAdded((a) => a.filter((m) => m.id !== id));
     router.refresh();
   }
 
@@ -145,10 +325,17 @@ export default function MediaSection({ sha256, items, skips }: Props) {
       setNote(`Error: ${j.error ?? res.statusText}`);
       return;
     }
+    setAdded((a) => a.map((m) => (m.id === id ? { ...m, label } : m)));
     router.refresh();
   }
 
-  const total = items.length;
+  // Server rows plus uploads this page finished that a refresh has not brought
+  // back yet (see the note on the component). Reconciled here rather than by an
+  // effect, so an item is never briefly in both lists or in neither.
+  const serverIds = new Set(items.map((m) => m.id));
+  const pending = added.filter((m) => !serverIds.has(m.id));
+  const shown = pending.length === 0 ? items : [...items, ...pending];
+  const total = shown.length;
   return (
     <section className="mt-8">
       <h2 className="text-lg font-medium">
@@ -159,7 +346,7 @@ export default function MediaSection({ sha256, items, skips }: Props) {
       )}
       <div className="mt-3 grid gap-8">
         {SECTIONS.map((s) => {
-          const mine = items.filter((m) => m.kind === s.kind);
+          const mine = shown.filter((m) => m.kind === s.kind);
           const skipped = skips[s.skipKey] && mine.length === 0;
           return (
             <div key={s.kind}>
@@ -170,7 +357,7 @@ export default function MediaSection({ sha256, items, skips }: Props) {
                     label={s.add}
                     accept={s.accept}
                     multiple={s.multiple}
-                    onFiles={(files) => files.forEach((f) => uploadFile(f, s.kind))}
+                    onFiles={(files) => start(files, s.kind)}
                   />
                 )}
               </div>
@@ -233,17 +420,32 @@ export default function MediaSection({ sha256, items, skips }: Props) {
               {u.error ? (
                 <>
                   <span className="text-red-500">{u.error}</span>
+                  {failed.current.has(u.key) && (
+                    <button
+                      onClick={() => retryUpload(u.key)}
+                      title="Resume from where it stopped"
+                      className="text-neutral-400 hover:text-neutral-600"
+                    >
+                      retry
+                    </button>
+                  )}
                   <button
-                    onClick={() => setUploads((x) => x.filter((y) => y.key !== u.key))}
+                    onClick={() => {
+                      failed.current.delete(u.key);
+                      setUploads((x) => x.filter((y) => y.key !== u.key));
+                    }}
                     className="text-neutral-400 hover:text-neutral-600"
                   >
                     dismiss
                   </button>
                 </>
+              ) : u.queued ? (
+                <span className="text-neutral-400">queued</span>
               ) : (
                 <>
                   <progress value={u.pct} max={1} className="h-1.5 w-40" />
                   <span className="tabular-nums">{Math.round(u.pct * 100)}%</span>
+                  {u.retry && <span className="text-amber-600 dark:text-amber-500">{u.retry}</span>}
                 </>
               )}
             </li>

--- a/hp-web/src/lib/contrib.ts
+++ b/hp-web/src/lib/contrib.ts
@@ -75,7 +75,9 @@ export async function contributionTarget(pool: Pool, sha256: string): Promise<Co
 }
 
 /** Surface a contribution on the ISR-cached build page right away, on every
- *  app slot (see lib/revalidate.ts). */
-export function revalidateBuildPages(sha256: string, name: string): void {
-  revalidateEverywhere([buildHref(sha256, name), `/builds/${sha256}`]);
+ *  app slot (see lib/revalidate.ts). Await the result before answering a
+ *  browser that will refresh the page on the reply, or its refresh can beat
+ *  the mirror to the sibling slot and render the pre-contribution page. */
+export function revalidateBuildPages(sha256: string, name: string): Promise<void> {
+  return revalidateEverywhere([buildHref(sha256, name), `/builds/${sha256}`]);
 }

--- a/hp-web/src/lib/media.ts
+++ b/hp-web/src/lib/media.ts
@@ -109,6 +109,13 @@ export interface MediaSession {
   label?: MediaLabel;
   /** Sniffed at the first chunk; absent until then. */
   contentType?: string;
+  /** Video poster blob, once extracted. Cached here so a finalize that has to
+   *  be retried does not run ffmpeg over the whole capture a second time. */
+  poster?: string | null;
+  /** Set once the row exists. The session outlives its payload in this state
+   *  so a client that never saw the reply can PUT again and be told the same
+   *  answer instead of a 404 for an upload that in fact succeeded. */
+  done?: BuildMediaView;
 }
 
 const SESSION_TTL_MS = 24 * 3600_000;
@@ -133,7 +140,7 @@ export async function createMediaSession(token: string, session: MediaSession): 
   const dir = path.join(assetStoreDir(), ".staging");
   await fsp.mkdir(dir, { recursive: true });
   await reapStaleSessions(dir).catch(() => {});
-  await fsp.writeFile(mediaSessionPath(token), JSON.stringify(session));
+  await updateMediaSession(token, session);
   await fsp.writeFile(mediaStagingPath(token), Buffer.alloc(0));
 }
 
@@ -145,13 +152,55 @@ export async function readMediaSession(token: string): Promise<MediaSession | nu
   }
 }
 
+/** Replace the sidecar. Written to a temp name and renamed, so a process that
+ *  dies mid-write leaves the previous session rather than truncated JSON that
+ *  reads back as "no such upload session". */
 export async function updateMediaSession(token: string, session: MediaSession): Promise<void> {
-  await fsp.writeFile(mediaSessionPath(token), JSON.stringify(session));
+  const dest = mediaSessionPath(token);
+  const tmp = `${dest}.tmp${process.pid}`;
+  await fsp.writeFile(tmp, JSON.stringify(session));
+  await fsp.rename(tmp, dest);
 }
 
 export async function dropMediaSession(token: string): Promise<void> {
   await fsp.rm(mediaSessionPath(token), { force: true });
   await fsp.rm(mediaStagingPath(token), { force: true });
+}
+
+/** Retire a finished session: drop the payload, keep the sidecar carrying the
+ *  row it produced. A duplicate PUT (the client timed out, or a proxy ate the
+ *  reply) then replays that answer instead of 404-ing an upload that worked.
+ *  The reaper clears the sidecar a day later. */
+export async function finishMediaSession(
+  token: string,
+  session: MediaSession,
+  media: BuildMediaView
+): Promise<void> {
+  await updateMediaSession(token, { ...session, done: media });
+  await fsp.rm(mediaStagingPath(token), { force: true });
+}
+
+// One in-flight request per token, so a retry that arrives while the request
+// it is retrying is still running waits instead of appending over it (two
+// appends at the same offset both pass the stat check and corrupt the file).
+// Chunks for one token are pinned to one slot by the front door, so a
+// per-process lock is the whole story (see deploy/nginx.conf).
+const sessionLocks = new Map<string, Promise<unknown>>();
+
+export function withMediaSession<T>(token: string, fn: () => Promise<T>): Promise<T> {
+  const prev = sessionLocks.get(token) ?? Promise.resolve();
+  // Runs whichever way the one in front settled: a failed request must not
+  // wedge the token for everything queued behind it.
+  const run = prev.then(fn, fn);
+  const gate: Promise<void> = run.then(
+    () => {},
+    () => {}
+  );
+  sessionLocks.set(token, gate);
+  void gate.then(() => {
+    if (sessionLocks.get(token) === gate) sessionLocks.delete(token);
+  });
+  return run;
 }
 
 async function reapStaleSessions(dir: string): Promise<void> {

--- a/hp-web/src/lib/revalidate.ts
+++ b/hp-web/src/lib/revalidate.ts
@@ -74,24 +74,31 @@ export function peerRevalidateRequest(
  * Revalidate these paths and tags on this process and on the sibling slot.
  * Pass `mirror: false` when already handling a mirrored request, so two slots
  * cannot bounce one bust back and forth.
+ *
+ * The local bust is synchronous. The returned promise settles when the mirror
+ * has landed. Ignoring it keeps the old fire-and-forget behaviour, which is
+ * what a bulk mutation wants. Await it when the caller is about to tell a
+ * browser "done" and that browser will immediately re-fetch the page: the
+ * refresh is load-balanced across both slots, so returning before the mirror
+ * lands is a live race against serving the stale page back. It never rejects.
  */
 export function revalidateEverywhere(
   paths: Iterable<string>,
   tags: Iterable<string> = [],
   opts: { mirror?: boolean } = {}
-): void {
+): Promise<void> {
   const p = [...new Set(paths)];
   const t = [...new Set(tags)];
   for (const path of p) revalidatePath(path);
   for (const tag of t) revalidateTag(tag, "max");
 
-  if (opts.mirror === false) return;
+  if (opts.mirror === false) return Promise.resolve();
   const req = peerRevalidateRequest(p, t);
-  if (!req) return;
-  // Fire and forget: the mutation this follows has already succeeded, and a
-  // sibling that cannot be reached right now is a stale page for a while, not
-  // a failed request for the caller. Logged so it is not silent.
-  void fetch(req.url, req.init).then(
+  if (!req) return Promise.resolve();
+  // A sibling that cannot be reached right now is a stale page for a while,
+  // not a failed request for the caller, so this resolves either way. Logged
+  // so it is not silent.
+  return fetch(req.url, req.init).then(
     (r) => {
       if (!r.ok) console.warn(`peer revalidate: ${req.url} -> ${r.status}`);
     },

--- a/hp-web/tests/media.test.ts
+++ b/hp-web/tests/media.test.ts
@@ -1,6 +1,24 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { inferMediaLabel, isMediaKind, isMediaLabel, sniffMedia } from "../src/lib/media";
+import { existsSync } from "node:fs";
+import { mkdtemp, readdir, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createMediaSession,
+  dropMediaSession,
+  finishMediaSession,
+  inferMediaLabel,
+  isMediaKind,
+  isMediaLabel,
+  mediaStagingPath,
+  readMediaSession,
+  sniffMedia,
+  updateMediaSession,
+  withMediaSession,
+  type BuildMediaView,
+  type MediaSession,
+} from "../src/lib/media";
 
 test("inferMediaLabel reads the front/back convention out of filenames", () => {
   assert.equal(inferMediaLabel("Earthworm Jim Front.png"), "front");
@@ -35,4 +53,118 @@ test("sniffMedia identifies the accepted containers by magic bytes", () => {
   const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0]);
   assert.deepEqual(sniffMedia(jpeg), { contentType: "image/jpeg", video: false });
   assert.equal(sniffMedia(Buffer.from("not an image at all!")), null);
+});
+
+// ── upload sessions ──────────────────────────────────────────────────────────
+// The store dir is read per call, so pointing the env at a temp dir scopes
+// every session path in these tests to it.
+
+async function tempStore(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "media-test-"));
+  process.env.ASSET_STORE_DIR = dir;
+  return dir;
+}
+
+const TOKEN = "0".repeat(32);
+
+const SESSION: MediaSession = {
+  build: "ab".repeat(32),
+  kind: "physical",
+  filename: "Front.png",
+  size: 12,
+  author: "someone",
+};
+
+const ROW = { id: 7, sha256: "cd".repeat(32), filename: "Front.png" } as BuildMediaView;
+
+test("a new session round-trips and stages an empty payload", async () => {
+  await tempStore();
+  await createMediaSession(TOKEN, SESSION);
+  assert.deepEqual(await readMediaSession(TOKEN), SESSION);
+  assert.equal((await stat(mediaStagingPath(TOKEN))).size, 0);
+});
+
+test("readMediaSession answers null for a token that was never opened", async () => {
+  await tempStore();
+  assert.equal(await readMediaSession(TOKEN), null);
+});
+
+test("updateMediaSession leaves no temp file behind", async () => {
+  const dir = await tempStore();
+  await createMediaSession(TOKEN, SESSION);
+  await updateMediaSession(TOKEN, { ...SESSION, contentType: "image/png" });
+
+  assert.equal((await readMediaSession(TOKEN))?.contentType, "image/png");
+  const staging = await readdir(join(dir, ".staging"));
+  assert.deepEqual(
+    staging.filter((n) => n.includes(".tmp")),
+    []
+  );
+});
+
+test("a finished session drops its payload but replays the row it produced", async () => {
+  await tempStore();
+  await createMediaSession(TOKEN, SESSION);
+  await writeFile(mediaStagingPath(TOKEN), Buffer.alloc(SESSION.size));
+
+  await finishMediaSession(TOKEN, SESSION, ROW);
+
+  // This is what makes a duplicate PUT safe: the bytes are gone, but the
+  // session still knows the answer, so a client whose reply went missing is
+  // told the upload worked instead of 404'd for a file that is on the site.
+  assert.equal(existsSync(mediaStagingPath(TOKEN)), false);
+  assert.deepEqual((await readMediaSession(TOKEN))?.done, ROW);
+});
+
+test("dropMediaSession removes both halves", async () => {
+  await tempStore();
+  await createMediaSession(TOKEN, SESSION);
+  await dropMediaSession(TOKEN);
+  assert.equal(await readMediaSession(TOKEN), null);
+  assert.equal(existsSync(mediaStagingPath(TOKEN)), false);
+});
+
+test("withMediaSession runs one request per token at a time", async () => {
+  const order: string[] = [];
+  const slow = async (name: string, ms: number) => {
+    order.push(`${name}:start`);
+    await new Promise((r) => setTimeout(r, ms));
+    order.push(`${name}:end`);
+  };
+
+  await Promise.all([
+    withMediaSession(TOKEN, () => slow("a", 20)),
+    withMediaSession(TOKEN, () => slow("b", 1)),
+  ]);
+
+  // Not a:start, b:start, b:end, a:end. The second waits out the first, so
+  // two appends can never both pass the same offset check.
+  assert.deepEqual(order, ["a:start", "a:end", "b:start", "b:end"]);
+});
+
+test("withMediaSession lets a different token run concurrently", async () => {
+  const other = "1".repeat(32);
+  const order: string[] = [];
+  await Promise.all([
+    withMediaSession(TOKEN, async () => {
+      order.push("a:start");
+      await new Promise((r) => setTimeout(r, 20));
+      order.push("a:end");
+    }),
+    withMediaSession(other, async () => {
+      order.push("b:start");
+      order.push("b:end");
+    }),
+  ]);
+  assert.deepEqual(order, ["a:start", "b:start", "b:end", "a:end"]);
+});
+
+test("withMediaSession is not wedged by a request that threw", async () => {
+  await assert.rejects(
+    withMediaSession(TOKEN, () => Promise.reject(new Error("boom"))),
+    /boom/
+  );
+  // A failed chunk must not take the token down with it: the retry that
+  // rescues the upload is the very next request on it.
+  assert.equal(await withMediaSession(TOKEN, () => Promise.resolve("ok")), "ok");
 });


### PR DESCRIPTION
Uploading several files at once was flaky because the client started every selected file at the same time and never retried anything, so one dropped connection or a slot restarting mid-deploy lost that file outright. Uploads now run three at a time with backoff retries, every step of the chunk protocol is safe to repeat, and a file that still fails gets a retry button that resumes from the offset the server already holds.

Finishing an upload also used to drop the session before writing the row, so a lost reply looked like a failure for a file that was in fact already on the site. The session now keeps the row it produced and replays it, finished files render from the upload's own response instead of racing a cache refresh across both slots, and the per hour upload cap goes from 60 to 240.