### PR TITLE
Open build media in a gallery lightbox

### DIFF
--- a/hp-web/src/app/api/media/[sha256]/route.ts
+++ b/hp-web/src/app/api/media/[sha256]/route.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from "next/server";
 import { blobSize, openBlobStream } from "@/lib/blobstore";
 import { getPool } from "@/lib/db";
-import { IMMUTABLE_CACHE, SANDBOX_CSP, streamResponse } from "@/lib/http";
-import { MEDIA_NS, mediaContentType } from "@/lib/media";
+import { contentDisposition, IMMUTABLE_CACHE, SANDBOX_CSP, streamResponse } from "@/lib/http";
+import { MEDIA_NS, mediaBlobInfo } from "@/lib/media";
 import { parseRange } from "@/lib/range";
 import { isSha256 } from "@/lib/validate";
 
@@ -26,8 +26,9 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   const { sha256 } = await ctx.params;
   if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
 
-  const contentType = await mediaContentType(getPool(), sha256);
-  if (!contentType) return Response.json({ error: "not found" }, { status: 404 });
+  const info = await mediaBlobInfo(getPool(), sha256);
+  if (!info) return Response.json({ error: "not found" }, { status: 404 });
+  const { contentType } = info;
 
   if (request.headers.get("if-none-match") === `"${sha256}-media"`) {
     return new Response(null, { status: 304, headers: { "Cache-Control": IMMUTABLE_CACHE, ETag: `"${sha256}-media"` } });
@@ -36,9 +37,14 @@ export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256:
   const size = await blobSize(sha256, MEDIA_NS);
   if (size == null) return Response.json({ error: "blob missing from store" }, { status: 404 });
 
+  // Saving from here keeps the uploader's own filename. The pages draw media
+  // from the bucket gateway, which only knows the hash, so this route is what
+  // the viewer's Download link points at.
+  const name = info.filename || `${sha256.slice(0, 12)}.${EXT[contentType] ?? "bin"}`;
+
   const headers: Record<string, string> = {
     "Content-Type": contentType,
-    "Content-Disposition": `inline; filename="${sha256.slice(0, 12)}.${EXT[contentType] ?? "bin"}"`,
+    "Content-Disposition": contentDisposition(name, true),
     "Cache-Control": IMMUTABLE_CACHE,
     ETag: `"${sha256}-media"`,
     "X-Content-Type-Options": "nosniff",

--- a/hp-web/src/app/builds/[buildId]/MediaSection.tsx
+++ b/hp-web/src/app/builds/[buildId]/MediaSection.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { BuildMediaView, MediaKind, MediaLabel, SkipFlags } from "@/lib/media";
+import { MediaThumb, useMedia } from "./MediaViewerHost";
 
 interface Viewer {
   name?: string;
@@ -32,7 +33,6 @@ interface Job {
 
 interface Props {
   sha256: string;
-  items: BuildMediaView[];
   skips: SkipFlags;
 }
 
@@ -153,11 +153,12 @@ const SECTIONS: Array<{
 // re-render of the page. The build page is ISR-cached and served by either app
 // slot, so waiting on a refresh to see your own upload is a race the uploader
 // used to lose often enough that a hard reload was the reliable way to see it.
-export default function MediaSection({ sha256, items, skips }: Props) {
+// That reconciliation lives in MediaViewerHost, which owns the list this draws.
+export default function MediaSection({ sha256, skips }: Props) {
   const router = useRouter();
+  const { items, open, add, drop, patch } = useMedia();
   const [viewer, setViewer] = useState<Viewer | null>(null);
   const [uploads, setUploads] = useState<Upload[]>([]);
-  const [added, setAdded] = useState<BuildMediaView[]>([]);
   const [note, setNote] = useState("");
   const nextKey = useRef(1);
   const queue = useRef<Job[]>([]);
@@ -269,7 +270,7 @@ export default function MediaSection({ sha256, items, skips }: Props) {
 
       failed.current.delete(key);
       setUploads((u) => u.filter((x) => x.key !== key));
-      setAdded((a) => (a.some((m) => m.id === media.id) ? a : [...a, media]));
+      add(media);
       scheduleRefresh();
     } catch (e) {
       if (!(e instanceof UploadError) || e.resumable) failed.current.set(key, job);
@@ -309,7 +310,7 @@ export default function MediaSection({ sha256, items, skips }: Props) {
       setNote(`Error: ${j.error ?? res.statusText}`);
       return;
     }
-    setAdded((a) => a.filter((m) => m.id !== id));
+    drop(id);
     router.refresh();
   }
 
@@ -325,17 +326,11 @@ export default function MediaSection({ sha256, items, skips }: Props) {
       setNote(`Error: ${j.error ?? res.statusText}`);
       return;
     }
-    setAdded((a) => a.map((m) => (m.id === id ? { ...m, label } : m)));
+    patch(id, { label });
     router.refresh();
   }
 
-  // Server rows plus uploads this page finished that a refresh has not brought
-  // back yet (see the note on the component). Reconciled here rather than by an
-  // effect, so an item is never briefly in both lists or in neither.
-  const serverIds = new Set(items.map((m) => m.id));
-  const pending = added.filter((m) => !serverIds.has(m.id));
-  const shown = pending.length === 0 ? items : [...items, ...pending];
-  const total = shown.length;
+  const total = items.length;
   return (
     <section className="mt-8">
       <h2 className="text-lg font-medium">
@@ -346,7 +341,7 @@ export default function MediaSection({ sha256, items, skips }: Props) {
       )}
       <div className="mt-3 grid gap-8">
         {SECTIONS.map((s) => {
-          const mine = shown.filter((m) => m.kind === s.kind);
+          const mine = items.filter((m) => m.kind === s.kind);
           const skipped = skips[s.skipKey] && mine.length === 0;
           return (
             <div key={s.kind}>
@@ -378,6 +373,15 @@ export default function MediaSection({ sha256, items, skips }: Props) {
                         src={m.url}
                         className="max-h-80 w-full rounded-md border border-neutral-200 bg-black dark:border-neutral-800"
                       />
+                      {/* The player takes the clicks here, so it is the filename
+                          that opens the gallery (same as the asset cards). */}
+                      <button
+                        onClick={() => open(m.id)}
+                        title={m.filename}
+                        className="mt-1 block w-0 min-w-full truncate text-left font-mono text-[11px] text-sky-700 hover:underline dark:text-sky-400"
+                      >
+                        {m.filename}
+                      </button>
                       <Caption item={m} viewer={viewer} onDelete={() => remove(m.id)} />
                     </figure>
                   ))}
@@ -386,18 +390,15 @@ export default function MediaSection({ sha256, items, skips }: Props) {
                 <div className="mt-2 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
                   {mine.map((m) => (
                     <figure key={m.id}>
-                      <a href={m.url} target="_blank" rel="noreferrer">
-                        {/* Physical photos are multi-MB scans; draw the cell from the
-                            server-scaled thumb (2x the cell, lanczos) instead of making
-                            the browser downsample the original. */}
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img
-                          src={s.kind === "physical" ? `/api/media/${m.sha256}/thumb?w=500` : m.url}
-                          alt={m.filename}
-                          loading="lazy"
-                          className={`${s.kind === "physical" ? "aspect-square" : "h-36"} w-full rounded-md border border-neutral-200 object-cover dark:border-neutral-800`}
-                        />
-                      </a>
+                      {/* Physical photos are multi-MB scans; the cell draws from
+                          the server-scaled thumb (2x the cell, lanczos) and the
+                          full image loads only once the gallery opens it. */}
+                      <MediaThumb
+                        item={m}
+                        width={s.kind === "physical" ? 500 : undefined}
+                        wrapClassName="block w-full"
+                        className={`${s.kind === "physical" ? "aspect-square" : "h-36"} w-full rounded-md border border-neutral-200 object-cover hover:border-sky-400 dark:border-neutral-800 dark:hover:border-sky-600`}
+                      />
                       <Caption
                         item={m}
                         viewer={viewer}

--- a/hp-web/src/app/builds/[buildId]/MediaViewer.tsx
+++ b/hp-web/src/app/builds/[buildId]/MediaViewer.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+// Lightbox over a build's community media — the media-side counterpart of
+// AssetViewer. ← → step through the gallery, Esc closes. Photos get the same
+// zoom/pan viewport as image assets (a disc scan is many times the size of its
+// grid cell); video plays inline over its poster.
+
+import { useEffect, useState } from "react";
+import { humanSize } from "@/lib/format";
+import type { BuildMediaView } from "@/lib/media";
+import ZoomPan from "./ZoomPan";
+
+/** Where the Download link points. Pages draw media from the public bucket
+ *  gateway, which serves every blob under its hash with no extension; this
+ *  route streams the same bytes under the name the file was uploaded as. */
+function mediaDownloadUrl(item: BuildMediaView): string {
+  return `/api/media/${item.sha256}`;
+}
+
+// The probe <img> measures the natural size ZoomPan needs for its fit scale;
+// the blob is immutable and hard-cached, so the visible <img> re-uses the
+// fetched bytes.
+function ImageBody({ item }: { item: BuildMediaView }) {
+  const [failed, setFailed] = useState(false);
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
+  if (failed) {
+    return <p className="p-6 text-sm text-red-500">Failed to load media.</p>;
+  }
+  if (!size) {
+    return (
+      <>
+        <p className="p-6 text-sm text-neutral-400">Loading…</p>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={item.url}
+          alt=""
+          className="hidden"
+          onLoad={(e) =>
+            setSize({ width: e.currentTarget.naturalWidth || 1, height: e.currentTarget.naturalHeight || 1 })
+          }
+          onError={() => setFailed(true)}
+        />
+      </>
+    );
+  }
+  return (
+    <div className="relative h-[75vh] w-[min(85rem,92vw)]">
+      <ZoomPan contentSize={size} className="h-full w-full rounded bg-neutral-900">
+        {(scale) => (
+          // Not next/image: blobs are content-addressed, immutable, and served
+          // with hard cache headers, so optimization would only re-encode them.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={item.url}
+            alt={item.filename}
+            draggable={false}
+            className="h-full w-full"
+            // Screenshots read pixel-crisp when magnified past 1:1.
+            style={{ imageRendering: scale > 1 ? "pixelated" : "auto" }}
+          />
+        )}
+      </ZoomPan>
+    </div>
+  );
+}
+
+function Body({ item }: { item: BuildMediaView }) {
+  const [failed, setFailed] = useState(false);
+  if (failed) {
+    return <p className="p-6 text-sm text-red-500">Failed to load media.</p>;
+  }
+  // Uploads are sniffed to MP4/WebM and PNG/JPEG/GIF/WebP (sniffMedia), so
+  // there is nothing here the browser cannot play or draw itself.
+  if (item.kind === "video") {
+    return (
+      <video
+        controls
+        preload="metadata"
+        poster={item.posterUrl ?? undefined}
+        src={item.url}
+        title={item.filename}
+        className="max-h-[75vh] max-w-[90vw] rounded bg-black"
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+  return <ImageBody item={item} />;
+}
+
+export default function MediaViewer({
+  items,
+  index,
+  onClose,
+  onNavigate,
+}: {
+  items: BuildMediaView[];
+  index: number;
+  onClose: () => void;
+  onNavigate: (index: number) => void;
+}) {
+  const item = items[index];
+  const prev = () => onNavigate((index - 1 + items.length) % items.length);
+  const next = () => onNavigate((index + 1) % items.length);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+      else if (e.key === "ArrowLeft") prev();
+      else if (e.key === "ArrowRight") next();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
+
+  // The overlay owns the viewport while open; keep the page from scrolling under it.
+  useEffect(() => {
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex flex-col bg-black/70 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Media viewer: ${item.filename}`}
+    >
+      <div
+        className="flex items-center gap-3 bg-neutral-950/80 px-4 py-2 text-sm text-neutral-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <span className="min-w-0 flex-1 truncate font-mono" title={item.filename}>
+          {item.filename}
+        </span>
+        <span className="hidden shrink-0 text-xs text-neutral-400 sm:inline">
+          by {item.author} · {item.created_at.slice(0, 10)}
+        </span>
+        <span className="shrink-0 text-xs text-neutral-400">
+          {humanSize(item.size)} · {item.content_type}
+        </span>
+        <a
+          href={mediaDownloadUrl(item)}
+          download={item.filename}
+          className="shrink-0 text-xs text-neutral-300 hover:text-white hover:underline"
+        >
+          Download
+        </a>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="shrink-0 rounded px-2 py-0.5 text-neutral-300 hover:bg-neutral-800 hover:text-white"
+        >
+          &times;
+        </button>
+      </div>
+
+      <div className="flex min-h-0 flex-1 items-center justify-center gap-2 p-4">
+        {items.length > 1 && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              prev();
+            }}
+            aria-label="Previous item"
+            className="shrink-0 rounded-full bg-neutral-900/70 px-3 py-2 text-lg text-neutral-300 hover:bg-neutral-800 hover:text-white"
+          >
+            &lsaquo;
+          </button>
+        )}
+        {/* Remount per item so per-file load state never bleeds across navigation. */}
+        <div className="flex min-w-0 items-center justify-center" onClick={(e) => e.stopPropagation()}>
+          <Body key={item.id} item={item} />
+        </div>
+        {items.length > 1 && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              next();
+            }}
+            aria-label="Next item"
+            className="shrink-0 rounded-full bg-neutral-900/70 px-3 py-2 text-lg text-neutral-300 hover:bg-neutral-800 hover:text-white"
+          >
+            &rsaquo;
+          </button>
+        )}
+      </div>
+
+      {items.length > 1 && (
+        <div className="pb-3 text-center text-xs text-neutral-400" onClick={(e) => e.stopPropagation()}>
+          {index + 1} / {items.length}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hp-web/src/app/builds/[buildId]/MediaViewerHost.tsx
+++ b/hp-web/src/app/builds/[buildId]/MediaViewerHost.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+// Single per-page owner of the community-media lightbox, mirroring
+// AssetViewerHost: anything that shows a media thumbnail (the header identity
+// photo, the media grid) opens it through this context. The open item is
+// reflected in the URL fragment (#media-<id>), so a photo is linkable and Back
+// closes the viewer. pushState/replaceState are shallow, so opening one never
+// refetches the page.
+//
+// The host also owns the item list. Uploads finish faster than the ISR-cached
+// build page comes back with them, so a finished row is adopted here and shows
+// in the grid (and in the viewer's sequence) until a refresh brings it around.
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import type { BuildMediaView } from "@/lib/media";
+import MediaViewer from "./MediaViewer";
+
+// The order the gallery steps through, matching how MediaSection lays its
+// sections out. Hardcoded rather than imported from lib/media, whose value
+// exports drag node builtins into the client bundle.
+const KIND_ORDER = ["screenshot", "video", "physical"];
+
+const HASH_PREFIX = "#media-";
+
+interface MediaContext {
+  /** Every media item on the page, in gallery order. */
+  items: BuildMediaView[];
+  /** Open the lightbox on one item; an id that is no longer on the page shows
+   *  nothing (a link to a since-deleted photo). */
+  open: (id: number) => void;
+  /** Adopt a row this page just uploaded. */
+  add: (item: BuildMediaView) => void;
+  /** Forget an adopted row (deleted before the refresh landed). */
+  drop: (id: number) => void;
+  /** Update an adopted row in place, e.g. its physical-photo label. */
+  patch: (id: number, fields: Partial<BuildMediaView>) => void;
+}
+
+const Ctx = createContext<MediaContext | null>(null);
+
+/** The page's media list and lightbox. Only valid under a MediaViewerHost. */
+export function useMedia(): MediaContext {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error("useMedia() outside a MediaViewerHost");
+  return ctx;
+}
+
+/** Id in a URL fragment, or null when no item is deep-linked there. */
+function hashId(hash: string): number | null {
+  if (!hash.startsWith(HASH_PREFIX)) return null;
+  const id = Number(hash.slice(HASH_PREFIX.length));
+  return Number.isInteger(id) ? id : null;
+}
+
+// Which item is open is read from the fragment rather than mirrored into
+// state, so a deep link, a Back press and a thumbnail click all arrive the same
+// way. History writes notify no one, so open/navigate/close ping subscribers
+// themselves; the server snapshot is empty, and the first client render after
+// hydration is what opens an incoming deep link.
+const listeners = new Set<() => void>();
+
+function subscribeToHash(onChange: () => void): () => void {
+  listeners.add(onChange);
+  window.addEventListener("popstate", onChange);
+  window.addEventListener("hashchange", onChange);
+  return () => {
+    listeners.delete(onChange);
+    window.removeEventListener("popstate", onChange);
+    window.removeEventListener("hashchange", onChange);
+  };
+}
+
+function writeHistory(write: () => void) {
+  write();
+  for (const l of listeners) l();
+}
+
+export default function MediaViewerHost({
+  items: server,
+  children,
+}: {
+  /** The build's media as the server rendered it. */
+  items: BuildMediaView[];
+  children: React.ReactNode;
+}) {
+  const [extra, setExtra] = useState<BuildMediaView[]>([]);
+  // The open item, by id rather than index: an upload that finishes while the
+  // viewer is open would otherwise slide the sequence under it.
+  const hash = useSyncExternalStore(subscribeToHash, () => window.location.hash, () => "");
+  const viewing = hashId(hash);
+  // Whether the open viewer owes the current history entry to open() — close()
+  // then rewinds with back(); a deep-linked viewer has no entry of ours to pop
+  // and rewrites the URL in place instead.
+  const pushed = useRef(false);
+
+  const items = useMemo(() => {
+    const fromServer = new Set(server.map((m) => m.id));
+    const all = [...server, ...extra.filter((m) => !fromServer.has(m.id))];
+    // Stable, so each kind keeps the server's own order (oldest first).
+    return all.sort((a, b) => KIND_ORDER.indexOf(a.kind) - KIND_ORDER.indexOf(b.kind));
+  }, [server, extra]);
+
+  const open = useCallback((id: number) => {
+    writeHistory(() => window.history.pushState(null, "", `${HASH_PREFIX}${id}`));
+    pushed.current = true;
+  }, []);
+
+  const add = useCallback(
+    (item: BuildMediaView) => setExtra((a) => (a.some((m) => m.id === item.id) ? a : [...a, item])),
+    []
+  );
+  const drop = useCallback((id: number) => setExtra((a) => a.filter((m) => m.id !== id)), []);
+  const patch = useCallback(
+    (id: number, fields: Partial<BuildMediaView>) =>
+      setExtra((a) => a.map((m) => (m.id === id ? { ...m, ...fields } : m))),
+    []
+  );
+
+  const navigate = useCallback(
+    (i: number) => {
+      const item = items[i];
+      if (!item) return;
+      writeHistory(() => window.history.replaceState(null, "", `${HASH_PREFIX}${item.id}`));
+    },
+    [items]
+  );
+
+  const close = useCallback(() => {
+    if (pushed.current) {
+      pushed.current = false;
+      // Rewinds to the entry before the viewer opened; popstate then reports
+      // the fragment-free URL and closes it.
+      window.history.back();
+    } else {
+      const { pathname, search } = window.location;
+      writeHistory(() => window.history.replaceState(null, "", `${pathname}${search}`));
+    }
+  }, []);
+
+  const index = viewing === null ? -1 : items.findIndex((m) => m.id === viewing);
+  const value = useMemo(() => ({ items, open, add, drop, patch }), [items, open, add, drop, patch]);
+
+  return (
+    <Ctx.Provider value={value}>
+      {children}
+      {index >= 0 && <MediaViewer items={items} index={index} onClose={close} onNavigate={navigate} />}
+    </Ctx.Provider>
+  );
+}
+
+/** A media thumbnail that opens the gallery instead of navigating to the blob
+ *  (which the bucket gateway serves under its hash, with no extension). */
+export function MediaThumb({
+  item,
+  className,
+  wrapClassName = "block",
+  width,
+}: {
+  item: BuildMediaView;
+  /** Classes for the image itself. */
+  className?: string;
+  /** Classes for the button around it, where the cell's own sizing goes. */
+  wrapClassName?: string;
+  /** Server-scaled thumb width; the original is drawn when unset. */
+  width?: 500 | 1000;
+}) {
+  const { open } = useMedia();
+  return (
+    <button onClick={() => open(item.id)} title={item.filename} className={wrapClassName}>
+      {/* Photos are multi-MB scans: draw the cell from the server-scaled thumb
+          (lanczos) instead of making the browser downsample the original. */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={width ? `/api/media/${item.sha256}/thumb?w=${width}` : item.url}
+        alt={item.filename}
+        loading="lazy"
+        className={className}
+      />
+    </button>
+  );
+}

--- a/hp-web/src/app/builds/[buildId]/page.tsx
+++ b/hp-web/src/app/builds/[buildId]/page.tsx
@@ -18,6 +18,7 @@ import FileTree from "./FileTree";
 import AssetGallery from "./AssetGallery";
 import AssetViewerHost from "./AssetViewerHost";
 import MediaSection from "./MediaSection";
+import MediaViewerHost, { MediaThumb } from "./MediaViewerHost";
 import ModeratorTools from "./ModeratorTools";
 import NotesSection from "./NotesSection";
 
@@ -178,6 +179,9 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
       {/* One lightbox for the whole page (gallery + file tree); it rewrites the
           URL to <href>/assets/<path> while an asset is open. */}
       <AssetViewerHost assets={assets} buildHref={href} returnHref={href}>
+      {/* Its media counterpart: the header photo and the media grid open the
+          same gallery, deep-linked as #media-<id>. */}
+      <MediaViewerHost items={mediaItems}>
       <Link href="/builds" className="text-sm text-neutral-500 hover:underline">&larr; All builds</Link>
 
       {/* Header block with the photo as a right column: flush with the title,
@@ -230,14 +234,12 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
       </dl>
       </div>
       {previewPhoto && (
-        <a href={previewPhoto.url} target="_blank" rel="noreferrer" className="shrink-0" title={previewPhoto.filename}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={`/api/media/${previewPhoto.sha256}/thumb?w=500`}
-            alt={previewPhoto.filename}
-            className="h-44 w-44 rounded-md border border-neutral-200 object-cover dark:border-neutral-800"
-          />
-        </a>
+        <MediaThumb
+          item={previewPhoto}
+          width={500}
+          wrapClassName="block shrink-0"
+          className="h-44 w-44 rounded-md border border-neutral-200 object-cover hover:border-sky-400 dark:border-neutral-800 dark:hover:border-sky-600"
+        />
       )}
       </div>
 
@@ -323,7 +325,7 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
         </section>
       )}
 
-      <MediaSection sha256={sha256} items={mediaItems} skips={skips} />
+      <MediaSection sha256={sha256} skips={skips} />
 
       <NotesSection sha256={sha256} notes={notes} skipped={skips.skip_notes} />
 
@@ -333,6 +335,7 @@ export default async function BuildPage({ params }: { params: Promise<{ buildId:
         </h2>
         <FileTree sha256={sha256} roots={pruneToExpanded(tree, expanded)} initiallyExpanded={[...expanded]} assets={assets} />
       </section>
+      </MediaViewerHost>
       </AssetViewerHost>
     </main>
   );

--- a/hp-web/src/lib/media.ts
+++ b/hp-web/src/lib/media.ts
@@ -353,16 +353,26 @@ export async function deleteMedia(pool: Pool, buildSha: string, id: number): Pro
   return !!r.rowCount;
 }
 
-/** Look up the served content type of a media blob (or a video's poster). */
-export async function mediaContentType(pool: Pool, sha256: string): Promise<string | null> {
+/** Look up how a media blob is served: its content type, and the name it was
+ *  uploaded under (null for a video's generated poster). */
+export async function mediaBlobInfo(
+  pool: Pool,
+  sha256: string
+): Promise<{ contentType: string; filename: string | null } | null> {
   const r = await pool.query(
-    `SELECT content_type FROM build_media WHERE sha256=$1
+    `SELECT content_type, filename FROM build_media WHERE sha256=$1
      UNION ALL
-     SELECT 'image/jpeg' FROM build_media WHERE poster_sha256=$1
+     SELECT 'image/jpeg', NULL::text FROM build_media WHERE poster_sha256=$1
      LIMIT 1`,
     [sha256]
   );
-  return (r.rows[0]?.content_type as string) ?? null;
+  const row = r.rows[0];
+  return row ? { contentType: row.content_type as string, filename: (row.filename as string) ?? null } : null;
+}
+
+/** Look up the served content type of a media blob (or a video's poster). */
+export async function mediaContentType(pool: Pool, sha256: string): Promise<string | null> {
+  return (await mediaBlobInfo(pool, sha256))?.contentType ?? null;
 }
 
 export async function getBuildNotes(pool: Pool, buildSha: string): Promise<BuildNoteRow[]> {


### PR DESCRIPTION
Media thumbnails linked straight at the blob, which the bucket gateway serves under its hash with no extension, so clicking a screenshot or a disc scan downloaded a nameless file instead of showing it. They now open a lightbox alongside the asset one: arrow keys step through every screenshot, video and photo on the build, Esc closes, photos get the same zoom and pan viewport, and the header identity shot opens it too.

The open item lives in the URL fragment (#media-<id>), so a photo is linkable and Back closes the viewer. A new MediaViewerHost owns the item list that MediaSection used to keep for itself, which is what lets a just-finished upload appear in the gallery before the page refreshes. Downloads point at /api/media/<sha256>, which now sends the filename the file was uploaded under.