### PR TITLE
Magazine metadata index

### DIFF
--- a/hp-web/db/migrations/012-magazines.sql
+++ b/hp-web/db/migrations/012-magazines.sql
@@ -1,0 +1,195 @@
+-- Gaming magazine metadata: normalized magazines and issues, page renders,
+-- per-section extracts with bounding boxes, entity links (games via the shared
+-- games table, people/personas, systems, tags), and a moderation audit trail.
+--
+-- The whole magazine family is ingested through the moderator API and then
+-- moderated in place, so on the production server it is PROD-ONLY DATA with
+-- the same never-wipe rules as build_media (see 006-user-media.sql): never
+-- drop, truncate, or reload from a local dump; schema changes stay additive.
+--
+-- Conventions:
+--   extract.kind is app-validated (src/lib/mag/kinds.ts), not a CHECK, so new
+--   kinds are one array edit. extract.status: auto|amended|rejected —
+--   'auto' rows are machine output and may be replaced by re-ingest;
+--   amended/rejected rows are moderator data and must survive re-ingest.
+--   Region coordinates are normalized 0-1 floats over the rendered page,
+--   origin top-left. Blob keys live under the mag/ namespace.
+--
+-- Idempotent, safe to re-run. Apply to every prism DB:
+--   psql -d <db> -f db/migrations/012-magazines.sql
+
+CREATE TABLE IF NOT EXISTS magazines (
+    id           BIGSERIAL PRIMARY KEY,
+    slug         TEXT NOT NULL UNIQUE,
+    title        TEXT NOT NULL,
+    aliases      TEXT[] NOT NULL DEFAULT '{}',
+    country      TEXT NOT NULL DEFAULT '',
+    language     TEXT NOT NULL DEFAULT '',       -- dominant content language, bcp47
+    publisher    TEXT NOT NULL DEFAULT '',
+    pages_public BOOLEAN NOT NULL DEFAULT TRUE,  -- full page renders public (crops are always public)
+    notes        TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS magazine_issue (
+    id            BIGSERIAL PRIMARY KEY,
+    magazine_id   BIGINT NOT NULL REFERENCES magazines(id),
+    slug          TEXT NOT NULL,                 -- per-magazine token: "022", "1991-08", "01"
+    label         TEXT NOT NULL,                 -- display: "Issue 22", "1991年8月号", "Ano 1 Nº 1"
+    volume        TEXT,
+    number        TEXT,
+    whole_number  TEXT,                          -- JP 通巻 etc.
+    cover_date    DATE,
+    cover_date_precision TEXT CHECK (cover_date_precision IN ('day','month','year')),
+    price_raw     TEXT,                          -- verbatim, all currencies
+    publisher_raw TEXT,                          -- as printed in this issue
+    page_count    INT,
+    binding       TEXT NOT NULL DEFAULT 'ltr' CHECK (binding IN ('ltr','rtl')),
+    pdf_sha256    TEXT,                          -- source PDF blob (mag/ ns); moderator-only, never public
+    pdf_size      BIGINT,
+    source_url    TEXT,                          -- provenance (manifest.tsv)
+    supplements   JSONB NOT NULL DEFAULT '[]',   -- advertised furoku: [{title, present}]
+    status        TEXT NOT NULL DEFAULT 'new',   -- new|rendering|extracted|reviewed (convention)
+    notes         TEXT NOT NULL DEFAULT '',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (magazine_id, slug)
+);
+
+CREATE TABLE IF NOT EXISTS magazine_page (
+    id            BIGSERIAL PRIMARY KEY,
+    issue_id      BIGINT NOT NULL REFERENCES magazine_issue(id) ON DELETE CASCADE,
+    pdf_index     INT NOT NULL,                  -- 1-based page in the source PDF
+    printed_label TEXT,                          -- "4", "supp:6"; NULL = unnumbered
+    width         INT,                           -- render pixels
+    height        INT,
+    image_sha256  TEXT,                          -- page render (mag/ ns); NULL until rendered
+    rendered_at   TIMESTAMPTZ,
+    UNIQUE (issue_id, pdf_index)
+);
+
+-- One extract = one addressable unit: a capsule review, a tip, a letter, an
+-- ad. Verbatim transcription (printed errors preserved) lives here; canonical
+-- identity lives in the link tables. Kind-specific structure (score grids,
+-- chart entries, ad products...) is app-validated JSONB in data.
+CREATE TABLE IF NOT EXISTS magazine_extract (
+    id              BIGSERIAL PRIMARY KEY,
+    issue_id        BIGINT NOT NULL REFERENCES magazine_issue(id) ON DELETE CASCADE,
+    kind            TEXT NOT NULL,               -- src/lib/mag/kinds.ts
+    section         TEXT,                        -- branded recurring section as printed ("Review Crew")
+    seq             INT NOT NULL DEFAULT 0,      -- reading order within the issue
+    title           TEXT,
+    language        TEXT NOT NULL DEFAULT '',    -- bcp47 of the original text
+    text_original   TEXT NOT NULL DEFAULT '',
+    text_en         TEXT,                        -- NULL for English originals (UI falls back)
+    translation     TEXT CHECK (translation IN ('machine','human')),
+    summary_en      TEXT,                        -- 1-2 English sentences for cards/snippets
+    data            JSONB NOT NULL DEFAULT '{}',
+    is_fictional    BOOLEAN NOT NULL DEFAULT FALSE,
+    sponsored       BOOLEAN NOT NULL DEFAULT FALSE,
+    content_warning TEXT,
+    client_key      TEXT,                        -- ingest idempotency key (skill-chosen)
+    status          TEXT NOT NULL DEFAULT 'auto', -- auto|amended|rejected (convention)
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mag_extract_client_key
+    ON magazine_extract(issue_id, client_key) WHERE client_key IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mag_extract_issue   ON magazine_extract(issue_id);
+CREATE INDEX IF NOT EXISTS idx_mag_extract_kind    ON magazine_extract(kind);
+CREATE INDEX IF NOT EXISTS idx_mag_extract_status  ON magazine_extract(status) WHERE status <> 'auto';
+-- Search: FTS over the original ('simple' — config-neutral) and the English
+-- side; trigram carries substring/exact matching, which is also the only
+-- effective path for CJK text ('simple' cannot tokenize it).
+CREATE INDEX IF NOT EXISTS idx_mag_extract_fts_orig ON magazine_extract
+    USING gin (to_tsvector('simple', coalesce(title,'') || ' ' || text_original));
+CREATE INDEX IF NOT EXISTS idx_mag_extract_fts_en ON magazine_extract
+    USING gin (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(text_en,'') || ' ' || coalesce(summary_en,'')));
+CREATE INDEX IF NOT EXISTS idx_mag_extract_trgm_orig ON magazine_extract
+    USING gin (text_original gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_mag_extract_trgm_en ON magazine_extract
+    USING gin (text_en gin_trgm_ops);
+
+-- Where an extract sits on the page(s): 1..N ordered rectangles (spread ads,
+-- articles continuing across pages, interleaved campaigns).
+CREATE TABLE IF NOT EXISTS extract_region (
+    id          BIGSERIAL PRIMARY KEY,
+    extract_id  BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    page_id     BIGINT NOT NULL REFERENCES magazine_page(id) ON DELETE CASCADE,
+    seq         INT NOT NULL DEFAULT 0,
+    x           REAL NOT NULL,
+    y           REAL NOT NULL,
+    w           REAL NOT NULL,
+    h           REAL NOT NULL,
+    crop_sha256 TEXT,                            -- png crop (mag/ ns); NULL until cropped
+    UNIQUE (extract_id, seq)
+);
+CREATE INDEX IF NOT EXISTS idx_extract_region_page ON extract_region(page_id);
+
+-- People, pseudonymous personas (Sushi-X, Quartermann, 超人バロムI), and
+-- organizations-as-author (U.S. National Video Game Team). Printed reader
+-- names are NOT entity-ized (they stay in extract text/data only).
+CREATE TABLE IF NOT EXISTS people (
+    id            BIGSERIAL PRIMARY KEY,
+    slug          TEXT NOT NULL UNIQUE,
+    name          TEXT NOT NULL,
+    name_original TEXT,                          -- native-script form
+    kind          TEXT NOT NULL DEFAULT 'person' CHECK (kind IN ('person','persona','organization')),
+    aliases       TEXT[] NOT NULL DEFAULT '{}',
+    notes         TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS extract_person (
+    extract_id BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    person_id  BIGINT NOT NULL REFERENCES people(id),
+    role       TEXT NOT NULL DEFAULT 'mentioned', -- interviewee|interviewer|author|artist|subject|mentioned|reviewer
+    PRIMARY KEY (extract_id, person_id, role)
+);
+CREATE INDEX IF NOT EXISTS idx_extract_person_person ON extract_person(person_id);
+
+-- Links into the SHARED games table (upsert by (name, system) like builds):
+-- a game page shows its builds and its magazine coverage. title_printed keeps
+-- the as-printed variant ("PSYCHIC WORLDS") next to the canonical link.
+CREATE TABLE IF NOT EXISTS extract_game (
+    extract_id    BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    game_id       BIGINT NOT NULL REFERENCES games(id),
+    role          TEXT NOT NULL DEFAULT 'subject', -- subject|mentioned|listed
+    title_printed TEXT,
+    PRIMARY KEY (extract_id, game_id)
+);
+CREATE INDEX IF NOT EXISTS idx_extract_game_game ON extract_game(game_id);
+
+CREATE TABLE IF NOT EXISTS extract_system (
+    extract_id BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    system     TEXT NOT NULL,                    -- canonical prism system string
+    PRIMARY KEY (extract_id, system)
+);
+CREATE INDEX IF NOT EXISTS idx_extract_system_system ON extract_system(system);
+
+-- Companies, events, hardware, series, topics — everything searchable that is
+-- not a game, person, or system.
+CREATE TABLE IF NOT EXISTS mag_tag (
+    id   BIGSERIAL PRIMARY KEY,
+    slug TEXT NOT NULL UNIQUE,
+    kind TEXT NOT NULL DEFAULT 'topic' CHECK (kind IN ('company','event','hardware','series','topic')),
+    name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS extract_tag (
+    extract_id BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    tag_id     BIGINT NOT NULL REFERENCES mag_tag(id),
+    PRIMARY KEY (extract_id, tag_id)
+);
+CREATE INDEX IF NOT EXISTS idx_extract_tag_tag ON extract_tag(tag_id);
+
+-- Moderation audit trail: one row per amend/reject/restore, field patches as
+-- {field: [old, new]}. The extract row carries the current state; this table
+-- carries who changed what, when.
+CREATE TABLE IF NOT EXISTS extract_revision (
+    id         BIGSERIAL PRIMARY KEY,
+    extract_id BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    editor     TEXT NOT NULL,                    -- wiki username, or "token"
+    change     JSONB NOT NULL,
+    note       TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_extract_revision_extract ON extract_revision(extract_id, id DESC);

--- a/hp-web/db/schema.sql
+++ b/hp-web/db/schema.sql
@@ -287,3 +287,188 @@ CREATE TABLE build_duplicate (
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE (build_sha256, name)
 );
+
+-- ── gaming magazine metadata ─────────────────────────────────────────────────
+-- Normalized magazines/issues, page renders, per-section extracts with
+-- bounding boxes, entity links, and a moderation audit trail (migration 012).
+-- Ingested through the moderator API and then moderated in place: PROD-ONLY
+-- DATA on the production server, same never-wipe rules as build_media.
+-- extract.kind is app-validated (src/lib/mag/kinds.ts); extract.status is
+-- auto|amended|rejected — re-ingest may only replace 'auto' rows. Region
+-- coordinates are normalized 0-1 over the rendered page, origin top-left.
+-- Blob keys (page renders, crops, source PDFs) live under the mag/ namespace;
+-- source PDFs are moderator-only, never public.
+
+CREATE TABLE magazines (
+    id           BIGSERIAL PRIMARY KEY,
+    slug         TEXT NOT NULL UNIQUE,
+    title        TEXT NOT NULL,
+    aliases      TEXT[] NOT NULL DEFAULT '{}',
+    country      TEXT NOT NULL DEFAULT '',
+    language     TEXT NOT NULL DEFAULT '',       -- dominant content language, bcp47
+    publisher    TEXT NOT NULL DEFAULT '',
+    pages_public BOOLEAN NOT NULL DEFAULT TRUE,  -- full page renders public (crops are always public)
+    notes        TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE magazine_issue (
+    id            BIGSERIAL PRIMARY KEY,
+    magazine_id   BIGINT NOT NULL REFERENCES magazines(id),
+    slug          TEXT NOT NULL,                 -- per-magazine token: "022", "1991-08", "01"
+    label         TEXT NOT NULL,                 -- display: "Issue 22", "1991年8月号", "Ano 1 Nº 1"
+    volume        TEXT,
+    number        TEXT,
+    whole_number  TEXT,                          -- JP 通巻 etc.
+    cover_date    DATE,
+    cover_date_precision TEXT CHECK (cover_date_precision IN ('day','month','year')),
+    price_raw     TEXT,                          -- verbatim, all currencies
+    publisher_raw TEXT,                          -- as printed in this issue
+    page_count    INT,
+    binding       TEXT NOT NULL DEFAULT 'ltr' CHECK (binding IN ('ltr','rtl')),
+    pdf_sha256    TEXT,                          -- source PDF blob (mag/ ns); moderator-only
+    pdf_size      BIGINT,
+    source_url    TEXT,                          -- provenance (manifest.tsv)
+    supplements   JSONB NOT NULL DEFAULT '[]',   -- advertised furoku: [{title, present}]
+    status        TEXT NOT NULL DEFAULT 'new',   -- new|rendering|extracted|reviewed (convention)
+    notes         TEXT NOT NULL DEFAULT '',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (magazine_id, slug)
+);
+
+CREATE TABLE magazine_page (
+    id            BIGSERIAL PRIMARY KEY,
+    issue_id      BIGINT NOT NULL REFERENCES magazine_issue(id) ON DELETE CASCADE,
+    pdf_index     INT NOT NULL,                  -- 1-based page in the source PDF
+    printed_label TEXT,                          -- "4", "supp:6"; NULL = unnumbered
+    width         INT,                           -- render pixels
+    height        INT,
+    image_sha256  TEXT,                          -- page render (mag/ ns); NULL until rendered
+    rendered_at   TIMESTAMPTZ,
+    UNIQUE (issue_id, pdf_index)
+);
+
+-- One extract = one addressable unit: a capsule review, a tip, a letter, an
+-- ad. Verbatim transcription (printed errors preserved) lives here; canonical
+-- identity lives in the link tables. Kind-specific structure (score grids,
+-- chart entries, ad products...) is app-validated JSONB in data.
+CREATE TABLE magazine_extract (
+    id              BIGSERIAL PRIMARY KEY,
+    issue_id        BIGINT NOT NULL REFERENCES magazine_issue(id) ON DELETE CASCADE,
+    kind            TEXT NOT NULL,               -- src/lib/mag/kinds.ts
+    section         TEXT,                        -- branded recurring section as printed ("Review Crew")
+    seq             INT NOT NULL DEFAULT 0,      -- reading order within the issue
+    title           TEXT,
+    language        TEXT NOT NULL DEFAULT '',    -- bcp47 of the original text
+    text_original   TEXT NOT NULL DEFAULT '',
+    text_en         TEXT,                        -- NULL for English originals (UI falls back)
+    translation     TEXT CHECK (translation IN ('machine','human')),
+    summary_en      TEXT,                        -- 1-2 English sentences for cards/snippets
+    data            JSONB NOT NULL DEFAULT '{}',
+    is_fictional    BOOLEAN NOT NULL DEFAULT FALSE,
+    sponsored       BOOLEAN NOT NULL DEFAULT FALSE,
+    content_warning TEXT,
+    client_key      TEXT,                        -- ingest idempotency key (skill-chosen)
+    status          TEXT NOT NULL DEFAULT 'auto', -- auto|amended|rejected (convention)
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX idx_mag_extract_client_key
+    ON magazine_extract(issue_id, client_key) WHERE client_key IS NOT NULL;
+CREATE INDEX idx_mag_extract_issue   ON magazine_extract(issue_id);
+CREATE INDEX idx_mag_extract_kind    ON magazine_extract(kind);
+CREATE INDEX idx_mag_extract_status  ON magazine_extract(status) WHERE status <> 'auto';
+-- FTS over the original ('simple') and English sides; trigram carries
+-- substring/exact matching and is the only effective path for CJK.
+CREATE INDEX idx_mag_extract_fts_orig ON magazine_extract
+    USING gin (to_tsvector('simple', coalesce(title,'') || ' ' || text_original));
+CREATE INDEX idx_mag_extract_fts_en ON magazine_extract
+    USING gin (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(text_en,'') || ' ' || coalesce(summary_en,'')));
+CREATE INDEX idx_mag_extract_trgm_orig ON magazine_extract
+    USING gin (text_original gin_trgm_ops);
+CREATE INDEX idx_mag_extract_trgm_en ON magazine_extract
+    USING gin (text_en gin_trgm_ops);
+
+-- Where an extract sits on the page(s): 1..N ordered rectangles (spread ads,
+-- articles continuing across pages, interleaved campaigns).
+CREATE TABLE extract_region (
+    id          BIGSERIAL PRIMARY KEY,
+    extract_id  BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    page_id     BIGINT NOT NULL REFERENCES magazine_page(id) ON DELETE CASCADE,
+    seq         INT NOT NULL DEFAULT 0,
+    x           REAL NOT NULL,
+    y           REAL NOT NULL,
+    w           REAL NOT NULL,
+    h           REAL NOT NULL,
+    crop_sha256 TEXT,                            -- png crop (mag/ ns); NULL until cropped
+    UNIQUE (extract_id, seq)
+);
+CREATE INDEX idx_extract_region_page ON extract_region(page_id);
+
+-- People, pseudonymous personas (Sushi-X, Quartermann), and organizations-as-
+-- author. Printed reader names are NOT entity-ized (text/data only).
+CREATE TABLE people (
+    id            BIGSERIAL PRIMARY KEY,
+    slug          TEXT NOT NULL UNIQUE,
+    name          TEXT NOT NULL,
+    name_original TEXT,                          -- native-script form
+    kind          TEXT NOT NULL DEFAULT 'person' CHECK (kind IN ('person','persona','organization')),
+    aliases       TEXT[] NOT NULL DEFAULT '{}',
+    notes         TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE extract_person (
+    extract_id BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    person_id  BIGINT NOT NULL REFERENCES people(id),
+    role       TEXT NOT NULL DEFAULT 'mentioned', -- interviewee|interviewer|author|artist|subject|mentioned|reviewer
+    PRIMARY KEY (extract_id, person_id, role)
+);
+CREATE INDEX idx_extract_person_person ON extract_person(person_id);
+
+-- Links into the SHARED games table (upsert by (name, system) like builds):
+-- a game page shows its builds and its magazine coverage. title_printed keeps
+-- the as-printed variant ("PSYCHIC WORLDS") next to the canonical link.
+CREATE TABLE extract_game (
+    extract_id    BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    game_id       BIGINT NOT NULL REFERENCES games(id),
+    role          TEXT NOT NULL DEFAULT 'subject', -- subject|mentioned|listed
+    title_printed TEXT,
+    PRIMARY KEY (extract_id, game_id)
+);
+CREATE INDEX idx_extract_game_game ON extract_game(game_id);
+
+CREATE TABLE extract_system (
+    extract_id BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    system     TEXT NOT NULL,                    -- canonical prism system string
+    PRIMARY KEY (extract_id, system)
+);
+CREATE INDEX idx_extract_system_system ON extract_system(system);
+
+-- Companies, events, hardware, series, topics — searchable non-game,
+-- non-person, non-system entities.
+CREATE TABLE mag_tag (
+    id   BIGSERIAL PRIMARY KEY,
+    slug TEXT NOT NULL UNIQUE,
+    kind TEXT NOT NULL DEFAULT 'topic' CHECK (kind IN ('company','event','hardware','series','topic')),
+    name TEXT NOT NULL
+);
+
+CREATE TABLE extract_tag (
+    extract_id BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    tag_id     BIGINT NOT NULL REFERENCES mag_tag(id),
+    PRIMARY KEY (extract_id, tag_id)
+);
+CREATE INDEX idx_extract_tag_tag ON extract_tag(tag_id);
+
+-- Moderation audit trail: one row per amend/reject/restore, field patches as
+-- {field: [old, new]}. The extract row carries the current state; this table
+-- carries who changed what, when.
+CREATE TABLE extract_revision (
+    id         BIGSERIAL PRIMARY KEY,
+    extract_id BIGINT NOT NULL REFERENCES magazine_extract(id) ON DELETE CASCADE,
+    editor     TEXT NOT NULL,                    -- wiki username, or "token"
+    change     JSONB NOT NULL,
+    note       TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_extract_revision_extract ON extract_revision(extract_id, id DESC);

--- a/hp-web/deploy/nginx.conf
+++ b/hp-web/deploy/nginx.conf
@@ -71,6 +71,10 @@ http {
     default                                                   $uri;
     "~^/api/asset/([0-9a-f]{64})"                             $1;
     "~^/api/build/[0-9a-f]{64}/media/upload/([A-Za-z0-9_-]+)" $1;
+    # One magazine issue = one slot: PDF chunk appends serialize per process,
+    # and the render job (in-process, lib/mag/store.ts) is visible to the
+    # status polls that would otherwise land on the idle slot.
+    "~^/api/mag/issues/([0-9]+)"                              mag-$1;
   }
 
   # Keepalive to the slots needs an empty Connection header and a WebSocket
@@ -131,7 +135,7 @@ http {
       return 200 "ok\n";
     }
 
-    location ~ "^/api/(asset/[0-9a-f]{64}|build/[0-9a-f]{64}/media/upload)/" {
+    location ~ "^/api/(asset/[0-9a-f]{64}|build/[0-9a-f]{64}/media/upload|mag/issues/[0-9]+)/" {
       proxy_pass http://app_pinned;
     }
 

--- a/hp-web/src/app/api/mag/blob/[sha256]/route.ts
+++ b/hp-web/src/app/api/mag/blob/[sha256]/route.ts
@@ -1,0 +1,63 @@
+import type { NextRequest } from "next/server";
+import { blobSize, openBlobStream } from "@/lib/blobstore";
+import { IMMUTABLE_CACHE, SANDBOX_CSP, streamResponse } from "@/lib/http";
+import { MAG_NS, magImageUrl } from "@/lib/mag/store";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// GET /api/mag/blob/<sha256> — one magazine image blob (page render or
+// crop). With a public gateway configured this 307s there (same contract as
+// /api/asset); without one it streams from the local store. Serves images
+// only: the mag/ namespace also holds source PDFs, which are moderator-only
+// and refuse to leave through this route.
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+
+  const size = await blobSize(sha256, MAG_NS);
+  if (size === null) return Response.json({ error: "not found" }, { status: 404 });
+
+  const contentType = sniffImage(await headOf(sha256));
+  if (!contentType) return Response.json({ error: "not an image" }, { status: 415 });
+
+  const gateway = process.env.ASSET_PUBLIC_BASE;
+  if (gateway) {
+    // 307 + bounded cache, never 308 (see /api/asset: a cached permanent
+    // redirect stranded browsers when the gateway moved hosts).
+    return new Response(null, {
+      status: 307,
+      headers: { Location: magImageUrl(sha256), "Cache-Control": "public, max-age=3600" },
+    });
+  }
+
+  const etag = `"${sha256}-mag"`;
+  if (request.headers.get("if-none-match") === etag) {
+    return new Response(null, { status: 304, headers: { "Cache-Control": IMMUTABLE_CACHE, ETag: etag } });
+  }
+  const stream = await openBlobStream(sha256, undefined, MAG_NS);
+  if (!stream) return Response.json({ error: "not found" }, { status: 404 });
+  return streamResponse(stream, size, null, {
+    "Content-Type": contentType,
+    "Cache-Control": IMMUTABLE_CACHE,
+    ETag: etag,
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": SANDBOX_CSP,
+  });
+}
+
+async function headOf(sha256: string): Promise<Buffer | null> {
+  const stream = await openBlobStream(sha256, { start: 0, end: 15 }, MAG_NS);
+  if (!stream) return null;
+  const chunks: Buffer[] = [];
+  for await (const c of stream) chunks.push(Buffer.from(c));
+  return Buffer.concat(chunks);
+}
+
+function sniffImage(head: Buffer | null): string | null {
+  if (!head || head.length < 4) return null;
+  if (head[0] === 0x89 && head[1] === 0x50 && head[2] === 0x4e && head[3] === 0x47) return "image/png";
+  if (head[0] === 0xff && head[1] === 0xd8 && head[2] === 0xff) return "image/jpeg";
+  return null;
+}

--- a/hp-web/src/app/api/mag/blob/[sha256]/thumb/route.ts
+++ b/hp-web/src/app/api/mag/blob/[sha256]/thumb/route.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import type { NextRequest } from "next/server";
+import { ensurePhotoScale, isPhotoScaleWidth } from "@/lib/ffmpeg";
+import { IMMUTABLE_CACHE, SANDBOX_CSP, streamResponse } from "@/lib/http";
+import { MAG_NS } from "@/lib/mag/store";
+import { isSha256 } from "@/lib/validate";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// GET /api/mag/blob/<sha256>/thumb?w=<500|1000> — scaled JPEG of a magazine
+// page render or crop, from the shared ffmpeg photo-scale cache. Page strips
+// and extract cards draw hundreds of images; full renders are ~2200px.
+export async function GET(request: NextRequest, ctx: { params: Promise<{ sha256: string }> }) {
+  const { sha256 } = await ctx.params;
+  if (!isSha256(sha256)) return Response.json({ error: "invalid sha256" }, { status: 400 });
+  const wParam = request.nextUrl.searchParams.get("w");
+  const width = wParam === null ? 500 : Number(wParam);
+  if (!isPhotoScaleWidth(width)) return Response.json({ error: "w must be 500 or 1000" }, { status: 400 });
+
+  const etag = `"${sha256}-magthumb-${width}"`;
+  if (request.headers.get("if-none-match") === etag) {
+    return new Response(null, { status: 304, headers: { "Cache-Control": IMMUTABLE_CACHE, ETag: etag } });
+  }
+
+  let scaled: string;
+  try {
+    scaled = await ensurePhotoScale(sha256, MAG_NS, width);
+  } catch {
+    // No usable ffmpeg or missing blob — the original still renders.
+    return Response.redirect(new URL(`/api/mag/blob/${sha256}`, request.url), 307);
+  }
+  const stat = await fsp.stat(scaled);
+  return streamResponse(fs.createReadStream(scaled), stat.size, null, {
+    "Content-Type": "image/jpeg",
+    "Cache-Control": IMMUTABLE_CACHE,
+    ETag: etag,
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": SANDBOX_CSP,
+  });
+}

--- a/hp-web/src/app/api/mag/extracts/[id]/reject/route.ts
+++ b/hp-web/src/app/api/mag/extracts/[id]/reject/route.ts
@@ -1,0 +1,32 @@
+import type { NextRequest } from "next/server";
+import { getModerator, requireModerator } from "@/lib/auth";
+import { getPool } from "@/lib/db";
+import { setExtractRejected } from "@/lib/mag/queries";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// POST /api/mag/extracts/<id>/reject { rejected: true|false, note? } —
+// hide an extract from the public surface (or restore it). Restoring lands
+// on 'amended', not 'auto': a human vouched for it, so re-ingest must not
+// overwrite it anymore.
+export async function POST(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const denied = await requireModerator(request);
+  if (denied) return denied;
+  const raw = (await ctx.params).id;
+  if (!/^\d{1,10}$/.test(raw)) return Response.json({ error: "invalid extract id" }, { status: 400 });
+  const body = (await request.json().catch(() => null)) as { rejected?: unknown; note?: unknown } | null;
+  if (!body || typeof body.rejected !== "boolean") {
+    return Response.json({ error: "body must carry rejected: true|false" }, { status: 400 });
+  }
+  const mod = await getModerator(request);
+  const extract = await setExtractRejected(
+    getPool(),
+    parseInt(raw, 10),
+    body.rejected,
+    mod?.name ?? "token",
+    typeof body.note === "string" ? body.note.slice(0, 2000) : undefined
+  );
+  if (!extract) return Response.json({ error: "not found" }, { status: 404 });
+  return Response.json({ extract });
+}

--- a/hp-web/src/app/api/mag/extracts/[id]/route.ts
+++ b/hp-web/src/app/api/mag/extracts/[id]/route.ts
@@ -1,0 +1,95 @@
+import type { NextRequest } from "next/server";
+import { getModerator, requireModerator } from "@/lib/auth";
+import { getPool } from "@/lib/db";
+import { isExtractKind, normalizeLang } from "@/lib/mag/kinds";
+import {
+  AMENDABLE_FIELDS,
+  amendExtract,
+  getExtract,
+  listExtractRevisions,
+  type AmendableField,
+  type AmendPatch,
+} from "@/lib/mag/queries";
+import { ensureIssueAssets } from "@/lib/mag/store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// GET /api/mag/extracts/<id> — one extract with regions and links. Rejected
+// extracts are visible only to moderators (they stay in the DB as the audit
+// substrate, not on the public surface). ?revisions=1 adds the audit trail
+// (moderator only).
+export async function GET(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const raw = (await ctx.params).id;
+  if (!/^\d{1,10}$/.test(raw)) return Response.json({ error: "invalid extract id" }, { status: 400 });
+  const pool = getPool();
+  const extract = await getExtract(pool, parseInt(raw, 10));
+  if (!extract) return Response.json({ error: "not found" }, { status: 404 });
+  const mod = await getModerator(request);
+  if (extract.status === "rejected" && !mod) return Response.json({ error: "not found" }, { status: 404 });
+  if (mod && request.nextUrl.searchParams.get("revisions") === "1") {
+    const revisions = await listExtractRevisions(pool, extract.id);
+    return Response.json({ extract, revisions });
+  }
+  return Response.json({ extract });
+}
+
+// PATCH /api/mag/extracts/<id> — moderator amendment. Body: { fields?,
+// regions?, note? }. Every change lands in extract_revision; a bbox change
+// resets the affected crops and re-kicks the crop job.
+export async function PATCH(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const denied = await requireModerator(request);
+  if (denied) return denied;
+  const raw = (await ctx.params).id;
+  if (!/^\d{1,10}$/.test(raw)) return Response.json({ error: "invalid extract id" }, { status: 400 });
+  const id = parseInt(raw, 10);
+
+  const body = (await request.json().catch(() => null)) as AmendPatch | null;
+  if (!body || typeof body !== "object") return Response.json({ error: "invalid body" }, { status: 400 });
+
+  const patch: AmendPatch = { note: typeof body.note === "string" ? body.note.slice(0, 2000) : undefined };
+  if (body.fields) {
+    if (typeof body.fields !== "object") return Response.json({ error: "fields must be an object" }, { status: 400 });
+    patch.fields = {};
+    for (const [k, v] of Object.entries(body.fields)) {
+      if (!(AMENDABLE_FIELDS as readonly string[]).includes(k)) {
+        return Response.json({ error: `field not amendable: ${k}` }, { status: 400 });
+      }
+      patch.fields[k as AmendableField] = v;
+    }
+    if ("kind" in patch.fields && !isExtractKind(patch.fields.kind)) {
+      return Response.json({ error: `unknown kind: ${String(patch.fields.kind)}` }, { status: 400 });
+    }
+    if ("language" in patch.fields) {
+      const lang = normalizeLang(patch.fields.language);
+      if (!lang) return Response.json({ error: "language must be a bcp47 code" }, { status: 400 });
+      patch.fields.language = lang;
+    }
+  }
+  if (body.regions) {
+    if (
+      !Array.isArray(body.regions) ||
+      body.regions.length === 0 ||
+      body.regions.some(
+        (r) =>
+          typeof r !== "object" ||
+          !Number.isInteger(r.pdf_index) ||
+          r.pdf_index < 1 ||
+          [r.x, r.y, r.w, r.h].some((n) => typeof n !== "number" || !Number.isFinite(n) || n < 0 || n > 1)
+      )
+    ) {
+      return Response.json({ error: "regions must be [{pdf_index, x, y, w, h}] in 0..1" }, { status: 400 });
+    }
+    patch.regions = body.regions;
+  }
+  if (!patch.fields && !patch.regions) {
+    return Response.json({ error: "nothing to amend" }, { status: 400 });
+  }
+
+  const pool = getPool();
+  const mod = await getModerator(request);
+  const updated = await amendExtract(pool, id, patch, mod?.name ?? "token");
+  if (!updated) return Response.json({ error: "not found" }, { status: 404 });
+  if (patch.regions) ensureIssueAssets(pool, updated.issue_id);
+  return Response.json({ extract: updated });
+}

--- a/hp-web/src/app/api/mag/issues/[id]/extracts/route.ts
+++ b/hp-web/src/app/api/mag/issues/[id]/extracts/route.ts
@@ -1,0 +1,75 @@
+import type { NextRequest } from "next/server";
+import { requireModerator } from "@/lib/auth";
+import { getPool } from "@/lib/db";
+import { MAX_BATCH, validateExtractInput } from "@/lib/mag/kinds";
+import {
+  deleteAutoExtracts,
+  getIssueById,
+  ingestExtract,
+  setIssueStatus,
+  type IngestResult,
+} from "@/lib/mag/queries";
+import { ensureIssueAssets } from "@/lib/mag/store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// POST /api/mag/issues/<id>/extracts — ingest a batch of up to MAX_BATCH
+// extracts (moderator only). Each item validates independently and lands (or
+// fails) independently: one malformed capsule review must not sink the other
+// 49. Idempotent by (issue, client_key): re-posting updates 'auto' rows and
+// leaves moderated rows untouched (reported as skipped: "moderated").
+export async function POST(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const denied = await requireModerator(request);
+  if (denied) return denied;
+  const raw = (await ctx.params).id;
+  if (!/^\d{1,10}$/.test(raw)) return Response.json({ error: "invalid issue id" }, { status: 400 });
+  const id = parseInt(raw, 10);
+  const pool = getPool();
+  const issue = await getIssueById(pool, id);
+  if (!issue) return Response.json({ error: "no such issue" }, { status: 404 });
+
+  const body = await request.json().catch(() => null);
+  const list = Array.isArray(body) ? body : Array.isArray((body as { extracts?: unknown[] })?.extracts) ? (body as { extracts: unknown[] }).extracts : null;
+  if (!list) return Response.json({ error: "body must be an array of extracts" }, { status: 400 });
+  if (list.length === 0) return Response.json({ results: [] });
+  if (list.length > MAX_BATCH) {
+    return Response.json({ error: `batch too large (max ${MAX_BATCH})` }, { status: 413 });
+  }
+
+  const results: IngestResult[] = [];
+  for (const [i, item] of list.entries()) {
+    const v = validateExtractInput(item);
+    if (!v.ok) {
+      const key = (item as { client_key?: unknown })?.client_key;
+      results.push({
+        client_key: typeof key === "string" ? key : `#${i}`,
+        skipped: "error",
+        error: v.error,
+      });
+      continue;
+    }
+    results.push(await ingestExtract(pool, id, v.value));
+  }
+
+  if (results.some((r) => "id" in r)) {
+    if (issue.status === "new" || issue.status === "rendering") await setIssueStatus(pool, id, "extracted");
+    ensureIssueAssets(pool, id); // crop the new regions in the background
+  }
+  return Response.json({ results });
+}
+
+// DELETE /api/mag/issues/<id>/extracts?only=auto — reset for re-ingest.
+// The only=auto parameter is required on purpose: the route that deletes
+// must say out loud that it cannot touch moderated rows.
+export async function DELETE(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const denied = await requireModerator(request);
+  if (denied) return denied;
+  const raw = (await ctx.params).id;
+  if (!/^\d{1,10}$/.test(raw)) return Response.json({ error: "invalid issue id" }, { status: 400 });
+  if (request.nextUrl.searchParams.get("only") !== "auto") {
+    return Response.json({ error: "pass only=auto (moderated extracts are never deleted)" }, { status: 400 });
+  }
+  const deleted = await deleteAutoExtracts(getPool(), parseInt(raw, 10));
+  return Response.json({ deleted });
+}

--- a/hp-web/src/app/api/mag/issues/[id]/pdf/[token]/route.ts
+++ b/hp-web/src/app/api/mag/issues/[id]/pdf/[token]/route.ts
@@ -1,0 +1,99 @@
+import fsp from "node:fs/promises";
+import type { NextRequest } from "next/server";
+import { requireModerator } from "@/lib/auth";
+import { storeBlobFromFile } from "@/lib/blobstore";
+import { getPool } from "@/lib/db";
+import { hashFile, withMediaSession } from "@/lib/media";
+import { setIssuePdf } from "@/lib/mag/queries";
+import { ensureIssueAssets, MAG_NS } from "@/lib/mag/store";
+import {
+  dropMagSession,
+  finishMagSession,
+  isMagToken,
+  magStagingPath,
+  PDF_MAX_CHUNK,
+  readMagSession,
+} from "@/lib/mag/upload";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// PUT /api/mag/issues/<id>/pdf/<token>?offset=N — append one chunk of the
+// issue's source PDF; the build-media chunk protocol verbatim (409 with the
+// truth on a stale offset, replayable finalize, one request per token at a
+// time). The first chunk must be a PDF; completion hashes, stores under
+// mag/, records pdf_sha256 on the issue, and kicks the render job.
+export async function PUT(request: NextRequest, ctx: { params: Promise<{ id: string; token: string }> }) {
+  const denied = await requireModerator(request);
+  if (denied) return denied;
+  const { id: rawId, token } = await ctx.params;
+  if (!/^\d{1,10}$/.test(rawId)) return Response.json({ error: "invalid issue id" }, { status: 400 });
+  if (!isMagToken(token)) return Response.json({ error: "invalid token" }, { status: 400 });
+  const id = parseInt(rawId, 10);
+
+  const offset = Number(request.nextUrl.searchParams.get("offset") ?? "0");
+
+  // Advisory pre-check before pulling the body (see the media route for why).
+  const known = await readMagSession(token);
+  if (known && known.issue === id) {
+    if (known.done) return Response.json({ done: true, sha256: known.done.sha256 });
+    const st = await fsp.stat(magStagingPath(token)).catch(() => null);
+    if (st && st.size < known.size && offset !== st.size) {
+      return Response.json({ offset: st.size }, { status: 409 });
+    }
+  }
+
+  const declared = Number(request.headers.get("content-length") ?? "0");
+  if (declared > PDF_MAX_CHUNK) return Response.json({ error: "chunk too large" }, { status: 413 });
+  const chunk = Buffer.from(await request.arrayBuffer());
+
+  return withMediaSession(`magpdf-${token}`, () => append(id, token, chunk, offset));
+}
+
+async function append(id: number, token: string, chunk: Buffer, offset: number): Promise<Response> {
+  const session = await readMagSession(token);
+  if (!session || session.issue !== id) {
+    return Response.json({ error: "no such upload session" }, { status: 404 });
+  }
+  if (session.done) return Response.json({ done: true, sha256: session.done.sha256 });
+  const staging = magStagingPath(token);
+  const st = await fsp.stat(staging).catch(() => null);
+  if (!st) return Response.json({ error: "no such upload session" }, { status: 404 });
+  let staged = st.size;
+  if (staged > session.size) {
+    await dropMagSession(token);
+    return Response.json({ error: "corrupt upload session" }, { status: 400 });
+  }
+
+  if (staged < session.size) {
+    if (!Number.isInteger(offset) || offset < 0) {
+      return Response.json({ error: "invalid offset" }, { status: 400 });
+    }
+    if (offset !== staged) return Response.json({ offset: staged }, { status: 409 });
+    if (!chunk.length) return Response.json({ error: "empty chunk" }, { status: 400 });
+    if (chunk.length > PDF_MAX_CHUNK) return Response.json({ error: "chunk too large" }, { status: 413 });
+    if (staged + chunk.length > session.size) {
+      return Response.json({ error: "chunk exceeds the claimed size" }, { status: 400 });
+    }
+    if (staged === 0 && !chunk.subarray(0, 5).equals(Buffer.from("%PDF-"))) {
+      await dropMagSession(token);
+      return Response.json({ error: "not a pdf" }, { status: 415 });
+    }
+    await fsp.appendFile(staging, chunk);
+    staged = (await fsp.stat(staging)).size;
+    if (staged < session.size) return Response.json({ done: false, offset: staged });
+    if (staged > session.size) {
+      await dropMagSession(token);
+      return Response.json({ error: "corrupt upload session" }, { status: 400 });
+    }
+  }
+
+  // Complete (possibly a retried finalize): hash, store, record, kick render.
+  const sha256 = await hashFile(staging);
+  await storeBlobFromFile(sha256, staging, { ns: MAG_NS, keepSource: true });
+  const pool = getPool();
+  await setIssuePdf(pool, id, sha256, session.size);
+  await finishMagSession(token, session, sha256);
+  ensureIssueAssets(pool, id);
+  return Response.json({ done: true, sha256 });
+}

--- a/hp-web/src/app/api/mag/issues/[id]/pdf/route.ts
+++ b/hp-web/src/app/api/mag/issues/[id]/pdf/route.ts
@@ -1,0 +1,64 @@
+import type { NextRequest } from "next/server";
+import { requireModerator, getModerator } from "@/lib/auth";
+import { blobSize, openBlobStream } from "@/lib/blobstore";
+import { getPool } from "@/lib/db";
+import { PDF_CSP, streamResponse } from "@/lib/http";
+import { getIssueById } from "@/lib/mag/queries";
+import { MAG_NS } from "@/lib/mag/store";
+import { createMagSession, newMagToken, PDF_MAX_BYTES } from "@/lib/mag/upload";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function parseId(raw: string): number | null {
+  return /^\d{1,10}$/.test(raw) ? parseInt(raw, 10) : null;
+}
+
+// POST /api/mag/issues/<id>/pdf { size } -> { token }: open a chunked upload
+// session for the issue's source PDF (moderator only). Chunks go to
+// PUT /api/mag/issues/<id>/pdf/<token>?offset=N.
+export async function POST(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const denied = await requireModerator(request);
+  if (denied) return denied;
+  const id = parseId((await ctx.params).id);
+  if (id === null) return Response.json({ error: "invalid issue id" }, { status: 400 });
+  const pool = getPool();
+  const issue = await getIssueById(pool, id);
+  if (!issue) return Response.json({ error: "no such issue" }, { status: 404 });
+
+  const body = (await request.json().catch(() => null)) as { size?: unknown } | null;
+  const size = body?.size;
+  if (typeof size !== "number" || !Number.isInteger(size) || size <= 0) {
+    return Response.json({ error: "size (bytes) is required" }, { status: 400 });
+  }
+  if (size > PDF_MAX_BYTES) return Response.json({ error: "pdf too large" }, { status: 413 });
+
+  const mod = await getModerator(request);
+  const token = newMagToken();
+  await createMagSession(token, { issue: id, size, author: mod?.name ?? "token" });
+  return Response.json({ token });
+}
+
+// GET /api/mag/issues/<id>/pdf — the source PDF, moderator only. Issue PDFs
+// are never public: the public surface is page renders and crops.
+export async function GET(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const denied = await requireModerator(request);
+  if (denied) return denied;
+  const id = parseId((await ctx.params).id);
+  if (id === null) return Response.json({ error: "invalid issue id" }, { status: 400 });
+  const pool = getPool();
+  const issue = await getIssueById(pool, id);
+  if (!issue?.pdf_sha256) return Response.json({ error: "no pdf" }, { status: 404 });
+
+  const size = await blobSize(issue.pdf_sha256, MAG_NS);
+  const stream = size === null ? null : await openBlobStream(issue.pdf_sha256, undefined, MAG_NS);
+  if (size === null || !stream) return Response.json({ error: "pdf blob missing" }, { status: 404 });
+  const name = `${issue.magazine_slug}-${issue.slug}.pdf`;
+  return streamResponse(stream, size, null, {
+    "Content-Type": "application/pdf",
+    "Content-Disposition": `attachment; filename="${name}"`,
+    "Cache-Control": "private, no-store",
+    "X-Content-Type-Options": "nosniff",
+    "Content-Security-Policy": PDF_CSP,
+  });
+}

--- a/hp-web/src/app/api/mag/issues/[id]/status/route.ts
+++ b/hp-web/src/app/api/mag/issues/[id]/status/route.ts
@@ -1,0 +1,39 @@
+import type { NextRequest } from "next/server";
+import { getPool } from "@/lib/db";
+import { getIssueById } from "@/lib/mag/queries";
+import { ensureIssueAssets, issueAssetsPending, issueAssetStatus } from "@/lib/mag/store";
+import { clientKey, rateLimit } from "@/lib/ratelimit";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// GET /api/mag/issues/<id>/status — render/crop progress plus extract counts.
+// Public (the issue page shows a "rendering" note), and self-healing: when
+// work is pending and no job is running, polling restarts it — same contract
+// as the video transcode status route, so a server restart mid-render needs
+// nothing but the next poll.
+export async function GET(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  if (!rateLimit(`magstatus:${clientKey(request)}`, 120, 60_000)) {
+    return Response.json({ error: "rate limit exceeded" }, { status: 429 });
+  }
+  const raw = (await ctx.params).id;
+  if (!/^\d{1,10}$/.test(raw)) return Response.json({ error: "invalid issue id" }, { status: 400 });
+  const id = parseInt(raw, 10);
+  const pool = getPool();
+  const issue = await getIssueById(pool, id);
+  if (!issue) return Response.json({ error: "no such issue" }, { status: 404 });
+
+  if (await issueAssetsPending(pool, id)) ensureIssueAssets(pool, id);
+  const assets = await issueAssetStatus(pool, id);
+  const extracts = await pool.query(
+    `SELECT count(*)::int AS total,
+            count(*) FILTER (WHERE status='auto')::int AS auto,
+            count(*) FILTER (WHERE status='amended')::int AS amended,
+            count(*) FILTER (WHERE status='rejected')::int AS rejected
+     FROM magazine_extract WHERE issue_id=$1`,
+    [id]
+  );
+  return new Response(JSON.stringify({ issue: issue.status, assets, extracts: extracts.rows[0] }), {
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+  });
+}

--- a/hp-web/src/app/api/mag/issues/route.ts
+++ b/hp-web/src/app/api/mag/issues/route.ts
@@ -1,0 +1,26 @@
+import type { NextRequest } from "next/server";
+import { requireModerator } from "@/lib/auth";
+import { getPool } from "@/lib/db";
+import { validateIssueInput } from "@/lib/mag/kinds";
+import { getMagazineBySlug, upsertIssue } from "@/lib/mag/queries";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// POST /api/mag/issues — upsert an issue by (magazine slug, issue slug),
+// moderator only. The magazine must already exist (POST /api/mag/magazines
+// first); a typo'd magazine slug must not silently mint a new magazine.
+export async function POST(request: NextRequest) {
+  const denied = await requireModerator(request);
+  if (denied) return denied;
+  const body = await request.json().catch(() => null);
+  const v = validateIssueInput(body);
+  if (!v.ok) return Response.json({ error: v.error }, { status: 400 });
+  const pool = getPool();
+  const magazine = await getMagazineBySlug(pool, v.value.magazine);
+  if (!magazine) {
+    return Response.json({ error: `no such magazine: ${v.value.magazine}` }, { status: 404 });
+  }
+  const issue = await upsertIssue(pool, magazine.id, v.value);
+  return Response.json({ issue: { ...issue, magazine_slug: magazine.slug } });
+}

--- a/hp-web/src/app/api/mag/magazines/route.ts
+++ b/hp-web/src/app/api/mag/magazines/route.ts
@@ -1,0 +1,22 @@
+import type { NextRequest } from "next/server";
+import { requireModerator } from "@/lib/auth";
+import { getPool } from "@/lib/db";
+import { validateMagazineInput } from "@/lib/mag/kinds";
+import { upsertMagazine } from "@/lib/mag/queries";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// POST /api/mag/magazines — upsert a magazine by slug (moderator only; ingest
+// tooling calls this before the first issue of a magazine). Optional fields
+// left out keep their stored values, so a later ingest can't blank out a
+// moderator's edits.
+export async function POST(request: NextRequest) {
+  const denied = await requireModerator(request);
+  if (denied) return denied;
+  const body = await request.json().catch(() => null);
+  const v = validateMagazineInput(body);
+  if (!v.ok) return Response.json({ error: v.error }, { status: 400 });
+  const magazine = await upsertMagazine(getPool(), v.value);
+  return Response.json({ magazine });
+}

--- a/hp-web/src/app/api/mag/search/route.ts
+++ b/hp-web/src/app/api/mag/search/route.ts
@@ -1,0 +1,32 @@
+import type { NextRequest } from "next/server";
+import { getPool } from "@/lib/db";
+import { searchExtracts } from "@/lib/mag/queries";
+import { clientKey, rateLimit } from "@/lib/ratelimit";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// GET /api/mag/search?q=...&magazine=&kind=&system=&language=&person=&game=
+//   &from=&to=&limit= — extract search. Quoted q ("...") is exact substring
+// (trigram; the CJK path); otherwise FTS over original + English text.
+export async function GET(request: NextRequest) {
+  if (!rateLimit(`magsearch:${clientKey(request)}`, 60, 60_000)) {
+    return Response.json({ error: "rate limit exceeded" }, { status: 429 });
+  }
+  const p = request.nextUrl.searchParams;
+  const q = (p.get("q") ?? "").trim().slice(0, 256);
+  if (!q) return Response.json({ results: [] });
+  const date = (v: string | null) => (v && /^\d{4}-\d{2}-\d{2}$/.test(v) ? v : undefined);
+  const results = await searchExtracts(getPool(), q, {
+    magazine: p.get("magazine")?.slice(0, 100) || undefined,
+    kind: p.get("kind")?.slice(0, 40) || undefined,
+    system: p.get("system")?.slice(0, 100) || undefined,
+    language: p.get("language")?.slice(0, 20) || undefined,
+    person: p.get("person")?.slice(0, 200) || undefined,
+    game: p.get("game")?.slice(0, 200) || undefined,
+    from: date(p.get("from")),
+    to: date(p.get("to")),
+    limit: Number(p.get("limit")) || undefined,
+  });
+  return Response.json({ results });
+}

--- a/hp-web/src/app/games/[slug]/GameMagCoverage.tsx
+++ b/hp-web/src/app/games/[slug]/GameMagCoverage.tsx
@@ -1,0 +1,91 @@
+// Server component: one game's magazine coverage, grouped with reviews (and
+// their score grids) first. Data comes pre-fetched from the page.
+
+import Link from "next/link";
+import { extractAnchor, issueHref, magThumbUrl } from "@/lib/mag/hrefs";
+import type { CoverageItem } from "@/lib/mag/queries";
+
+const GROUPS: { title: string; kinds: string[] }[] = [
+  { title: "Reviews", kinds: ["review"] },
+  { title: "Previews", kinds: ["preview"] },
+  { title: "Guides and tips", kinds: ["strategy", "tips"] },
+  { title: "Features and interviews", kinds: ["feature", "interview", "news", "rumor", "column"] },
+  { title: "Advertising", kinds: ["ad"] },
+  { title: "Charts and scores", kinds: ["chart", "high_scores", "calendar"] },
+];
+
+function scoreLine(data: Record<string, unknown>): string | null {
+  const scores = Array.isArray(data.scores) ? (data.scores as Record<string, unknown>[]) : [];
+  const average = data.average as { value?: unknown; scale?: unknown } | undefined;
+  const parts = scores.slice(0, 6).map((s) => `${String(s.reviewer ?? "?")} ${String(s.value ?? "?")}`);
+  if (average?.value !== undefined) {
+    parts.push(`avg ${String(average.value)}${average.scale ? `/${String(average.scale)}` : ""}`);
+  }
+  return parts.length ? parts.join(" · ") : null;
+}
+
+export default function GameMagCoverage({ coverage }: { coverage: CoverageItem[] }) {
+  if (coverage.length === 0) return null;
+  const seen = new Set<string>(GROUPS.flatMap((g) => g.kinds));
+  const rest = coverage.filter((c) => !seen.has(c.kind));
+
+  return (
+    <section className="mx-auto mt-10 max-w-4xl">
+      <h2 className="text-lg font-medium">Magazine coverage</h2>
+      <p className="mt-1 text-xs text-neutral-500">
+        {coverage.length} indexed {coverage.length === 1 ? "appearance" : "appearances"} in the magazine archive.
+      </p>
+      {[...GROUPS, { title: "Elsewhere", kinds: [] }].map((g) => {
+        const items = g.kinds.length ? coverage.filter((c) => g.kinds.includes(c.kind)) : rest;
+        if (items.length === 0) return null;
+        return (
+          <div key={g.title} className="mt-5">
+            <h3 className="text-sm font-semibold text-neutral-500">{g.title}</h3>
+            <ul className="mt-2 space-y-2">
+              {items.map((h) => {
+                const scores = h.kind === "review" ? scoreLine(h.data) : null;
+                return (
+                  <li key={h.id}>
+                    <Link
+                      href={`${issueHref(h.magazine_slug, h.issue_slug)}#${extractAnchor(h.id)}`}
+                      className="flex gap-3 rounded-md border border-neutral-200 p-2 hover:border-neutral-400 dark:border-neutral-800 dark:hover:border-neutral-600"
+                    >
+                      {h.crop_sha256 && (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={magThumbUrl(h.crop_sha256, 500)}
+                          alt=""
+                          className="h-16 w-16 shrink-0 rounded-sm bg-neutral-100 object-cover dark:bg-neutral-800"
+                          loading="lazy"
+                        />
+                      )}
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">
+                          {h.magazine_title} {h.issue_label}
+                          {h.cover_date ? (
+                            <span className="font-normal text-neutral-500"> · {h.cover_date.slice(0, 7)}</span>
+                          ) : null}
+                        </div>
+                        {scores ? (
+                          <div className="text-xs font-medium text-emerald-800 dark:text-emerald-300">{scores}</div>
+                        ) : (
+                          <div className="text-xs text-neutral-500">
+                            {h.title || h.section || h.kind.replace("_", " ")}
+                            {h.title_printed && h.title_printed !== h.title ? ` (printed as "${h.title_printed}")` : ""}
+                          </div>
+                        )}
+                        {h.summary_en && (
+                          <div className="mt-0.5 line-clamp-1 text-xs text-neutral-600 dark:text-neutral-400">{h.summary_en}</div>
+                        )}
+                      </div>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/hp-web/src/app/games/[slug]/page.tsx
+++ b/hp-web/src/app/games/[slug]/page.tsx
@@ -5,10 +5,12 @@ import { notFound } from "next/navigation";
 import { getModeratorFromHeaders } from "@/lib/auth";
 import { getPool } from "@/lib/db";
 import { getGameAssets, getGameBySlug, getGameBuilds } from "@/lib/queries";
+import { getGameCoverage } from "@/lib/mag/queries";
 import { assetExcerpts, assetMonths, assetTotals, orderAssets } from "@/lib/assets";
 import AssetGallery from "../../builds/[buildId]/AssetGallery";
 import AssetViewerHost from "../../builds/[buildId]/AssetViewerHost";
 import GameBuilds from "./GameBuilds";
+import GameMagCoverage from "./GameMagCoverage";
 
 // The timeline shows at most this many items per kind per month; the rest
 // live on /games/<slug>/assets. Excerpt reads stay bounded regardless.
@@ -46,9 +48,10 @@ export default async function GamePage({ params }: Params) {
   // The page renders per-request (force-dynamic), so a wiki-moderator's
   // cookies reveal private builds here — badged, exactly like /builds.
   const includePrivate = !!(await getModeratorFromHeaders(await headers()));
-  const [builds, assets] = await Promise.all([
+  const [builds, assets, coverage] = await Promise.all([
     getGameBuilds(pool, game.id, includePrivate),
     getGameAssets(pool, game.id, includePrivate),
+    getGameCoverage(pool, game.id),
   ]);
   // Timeline: one bucket per month of the assets' own file dates. The viewer
   // steps through the whole timeline in order; each month's gallery shows a
@@ -81,6 +84,7 @@ export default async function GamePage({ params }: Params) {
           </div>
 
           <GameBuilds builds={builds} />
+          <GameMagCoverage coverage={coverage} />
         </div>
 
         {assets.length > 0 && (

--- a/hp-web/src/app/magazines/MagSearch.tsx
+++ b/hp-web/src/app/magazines/MagSearch.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+// Extract search box for /magazines: full text across every issue, with
+// magazine/kind filters. Quote the query ("exact phrase") for exact substring
+// matching (also the way to search Japanese text). URL-driven like the
+// builds browser: state lives in ?q=&magazine=&kind=, so results are
+// shareable and survive reloads.
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { EXTRACT_KINDS } from "@/lib/mag/kinds";
+import { extractAnchor, issueHref, magThumbUrl } from "@/lib/mag/hrefs";
+
+interface Hit {
+  id: number;
+  kind: string;
+  section: string | null;
+  title: string | null;
+  language: string;
+  summary_en: string | null;
+  snippet: string | null;
+  issue_slug: string;
+  issue_label: string;
+  cover_date: string | null;
+  magazine_slug: string;
+  magazine_title: string;
+  crop_sha256: string | null;
+}
+
+/** Render a ts_headline/snippetFrom string, highlighting [[...]] spans. */
+function Snippet({ text }: { text: string }) {
+  const parts = text.split(/\[\[(.+?)\]\]/g);
+  return (
+    <span>
+      {parts.map((p, i) =>
+        i % 2 === 1 ? (
+          <mark key={i} className="rounded-sm bg-amber-200 px-0.5 dark:bg-amber-700/60">{p}</mark>
+        ) : (
+          <span key={i}>{p}</span>
+        )
+      )}
+    </span>
+  );
+}
+
+export default function MagSearch({ magazines }: { magazines: { slug: string; title: string }[] }) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [q, setQ] = useState(params.get("q") ?? "");
+  const [magazine, setMagazine] = useState(params.get("magazine") ?? "");
+  const [kind, setKind] = useState(params.get("kind") ?? "");
+  // Results are keyed by the URL query they answered. Everything else is
+  // derived: no fetch in flight has landed for the current URL -> busy; the
+  // URL has no query -> nothing renders. No state-syncing effects.
+  const [fetched, setFetched] = useState<{ key: string; hits: Hit[] } | null>(null);
+  const seq = useRef(0);
+
+  const urlQ = params.get("q") ?? "";
+  const urlMagazine = params.get("magazine") ?? "";
+  const urlKind = params.get("kind") ?? "";
+  const urlKey = `${urlQ}\0${urlMagazine}\0${urlKind}`;
+
+  useEffect(() => {
+    if (!urlQ.trim()) return;
+    const mine = ++seq.current;
+    const query = new URLSearchParams({ q: urlQ });
+    if (urlMagazine) query.set("magazine", urlMagazine);
+    if (urlKind) query.set("kind", urlKind);
+    fetch(`/api/mag/search?${query}`, { cache: "no-store" })
+      .then((r) => r.json())
+      .then((data) => {
+        if (seq.current === mine) setFetched({ key: urlKey, hits: (data.results as Hit[]) ?? [] });
+      })
+      .catch(() => {
+        if (seq.current === mine) setFetched({ key: urlKey, hits: [] });
+      });
+  }, [urlQ, urlMagazine, urlKind, urlKey]);
+
+  const hits = urlQ.trim() && fetched?.key === urlKey ? fetched.hits : null;
+  const busy = !!urlQ.trim() && hits === null;
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    const next = new URLSearchParams();
+    if (q.trim()) next.set("q", q.trim());
+    if (magazine) next.set("magazine", magazine);
+    if (kind) next.set("kind", kind);
+    router.replace(`/magazines${next.size ? `?${next}` : ""}`, { scroll: false });
+  }
+
+  return (
+    <div className="mt-6">
+      <form onSubmit={submit} className="flex flex-wrap gap-2">
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder={'search all issues… (quote for "exact match")'}
+          className="min-w-48 flex-1 rounded-md border border-neutral-300 bg-transparent px-3 py-1.5 text-sm outline-none focus:border-neutral-500 dark:border-neutral-700"
+          aria-label="Search magazine extracts"
+        />
+        <select
+          value={magazine}
+          onChange={(e) => setMagazine(e.target.value)}
+          className="rounded-md border border-neutral-300 bg-transparent px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+          aria-label="Magazine filter"
+        >
+          <option value="">all magazines</option>
+          {magazines.map((m) => (
+            <option key={m.slug} value={m.slug}>{m.title}</option>
+          ))}
+        </select>
+        <select
+          value={kind}
+          onChange={(e) => setKind(e.target.value)}
+          className="rounded-md border border-neutral-300 bg-transparent px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+          aria-label="Kind filter"
+        >
+          <option value="">all kinds</option>
+          {EXTRACT_KINDS.map((k) => (
+            <option key={k} value={k}>{k.replace("_", " ")}</option>
+          ))}
+        </select>
+        <button
+          type="submit"
+          className="rounded-md border border-neutral-300 px-3 py-1.5 text-sm hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
+        >
+          Search
+        </button>
+      </form>
+
+      {busy && <p className="mt-4 text-sm text-neutral-500">Searching…</p>}
+      {hits && !busy && (
+        <div className="mt-4">
+          <p className="text-xs text-neutral-500">
+            {hits.length === 0 ? "No matches." : `${hits.length} ${hits.length === 1 ? "match" : "matches"}`}
+          </p>
+          <ul className="mt-2 space-y-2">
+            {hits.map((h) => (
+              <li key={h.id}>
+                <Link
+                  href={`${issueHref(h.magazine_slug, h.issue_slug)}#${extractAnchor(h.id)}`}
+                  className="flex gap-3 rounded-md border border-neutral-200 p-2 hover:border-neutral-400 dark:border-neutral-800 dark:hover:border-neutral-600"
+                >
+                  {h.crop_sha256 && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={magThumbUrl(h.crop_sha256, 500)}
+                      alt=""
+                      className="h-16 w-16 shrink-0 rounded-sm bg-neutral-100 object-cover dark:bg-neutral-800"
+                      loading="lazy"
+                    />
+                  )}
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">
+                      {h.title || h.section || h.kind.replace("_", " ")}
+                    </div>
+                    <div className="text-xs text-neutral-500">
+                      {h.magazine_title} · {h.issue_label}
+                      {h.cover_date ? ` · ${h.cover_date.slice(0, 7)}` : ""} ·{" "}
+                      <span className="rounded bg-neutral-100 px-1 py-0.5 dark:bg-neutral-800">{h.kind.replace("_", " ")}</span>
+                    </div>
+                    {(h.snippet || h.summary_en) && (
+                      <div className="mt-0.5 line-clamp-2 text-xs text-neutral-600 dark:text-neutral-400">
+                        {h.snippet ? <Snippet text={h.snippet} /> : h.summary_en}
+                      </div>
+                    )}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hp-web/src/app/magazines/[slug]/[issue]/IssueBrowser.tsx
+++ b/hp-web/src/app/magazines/[slug]/[issue]/IssueBrowser.tsx
@@ -1,0 +1,602 @@
+"use client";
+
+// The issue page body: page strip with extract-region overlays, kind filter,
+// original/English toggle, and every extract as a card grouped by page. A
+// lightweight lightbox opens crops and full pages (probe-then-ZoomPan, the
+// MediaViewer recipe). Deep links use plain #x-<id> anchors, so search hits
+// land on the card without any history choreography.
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import ZoomPan from "../../../builds/[buildId]/ZoomPan";
+import { extractAnchor, magBlobUrl, magThumbUrl, personHref } from "@/lib/mag/hrefs";
+import ModTools from "./ModTools";
+
+export interface IssuePageItem {
+  pdf_index: number;
+  printed_label: string | null;
+  image_sha256: string | null;
+  width: number | null;
+  height: number | null;
+}
+
+export interface RegionItem {
+  id: number;
+  seq: number;
+  pdf_index: number;
+  printed_label: string | null;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  crop_sha256: string | null;
+  page_sha256: string | null;
+  page_width: number | null;
+  page_height: number | null;
+}
+
+export interface IssueExtractItem {
+  id: number;
+  kind: string;
+  section: string | null;
+  seq: number;
+  title: string | null;
+  language: string;
+  /** Previews — the server truncates; `truncated` says the full text is a
+   *  fetch away (GET /api/mag/extracts/<id>). */
+  text_original: string | null;
+  text_en: string | null;
+  truncated: boolean;
+  translation: "machine" | "human" | null;
+  summary_en: string | null;
+  data: Record<string, unknown>;
+  is_fictional: boolean;
+  sponsored: boolean;
+  content_warning: string | null;
+  status: string;
+  regions: RegionItem[];
+  games: { game_id: number; name: string; system: string; slug: string | null; role: string; title_printed: string | null }[];
+  people: { person_id: number; slug: string; name: string; name_original: string | null; kind: string; role: string }[];
+  systems: string[];
+  tags: { slug: string; kind: string; name: string }[];
+}
+
+const KIND_TINT: Record<string, string> = {
+  review: "bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200",
+  preview: "bg-teal-100 text-teal-900 dark:bg-teal-900/40 dark:text-teal-200",
+  interview: "bg-violet-100 text-violet-900 dark:bg-violet-900/40 dark:text-violet-200",
+  strategy: "bg-cyan-100 text-cyan-900 dark:bg-cyan-900/40 dark:text-cyan-200",
+  tips: "bg-cyan-100 text-cyan-900 dark:bg-cyan-900/40 dark:text-cyan-200",
+  chart: "bg-indigo-100 text-indigo-900 dark:bg-indigo-900/40 dark:text-indigo-200",
+  high_scores: "bg-indigo-100 text-indigo-900 dark:bg-indigo-900/40 dark:text-indigo-200",
+  ad: "bg-rose-100 text-rose-900 dark:bg-rose-900/40 dark:text-rose-200",
+  ad_index: "bg-rose-100 text-rose-900 dark:bg-rose-900/40 dark:text-rose-200",
+  comic: "bg-fuchsia-100 text-fuchsia-900 dark:bg-fuchsia-900/40 dark:text-fuchsia-200",
+  fiction: "bg-fuchsia-100 text-fuchsia-900 dark:bg-fuchsia-900/40 dark:text-fuchsia-200",
+  news: "bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200",
+  rumor: "bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200",
+};
+
+function kindChip(kind: string): string {
+  return KIND_TINT[kind] ?? "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300";
+}
+
+interface LightboxItem {
+  url: string;
+  caption: string;
+}
+
+function Lightbox({ item, onClose }: { item: LightboxItem; onClose: () => void }) {
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex flex-col bg-black/75 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
+      tabIndex={-1}
+    >
+      <div className="flex items-center justify-between px-4 py-2 text-sm text-neutral-200">
+        <span className="truncate">{item.caption}</span>
+        <button onClick={onClose} className="rounded px-2 py-1 hover:bg-white/10" aria-label="Close">
+          ×
+        </button>
+      </div>
+      <div className="min-h-0 flex-1" onClick={(e) => e.stopPropagation()}>
+        {size ? (
+          <ZoomPan contentSize={size} className="h-full w-full">
+            {(scale) => (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={item.url}
+                alt={item.caption}
+                width={size.width * scale}
+                height={size.height * scale}
+                style={{ imageRendering: scale > 1 ? "pixelated" : "auto" }}
+                draggable={false}
+              />
+            )}
+          </ZoomPan>
+        ) : (
+          // Probe render: measure the natural size, then hand off to ZoomPan.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={item.url}
+            alt={item.caption}
+            className="mx-auto max-h-full max-w-full object-contain"
+            onLoad={(e) => {
+              const img = e.currentTarget;
+              if (img.naturalWidth && img.naturalHeight) {
+                setSize({ width: img.naturalWidth, height: img.naturalHeight });
+              }
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Compact structured-data rendering per kind: score rows, fact boxes,
+ *  chart/high-score tables, ad product lists. Anything unrecognized simply
+ *  doesn't render — data is schemaless by design. */
+function DataBlock({ data }: { data: Record<string, unknown> }) {
+  const scores = Array.isArray(data.scores) ? (data.scores as Record<string, unknown>[]) : null;
+  const average = data.average as { value?: unknown; scale?: unknown } | undefined;
+  const axes = Array.isArray(data.axes) ? (data.axes as Record<string, unknown>[]) : null;
+  const factBox = data.fact_box as Record<string, unknown> | undefined;
+  const entries = Array.isArray(data.entries) ? (data.entries as Record<string, unknown>[]) : null;
+  const products = Array.isArray(data.products) ? (data.products as Record<string, unknown>[]) : null;
+  const advertiser = typeof data.advertiser === "string" ? data.advertiser : null;
+  const source = typeof data.source === "string" ? data.source : null;
+
+  const hasAny = scores?.length || axes?.length || factBox || entries?.length || products?.length || advertiser;
+  if (!hasAny) return null;
+
+  return (
+    <div className="mt-2 space-y-2 text-xs">
+      {scores && scores.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {scores.map((s, i) => (
+            <span key={i} className="rounded border border-neutral-300 px-1.5 py-0.5 dark:border-neutral-700">
+              <span className="text-neutral-500">{String(s.reviewer ?? "?")}</span>{" "}
+              <strong>{String(s.value ?? "?")}</strong>
+              {s.scale ? <span className="text-neutral-400">/{String(s.scale)}</span> : null}
+            </span>
+          ))}
+          {average?.value !== undefined && (
+            <span className="rounded bg-emerald-100 px-1.5 py-0.5 font-semibold text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200">
+              avg {String(average.value)}
+              {average.scale ? `/${String(average.scale)}` : ""}
+            </span>
+          )}
+        </div>
+      )}
+      {axes && axes.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {axes.map((a, i) => (
+            <span key={i} className="rounded border border-neutral-300 px-1.5 py-0.5 dark:border-neutral-700">
+              <span className="text-neutral-500">{String(a.axis ?? "?")}</span> <strong>{String(a.value ?? "?")}</strong>
+              {a.scale ? <span className="text-neutral-400">/{String(a.scale)}</span> : null}
+            </span>
+          ))}
+        </div>
+      )}
+      {factBox && (
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-0.5 sm:grid-cols-3">
+          {Object.entries(factBox)
+            .filter(([, v]) => v !== null && v !== undefined && v !== "")
+            .slice(0, 12)
+            .map(([k, v]) => (
+              <div key={k} className="flex gap-1">
+                <dt className="text-neutral-500">{k.replace(/_/g, " ")}:</dt>
+                <dd className="truncate font-medium">{String(v)}</dd>
+              </div>
+            ))}
+        </dl>
+      )}
+      {advertiser && (
+        <p>
+          <span className="text-neutral-500">advertiser:</span> <strong>{advertiser}</strong>
+          {typeof data.reader_service_no === "number" || typeof data.reader_service_no === "string" ? (
+            <span className="text-neutral-500"> · reader service #{String(data.reader_service_no)}</span>
+          ) : null}
+        </p>
+      )}
+      {products && products.length > 0 && (
+        <p className="text-neutral-600 dark:text-neutral-400">
+          {products
+            .slice(0, 12)
+            .map((p) => [p.title_printed, p.system_printed ? `(${String(p.system_printed)})` : ""].filter(Boolean).join(" "))
+            .join(" · ")}
+          {products.length > 12 ? ` · +${products.length - 12} more` : ""}
+        </p>
+      )}
+      {entries && entries.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="min-w-0 text-left">
+            <tbody>
+              {entries.slice(0, 15).map((row, i) => (
+                <tr key={i} className="border-b border-neutral-100 last:border-0 dark:border-neutral-800">
+                  {["rank", "prev_rank", "player", "title_printed", "event", "value", "points", "comment"]
+                    .filter((c) => row[c] !== undefined && row[c] !== null && row[c] !== "")
+                    .slice(0, 5)
+                    .map((c) => (
+                      <td key={c} className="py-0.5 pr-3 align-top">
+                        {c === "rank" ? <strong>{String(row[c])}</strong> : String(row[c])}
+                      </td>
+                    ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {entries.length > 15 && <p className="text-neutral-400">+{entries.length - 15} more rows</p>}
+        </div>
+      )}
+      {source && <p className="text-neutral-400">source: {source.replace(/_/g, " ")}</p>}
+    </div>
+  );
+}
+
+function ExtractText({
+  item,
+  lang,
+}: {
+  item: IssueExtractItem;
+  lang: "original" | "en";
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [full, setFull] = useState<{ text_original: string; text_en: string | null } | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const text =
+    lang === "en"
+      ? (full?.text_en ?? item.text_en) ?? item.summary_en ?? (full?.text_original ?? item.text_original)
+      : (full?.text_original ?? item.text_original);
+  if (!text && !item.summary_en) return null;
+
+  async function expand() {
+    if (expanded) {
+      setExpanded(false);
+      return;
+    }
+    if (item.truncated && !full) {
+      setLoading(true);
+      try {
+        const r = await fetch(`/api/mag/extracts/${item.id}`, { cache: "no-store" });
+        if (r.ok) {
+          const data = (await r.json()) as { extract: { text_original: string; text_en: string | null } };
+          setFull({ text_original: data.extract.text_original, text_en: data.extract.text_en });
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+    setExpanded(true);
+  }
+
+  const clamped = !expanded;
+  return (
+    <div className="mt-2">
+      {lang === "en" && !item.text_en && item.summary_en && text === item.summary_en && (
+        <p className="mb-1 text-[10px] uppercase tracking-wide text-neutral-400">summary</p>
+      )}
+      <p
+        className={`whitespace-pre-wrap text-sm leading-relaxed text-neutral-800 dark:text-neutral-200 ${clamped ? "line-clamp-4" : ""}`}
+        lang={lang === "en" ? "en" : item.language}
+      >
+        {text}
+      </p>
+      {(item.truncated || (text && text.length > 350)) && (
+        <button onClick={expand} className="mt-1 text-xs text-sky-700 hover:underline dark:text-sky-300">
+          {loading ? "loading…" : expanded ? "collapse" : "read all"}
+        </button>
+      )}
+      {lang === "en" && item.translation === "machine" && item.text_en && (
+        <p className="mt-1 text-[10px] uppercase tracking-wide text-neutral-400">machine translation</p>
+      )}
+    </div>
+  );
+}
+
+export default function IssueBrowser({
+  issueId,
+  binding,
+  pages,
+  extracts,
+  pagesPublic,
+  moderator,
+}: {
+  issueId: number;
+  binding: "ltr" | "rtl";
+  pages: IssuePageItem[];
+  extracts: IssueExtractItem[];
+  pagesPublic: boolean;
+  moderator: boolean;
+}) {
+  const [kindFilter, setKindFilter] = useState<string | null>(null);
+  const [lang, setLang] = useState<"original" | "en">("original");
+  const [box, setBox] = useState<LightboxItem | null>(null);
+
+  const kinds = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const e of extracts) counts.set(e.kind, (counts.get(e.kind) ?? 0) + 1);
+    return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  }, [extracts]);
+
+  const hasTranslations = useMemo(
+    () => extracts.some((e) => e.text_en || (e.language && e.language !== "en" && e.summary_en)),
+    [extracts]
+  );
+
+  const visible = kindFilter ? extracts.filter((e) => e.kind === kindFilter) : extracts;
+
+  // Group by first region's page, in reading order.
+  const byPage = useMemo(() => {
+    const groups = new Map<number, IssueExtractItem[]>();
+    for (const e of visible) {
+      const page = e.regions[0]?.pdf_index ?? 0;
+      const list = groups.get(page) ?? [];
+      list.push(e);
+      groups.set(page, list);
+    }
+    return [...groups.entries()].sort((a, b) => a[0] - b[0]);
+  }, [visible]);
+
+  const regionsByPage = useMemo(() => {
+    const m = new Map<number, { id: number; x: number; y: number; w: number; h: number; rejected: boolean }[]>();
+    for (const e of extracts) {
+      for (const r of e.regions) {
+        const list = m.get(r.pdf_index) ?? [];
+        list.push({ id: e.id, x: r.x, y: r.y, w: r.w, h: r.h, rejected: e.status === "rejected" });
+        m.set(r.pdf_index, list);
+      }
+    }
+    return m;
+  }, [extracts]);
+
+  const pageLabel = (p: IssuePageItem) => p.printed_label ?? `pdf ${p.pdf_index}`;
+
+  return (
+    <div className="mx-auto mt-8 max-w-5xl">
+      {box && <Lightbox item={box} onClose={() => setBox(null)} />}
+
+      {pagesPublic && pages.some((p) => p.image_sha256) && (
+        <section aria-label="Pages">
+          <div className="flex gap-2 overflow-x-auto pb-2" dir={binding === "rtl" ? "rtl" : undefined}>
+            {pages.map((p) => (
+              <figure key={p.pdf_index} className="w-24 shrink-0">
+                <div className="relative">
+                  {p.image_sha256 ? (
+                    <button
+                      onClick={() =>
+                        setBox({ url: magBlobUrl(p.image_sha256!), caption: `Page ${pageLabel(p)}` })
+                      }
+                      className="block w-full"
+                      aria-label={`Open page ${pageLabel(p)}`}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={magThumbUrl(p.image_sha256, 500)}
+                        alt={`Page ${pageLabel(p)}`}
+                        className="w-full rounded-sm border border-neutral-200 dark:border-neutral-800"
+                        loading="lazy"
+                      />
+                    </button>
+                  ) : (
+                    <div className="flex aspect-[3/4] w-full items-center justify-center rounded-sm border border-dashed border-neutral-300 text-[10px] text-neutral-400 dark:border-neutral-700">
+                      …
+                    </div>
+                  )}
+                  {(regionsByPage.get(p.pdf_index) ?? []).length > 0 && (
+                    <svg className="pointer-events-none absolute inset-0 h-full w-full" viewBox="0 0 100 100" preserveAspectRatio="none">
+                      {(regionsByPage.get(p.pdf_index) ?? []).map((r, i) => (
+                        <a key={`${r.id}-${i}`} href={`#${extractAnchor(r.id)}`} className="pointer-events-auto">
+                          <rect
+                            x={r.x * 100}
+                            y={r.y * 100}
+                            width={r.w * 100}
+                            height={r.h * 100}
+                            className={
+                              r.rejected
+                                ? "fill-transparent stroke-red-400/70"
+                                : "fill-sky-400/10 stroke-sky-500/70 hover:fill-sky-400/25"
+                            }
+                            strokeWidth="1"
+                            vectorEffect="non-scaling-stroke"
+                          />
+                        </a>
+                      ))}
+                    </svg>
+                  )}
+                </div>
+                <figcaption className="mt-0.5 text-center text-[10px] text-neutral-500">{pageLabel(p)}</figcaption>
+              </figure>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <div className="sticky top-0 z-10 mt-4 flex flex-wrap items-center gap-1.5 border-b border-neutral-200 bg-[var(--background)] py-2 text-xs dark:border-neutral-800">
+        <button
+          onClick={() => setKindFilter(null)}
+          className={`rounded px-1.5 py-0.5 ${kindFilter === null ? "bg-neutral-800 text-white dark:bg-neutral-200 dark:text-neutral-900" : "bg-neutral-100 dark:bg-neutral-800"}`}
+        >
+          all {extracts.length}
+        </button>
+        {kinds.map(([k, n]) => (
+          <button
+            key={k}
+            onClick={() => setKindFilter(kindFilter === k ? null : k)}
+            className={`rounded px-1.5 py-0.5 ${kindFilter === k ? "bg-neutral-800 text-white dark:bg-neutral-200 dark:text-neutral-900" : kindChip(k)}`}
+          >
+            {k.replace("_", " ")} {n}
+          </button>
+        ))}
+        {hasTranslations && (
+          <span className="ml-auto inline-flex overflow-hidden rounded border border-neutral-300 dark:border-neutral-700">
+            <button
+              onClick={() => setLang("original")}
+              className={`px-2 py-0.5 ${lang === "original" ? "bg-neutral-800 text-white dark:bg-neutral-200 dark:text-neutral-900" : ""}`}
+            >
+              original
+            </button>
+            <button
+              onClick={() => setLang("en")}
+              className={`px-2 py-0.5 ${lang === "en" ? "bg-neutral-800 text-white dark:bg-neutral-200 dark:text-neutral-900" : ""}`}
+            >
+              english
+            </button>
+          </span>
+        )}
+      </div>
+
+      {byPage.map(([page, items]) => (
+        <section key={page} className="mt-6">
+          <h2 className="text-sm font-semibold text-neutral-500">
+            Page {items[0]?.regions[0]?.printed_label ?? `pdf ${page}`}
+          </h2>
+          <div className="mt-2 space-y-3">
+            {items.map((e) => (
+              <article
+                key={e.id}
+                id={extractAnchor(e.id)}
+                className={`flex scroll-mt-24 gap-3 rounded-md border p-3 target:border-sky-500 target:ring-1 target:ring-sky-500 ${
+                  e.status === "rejected"
+                    ? "border-red-300 opacity-60 dark:border-red-900"
+                    : "border-neutral-200 dark:border-neutral-800"
+                }`}
+              >
+                <div className="w-28 shrink-0 sm:w-36">
+                  {e.regions[0]?.crop_sha256 ? (
+                    <button
+                      onClick={() =>
+                        setBox({
+                          url: magBlobUrl(e.regions[0].crop_sha256!),
+                          caption: e.title ?? e.section ?? e.kind,
+                        })
+                      }
+                      className="block w-full"
+                      aria-label="Open excerpt"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={magThumbUrl(e.regions[0].crop_sha256, 500)}
+                        alt=""
+                        className="w-full rounded-sm border border-neutral-200 dark:border-neutral-800"
+                        loading="lazy"
+                      />
+                    </button>
+                  ) : (
+                    <div className="flex aspect-square w-full items-center justify-center rounded-sm border border-dashed border-neutral-300 text-[10px] text-neutral-400 dark:border-neutral-700">
+                      cropping…
+                    </div>
+                  )}
+                  {e.regions.length > 1 && (
+                    <p className="mt-0.5 text-center text-[10px] text-neutral-400">
+                      {e.regions.length} regions
+                    </p>
+                  )}
+                </div>
+
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-1.5 text-xs">
+                    <span className={`rounded px-1.5 py-0.5 font-medium ${kindChip(e.kind)}`}>
+                      {e.kind.replace("_", " ")}
+                    </span>
+                    {e.section && <span className="text-neutral-500">{e.section}</span>}
+                    {e.is_fictional && (
+                      <span className="rounded bg-fuchsia-100 px-1.5 py-0.5 text-fuchsia-900 dark:bg-fuchsia-900/40 dark:text-fuchsia-200">
+                        fictional
+                      </span>
+                    )}
+                    {e.sponsored && (
+                      <span className="rounded bg-amber-100 px-1.5 py-0.5 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200">
+                        sponsored
+                      </span>
+                    )}
+                    {e.content_warning && (
+                      <span
+                        className="rounded bg-red-100 px-1.5 py-0.5 text-red-900 dark:bg-red-900/40 dark:text-red-200"
+                        title={e.content_warning}
+                      >
+                        content note
+                      </span>
+                    )}
+                    {moderator && e.status !== "auto" && (
+                      <span
+                        className={`rounded px-1.5 py-0.5 ${
+                          e.status === "rejected"
+                            ? "bg-red-100 text-red-900 dark:bg-red-900/40 dark:text-red-200"
+                            : "bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200"
+                        }`}
+                      >
+                        {e.status}
+                      </span>
+                    )}
+                  </div>
+                  {(e.title || e.summary_en) && (
+                    <h3 className="mt-1 text-sm font-medium">
+                      {e.title ?? e.summary_en}
+                    </h3>
+                  )}
+
+                  {(e.games.length > 0 || e.people.length > 0 || e.systems.length > 0 || e.tags.length > 0) && (
+                    <div className="mt-1.5 flex flex-wrap gap-1.5 text-xs">
+                      {e.games.map((g) => (
+                        <Link
+                          key={g.game_id}
+                          href={g.slug ? `/games/${g.slug}` : "#"}
+                          className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 hover:bg-sky-200 dark:bg-sky-900/40 dark:text-sky-200 dark:hover:bg-sky-900/70"
+                          title={g.title_printed && g.title_printed !== g.name ? `printed as "${g.title_printed}"` : undefined}
+                        >
+                          {g.name}
+                          {g.system ? <span className="font-normal text-sky-700/70 dark:text-sky-300/70"> · {g.system}</span> : null}
+                        </Link>
+                      ))}
+                      {e.people.map((p) => (
+                        <Link
+                          key={`${p.person_id}-${p.role}`}
+                          href={personHref(p.slug)}
+                          className="rounded bg-violet-100 px-1.5 py-0.5 font-medium text-violet-900 hover:bg-violet-200 dark:bg-violet-900/40 dark:text-violet-200 dark:hover:bg-violet-900/70"
+                          title={p.kind === "persona" ? `${p.role} (persona)` : p.role}
+                        >
+                          {p.name}
+                        </Link>
+                      ))}
+                      {e.systems.map((s) => (
+                        <span key={s} className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">{s}</span>
+                      ))}
+                      {e.tags.map((t) => (
+                        <span
+                          key={t.slug}
+                          className="rounded bg-neutral-100 px-1.5 py-0.5 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400"
+                          title={t.kind}
+                        >
+                          {t.name}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  <DataBlock data={e.data} />
+                  <ExtractText item={e} lang={lang} />
+
+                  {moderator && <ModTools extract={e} />}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      {visible.length === 0 && (
+        <p className="mt-10 text-sm text-neutral-500">
+          {extracts.length === 0 ? "No extracts ingested yet." : "Nothing matches this filter."}
+        </p>
+      )}
+      <p className="mt-10 text-[10px] text-neutral-400">issue #{issueId}</p>
+    </div>
+  );
+}

--- a/hp-web/src/app/magazines/[slug]/[issue]/ModTools.tsx
+++ b/hp-web/src/app/magazines/[slug]/[issue]/ModTools.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+// Inline moderation for one extract: amend (field patch dialog) and
+// reject/restore. Purely cosmetic gating — the PATCH and reject routes
+// re-check credentials server-side.
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { EXTRACT_KINDS } from "@/lib/mag/kinds";
+import { useModerator } from "@/components/useModerator";
+import type { IssueExtractItem } from "./IssueBrowser";
+
+interface FullText {
+  text_original: string;
+  text_en: string | null;
+  summary_en: string | null;
+  data: Record<string, unknown>;
+}
+
+export default function ModTools({ extract }: { extract: IssueExtractItem }) {
+  const { moderator, token } = useModerator();
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<Record<string, string | boolean>>({});
+  const [dataText, setDataText] = useState("");
+
+  if (!moderator) return null;
+
+  const authHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(token ? { "x-moderation-token": token } : {}),
+  };
+
+  async function openEditor() {
+    setError(null);
+    // The card only carries previews; edit the real thing.
+    const r = await fetch(`/api/mag/extracts/${extract.id}`, { cache: "no-store" });
+    if (!r.ok) {
+      setError("could not load extract");
+      return;
+    }
+    const { extract: full } = (await r.json()) as { extract: FullText & IssueExtractItem };
+    setForm({
+      kind: full.kind,
+      section: full.section ?? "",
+      title: full.title ?? "",
+      language: full.language,
+      text_original: full.text_original,
+      text_en: full.text_en ?? "",
+      summary_en: full.summary_en ?? "",
+      content_warning: full.content_warning ?? "",
+      is_fictional: full.is_fictional,
+      sponsored: full.sponsored,
+    });
+    setDataText(JSON.stringify(full.data, null, 2));
+    setOpen(true);
+  }
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    try {
+      let data: unknown;
+      try {
+        data = dataText.trim() ? JSON.parse(dataText) : {};
+      } catch {
+        setError("data is not valid JSON");
+        return;
+      }
+      const fields: Record<string, unknown> = {
+        kind: form.kind,
+        section: (form.section as string).trim() || null,
+        title: (form.title as string).trim() || null,
+        language: form.language,
+        text_original: form.text_original,
+        text_en: (form.text_en as string).trim() || null,
+        summary_en: (form.summary_en as string).trim() || null,
+        content_warning: (form.content_warning as string).trim() || null,
+        is_fictional: !!form.is_fictional,
+        sponsored: !!form.sponsored,
+        data,
+      };
+      const r = await fetch(`/api/mag/extracts/${extract.id}`, {
+        method: "PATCH",
+        headers: authHeaders,
+        body: JSON.stringify({ fields }),
+      });
+      if (!r.ok) {
+        setError(((await r.json().catch(() => null)) as { error?: string } | null)?.error ?? `HTTP ${r.status}`);
+        return;
+      }
+      setOpen(false);
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function setRejected(rejected: boolean) {
+    setBusy(true);
+    setError(null);
+    try {
+      const r = await fetch(`/api/mag/extracts/${extract.id}/reject`, {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ rejected }),
+      });
+      if (!r.ok) {
+        setError(((await r.json().catch(() => null)) as { error?: string } | null)?.error ?? `HTTP ${r.status}`);
+        return;
+      }
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const input =
+    "w-full rounded-md border border-neutral-300 bg-transparent px-2 py-1 text-sm dark:border-neutral-700";
+
+  return (
+    <div className="mt-2 border-t border-dashed border-neutral-200 pt-2 dark:border-neutral-800">
+      <div className="flex items-center gap-2 text-xs">
+        <button onClick={openEditor} disabled={busy} className="text-sky-700 hover:underline dark:text-sky-300">
+          Edit
+        </button>
+        {extract.status === "rejected" ? (
+          <button onClick={() => setRejected(false)} disabled={busy} className="text-emerald-700 hover:underline dark:text-emerald-300">
+            Restore
+          </button>
+        ) : (
+          <button onClick={() => setRejected(true)} disabled={busy} className="text-red-700 hover:underline dark:text-red-300">
+            Reject
+          </button>
+        )}
+        {error && <span className="text-red-600 dark:text-red-400">{error}</span>}
+      </div>
+
+      {open && (
+        <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true">
+          <div className="max-h-full w-full max-w-2xl overflow-y-auto rounded-md border border-neutral-300 bg-[var(--background)] p-4 dark:border-neutral-700">
+            <h3 className="text-sm font-semibold">Amend extract #{extract.id}</h3>
+            <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+              <label className="block">
+                <span className="text-xs text-neutral-500">kind</span>
+                <select
+                  value={form.kind as string}
+                  onChange={(e) => setForm({ ...form, kind: e.target.value })}
+                  className={input}
+                >
+                  {EXTRACT_KINDS.map((k) => (
+                    <option key={k} value={k}>{k}</option>
+                  ))}
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-xs text-neutral-500">section</span>
+                <input value={form.section as string} onChange={(e) => setForm({ ...form, section: e.target.value })} className={input} />
+              </label>
+              <label className="col-span-2 block">
+                <span className="text-xs text-neutral-500">title</span>
+                <input value={form.title as string} onChange={(e) => setForm({ ...form, title: e.target.value })} className={input} />
+              </label>
+              <label className="block">
+                <span className="text-xs text-neutral-500">language (bcp47)</span>
+                <input value={form.language as string} onChange={(e) => setForm({ ...form, language: e.target.value })} className={input} />
+              </label>
+              <label className="block">
+                <span className="text-xs text-neutral-500">content warning</span>
+                <input
+                  value={form.content_warning as string}
+                  onChange={(e) => setForm({ ...form, content_warning: e.target.value })}
+                  className={input}
+                />
+              </label>
+              <label className="col-span-2 block">
+                <span className="text-xs text-neutral-500">original text (verbatim)</span>
+                <textarea
+                  value={form.text_original as string}
+                  onChange={(e) => setForm({ ...form, text_original: e.target.value })}
+                  rows={6}
+                  className={`${input} font-mono text-xs`}
+                />
+              </label>
+              <label className="col-span-2 block">
+                <span className="text-xs text-neutral-500">english text</span>
+                <textarea
+                  value={form.text_en as string}
+                  onChange={(e) => setForm({ ...form, text_en: e.target.value })}
+                  rows={4}
+                  className={`${input} font-mono text-xs`}
+                />
+              </label>
+              <label className="col-span-2 block">
+                <span className="text-xs text-neutral-500">english summary</span>
+                <textarea
+                  value={form.summary_en as string}
+                  onChange={(e) => setForm({ ...form, summary_en: e.target.value })}
+                  rows={2}
+                  className={input}
+                />
+              </label>
+              <label className="col-span-2 block">
+                <span className="text-xs text-neutral-500">structured data (JSON)</span>
+                <textarea value={dataText} onChange={(e) => setDataText(e.target.value)} rows={6} className={`${input} font-mono text-xs`} />
+              </label>
+              <label className="flex items-center gap-1.5 text-xs">
+                <input
+                  type="checkbox"
+                  checked={!!form.is_fictional}
+                  onChange={(e) => setForm({ ...form, is_fictional: e.target.checked })}
+                />
+                fictional
+              </label>
+              <label className="flex items-center gap-1.5 text-xs">
+                <input
+                  type="checkbox"
+                  checked={!!form.sponsored}
+                  onChange={(e) => setForm({ ...form, sponsored: e.target.checked })}
+                />
+                sponsored
+              </label>
+            </div>
+            {error && <p className="mt-2 text-xs text-red-600 dark:text-red-400">{error}</p>}
+            <div className="mt-4 flex justify-end gap-2 text-sm">
+              <button onClick={() => setOpen(false)} disabled={busy} className="rounded-md border border-neutral-300 px-3 py-1 dark:border-neutral-700">
+                Cancel
+              </button>
+              <button
+                onClick={save}
+                disabled={busy}
+                className="rounded-md bg-neutral-800 px-3 py-1 text-white disabled:opacity-50 dark:bg-neutral-200 dark:text-neutral-900"
+              >
+                {busy ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hp-web/src/app/magazines/[slug]/[issue]/RenderProgress.tsx
+++ b/hp-web/src/app/magazines/[slug]/[issue]/RenderProgress.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+// Rendering/cropping progress note. The status endpoint self-heals (polling
+// restarts a dead job), so this is a plain poll loop; the page refreshes once
+// everything is done so the strip and crops appear without a manual reload.
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+interface Status {
+  assets: {
+    state: string;
+    error?: string;
+    pages_total: number;
+    pages_rendered: number;
+    crops_total: number;
+    crops_done: number;
+  };
+}
+
+export default function RenderProgress({ issueId }: { issueId: number }) {
+  const router = useRouter();
+  const [status, setStatus] = useState<Status | null>(null);
+  const done = useRef(false);
+
+  useEffect(() => {
+    let stop = false;
+    const tick = async () => {
+      try {
+        const r = await fetch(`/api/mag/issues/${issueId}/status`, { cache: "no-store" });
+        if (!r.ok) return;
+        const s = (await r.json()) as Status;
+        if (stop) return;
+        setStatus(s);
+        const a = s.assets;
+        const complete =
+          a.state !== "working" &&
+          a.pages_total > 0 &&
+          a.pages_rendered >= a.pages_total &&
+          a.crops_done >= a.crops_total;
+        if (complete && !done.current) {
+          done.current = true;
+          router.refresh();
+        }
+      } catch {
+        // Transient; the next tick retries.
+      }
+    };
+    void tick();
+    const t = setInterval(tick, 4000);
+    return () => {
+      stop = true;
+      clearInterval(t);
+    };
+  }, [issueId, router]);
+
+  const a = status?.assets;
+  return (
+    <p className="mt-3 rounded-md border border-dashed border-neutral-300 px-3 py-2 text-xs text-neutral-500 dark:border-neutral-700">
+      {a
+        ? a.state === "failed"
+          ? `Rendering failed: ${a.error ?? "unknown error"} — polling retries automatically.`
+          : `Rendering pages ${a.pages_rendered}/${a.pages_total || "?"}, crops ${a.crops_done}/${a.crops_total}…`
+        : "Checking render status…"}
+    </p>
+  );
+}

--- a/hp-web/src/app/magazines/[slug]/[issue]/opengraph-image.tsx
+++ b/hp-web/src/app/magazines/[slug]/[issue]/opengraph-image.tsx
@@ -1,0 +1,130 @@
+// Social-preview card for a magazine issue: wordmark, magazine + issue label,
+// fact chips (date, price, pages, extract count), and the cover render in the
+// image pane. Same satori recipe as the build card, including the
+// retry-without-image fallback.
+
+import fsp from "node:fs/promises";
+import { ImageResponse } from "next/og";
+import { getPool } from "@/lib/db";
+import { ensurePhotoScale } from "@/lib/ffmpeg";
+import { MAG_NS } from "@/lib/mag/store";
+import { getIssue, type IssueWithMagazine } from "@/lib/mag/queries";
+
+export const runtime = "nodejs";
+export const alt = "Magazine issue summary card";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+async function findCover(issueId: number): Promise<string | null> {
+  const r = await getPool().query(
+    "SELECT image_sha256 FROM magazine_page WHERE issue_id=$1 AND pdf_index=1 AND image_sha256 IS NOT NULL",
+    [issueId]
+  );
+  const sha = (r.rows[0] as { image_sha256: string } | undefined)?.image_sha256;
+  if (!sha) return null;
+  try {
+    // Page renders are ~2200px JPEGs; the cached 1000px scale is card-sized.
+    const scaled = await ensurePhotoScale(sha, MAG_NS, 1000);
+    const bytes = await fsp.readFile(scaled);
+    return `data:image/jpeg;base64,${bytes.toString("base64")}`;
+  } catch {
+    return null;
+  }
+}
+
+function facts(issue: IssueWithMagazine, extracts: number): string[] {
+  const out: string[] = [];
+  if (issue.cover_date) {
+    out.push(issue.cover_date.slice(0, issue.cover_date_precision === "year" ? 4 : 7));
+  }
+  if (issue.price_raw) out.push(issue.price_raw);
+  if (issue.page_count) out.push(`${issue.page_count} pages`);
+  if (extracts > 0) out.push(`${extracts} extracts`);
+  return out.slice(0, 4);
+}
+
+function Card({ issue, extracts, cover }: { issue: IssueWithMagazine; extracts: number; cover: string | null }) {
+  return (
+    <div style={{ width: "100%", height: "100%", display: "flex", background: "#0a0a0a", color: "#fafafa" }}>
+      <div
+        style={{
+          flex: 1,
+          minWidth: 0,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: 56,
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div style={{ fontSize: 26, letterSpacing: 6, color: "#737373" }}>HIDDEN PALACE MAGAZINES</div>
+          <div style={{ marginTop: 30, fontSize: 54, lineHeight: 1.15, lineClamp: 3, display: "block" }}>
+            {`${issue.magazine_title} ${issue.label}`}
+          </div>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 26 }}>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 14 }}>
+            {facts(issue, extracts).map((f) => (
+              <div
+                key={f}
+                style={{
+                  border: "1px solid #333333",
+                  borderRadius: 10,
+                  padding: "8px 20px",
+                  fontSize: 27,
+                  color: "#d4d4d4",
+                }}
+              >
+                {f}
+              </div>
+            ))}
+          </div>
+          <div style={{ fontSize: 23, color: "#525252" }}>{"hiddenpalace.org/magazines"}</div>
+        </div>
+      </div>
+      {cover && (
+        <div
+          style={{
+            width: 480,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: "#171717",
+            borderLeft: "1px solid #262626",
+            padding: 24,
+          }}
+        >
+          <img src={cover} alt="" style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain", borderRadius: 12 }} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+async function render(issue: IssueWithMagazine, extracts: number, cover: string | null): Promise<Response> {
+  const img = new ImageResponse(<Card issue={issue} extracts={extracts} cover={cover} />, size);
+  const buf = await img.arrayBuffer();
+  return new Response(buf, {
+    headers: { "Content-Type": contentType, "Cache-Control": "public, max-age=3600" },
+  });
+}
+
+export default async function OgImage({ params }: { params: Promise<{ slug: string; issue: string }> }) {
+  const { slug, issue: issueSlug } = await params;
+  const pool = getPool();
+  const issue = await getIssue(pool, decodeURIComponent(slug), decodeURIComponent(issueSlug));
+  if (!issue) return new Response("not found", { status: 404 });
+  const count = await pool.query(
+    "SELECT count(*)::int AS n FROM magazine_extract WHERE issue_id=$1 AND status <> 'rejected'",
+    [issue.id]
+  );
+  const extracts = (count.rows[0] as { n: number }).n;
+  // The cover pane respects the per-magazine pages_public toggle: when full
+  // pages are unlisted, the unfurl card stays text-only too.
+  const cover = issue.pages_public ? await findCover(issue.id) : null;
+  try {
+    return await render(issue, extracts, cover);
+  } catch {
+    return await render(issue, extracts, null);
+  }
+}

--- a/hp-web/src/app/magazines/[slug]/[issue]/page.tsx
+++ b/hp-web/src/app/magazines/[slug]/[issue]/page.tsx
@@ -1,0 +1,158 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import { getModeratorFromHeaders } from "@/lib/auth";
+import { getPool } from "@/lib/db";
+import { magazineHref } from "@/lib/mag/hrefs";
+import { getIssue, getIssueExtracts, listIssuePages } from "@/lib/mag/queries";
+import IssueBrowser, { type IssueExtractItem, type IssuePageItem } from "./IssueBrowser";
+import RenderProgress from "./RenderProgress";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Card text previews stay small so a 400-extract issue (price lists included,
+// verbatim by policy) doesn't ship megabytes of JSON; the full text loads per
+// extract on expand from /api/mag/extracts/<id>.
+const TEXT_PREVIEW = 1200;
+
+interface Params {
+  params: Promise<{ slug: string; issue: string }>;
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { slug, issue } = await params;
+  const row = await getIssue(getPool(), decodeURIComponent(slug), decodeURIComponent(issue));
+  if (!row) return {};
+  return {
+    title: `${row.magazine_title} ${row.label}`,
+    description: `Indexed contents of ${row.magazine_title} ${row.label}`,
+  };
+}
+
+function preview(text: string | null): { text: string | null; truncated: boolean } {
+  if (!text) return { text: null, truncated: false };
+  if (text.length <= TEXT_PREVIEW) return { text, truncated: false };
+  return { text: text.slice(0, TEXT_PREVIEW), truncated: true };
+}
+
+// /magazines/<slug>/<issue> — the showcase page: identity block, page strip
+// with extract-region overlays, and every extract grouped by page with
+// original/English text, entity chips, and inline moderation.
+export default async function IssuePage({ params }: Params) {
+  const { slug, issue: issueSlug } = await params;
+  const pool = getPool();
+  const issue = await getIssue(pool, decodeURIComponent(slug), decodeURIComponent(issueSlug));
+  if (!issue) notFound();
+
+  const moderator = !!(await getModeratorFromHeaders(await headers()));
+  const [pages, extracts] = await Promise.all([
+    listIssuePages(pool, issue.id),
+    getIssueExtracts(pool, issue.id, moderator),
+  ]);
+
+  const pageItems: IssuePageItem[] = pages.map((p) => ({
+    pdf_index: p.pdf_index,
+    printed_label: p.printed_label,
+    image_sha256: p.image_sha256,
+    width: p.width,
+    height: p.height,
+  }));
+
+  const items: IssueExtractItem[] = extracts.map((e) => {
+    const orig = preview(e.text_original);
+    const en = preview(e.text_en);
+    return {
+      id: e.id,
+      kind: e.kind,
+      section: e.section,
+      seq: e.seq,
+      title: e.title,
+      language: e.language,
+      text_original: orig.text,
+      text_en: en.text,
+      truncated: orig.truncated || en.truncated,
+      translation: e.translation,
+      summary_en: e.summary_en,
+      data: e.data,
+      is_fictional: e.is_fictional,
+      sponsored: e.sponsored,
+      content_warning: e.content_warning,
+      status: e.status,
+      regions: e.regions,
+      games: e.games,
+      people: e.people,
+      systems: e.systems,
+      tags: e.tags,
+    };
+  });
+
+  const supplements = issue.supplements.filter((s) => s && typeof s.title === "string");
+  const rendering =
+    !!issue.pdf_sha256 &&
+    (pages.length === 0 ||
+      (issue.page_count !== null && pages.filter((p) => p.image_sha256).length < issue.page_count) ||
+      extracts.some((e) => e.regions.some((r) => !r.crop_sha256 && r.page_sha256)));
+
+  return (
+    <main className="mx-auto max-w-none px-4 py-10 sm:px-8">
+      <div className="mx-auto max-w-5xl">
+        <Link href={magazineHref(issue.magazine_slug)} className="text-sm text-neutral-500 hover:underline">
+          &larr; {issue.magazine_title}
+        </Link>
+        <h1 className="mt-3 text-2xl font-semibold tracking-tight">
+          {issue.magazine_title} <span className="text-neutral-500">{issue.label}</span>
+        </h1>
+        <div className="mt-2 flex flex-wrap gap-2 text-xs">
+          {issue.cover_date && (
+            <span className="rounded bg-neutral-100 px-1.5 py-0.5 font-medium dark:bg-neutral-800">
+              {issue.cover_date.slice(0, issue.cover_date_precision === "year" ? 4 : issue.cover_date_precision === "month" ? 7 : 10)}
+            </span>
+          )}
+          {issue.volume && <span className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">Vol. {issue.volume}</span>}
+          {issue.number && <span className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">No. {issue.number}</span>}
+          {issue.whole_number && (
+            <span className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">whole no. {issue.whole_number}</span>
+          )}
+          {issue.price_raw && <span className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">{issue.price_raw}</span>}
+          {issue.page_count !== null && (
+            <span className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">{issue.page_count} pages</span>
+          )}
+          <span className="rounded bg-sky-100 px-1.5 py-0.5 font-medium text-sky-900 dark:bg-sky-900/40 dark:text-sky-200">
+            {items.filter((e) => e.status !== "rejected").length} extracts
+          </span>
+          {issue.source_url && (
+            <a href={issue.source_url} className="text-neutral-500 underline decoration-dotted hover:text-neutral-700 dark:hover:text-neutral-300" rel="nofollow noopener">
+              scan source
+            </a>
+          )}
+        </div>
+        {supplements.length > 0 && (
+          <p className="mt-2 text-xs text-neutral-500">
+            Supplements:{" "}
+            {supplements.map((s, i) => (
+              <span key={i}>
+                {i > 0 && ", "}
+                {s.title}
+                {s.present ? "" : " (not in this scan)"}
+              </span>
+            ))}
+          </p>
+        )}
+        {issue.publisher_raw && <p className="mt-1 text-xs text-neutral-500">{issue.publisher_raw}</p>}
+
+        {rendering && <RenderProgress issueId={issue.id} />}
+      </div>
+
+      <IssueBrowser
+        issueId={issue.id}
+        binding={issue.binding}
+        pages={pageItems}
+        extracts={items}
+        pagesPublic={issue.pages_public || moderator}
+        moderator={moderator}
+      />
+    </main>
+  );
+}

--- a/hp-web/src/app/magazines/[slug]/page.tsx
+++ b/hp-web/src/app/magazines/[slug]/page.tsx
@@ -1,0 +1,88 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getPool } from "@/lib/db";
+import { issueHref, magThumbUrl } from "@/lib/mag/hrefs";
+import { getMagazineBySlug, listIssues } from "@/lib/mag/queries";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { slug } = await params;
+  const magazine = await getMagazineBySlug(getPool(), decodeURIComponent(slug));
+  if (!magazine) return {};
+  return { title: magazine.title, description: `${magazine.title}: indexed issues` };
+}
+
+// /magazines/<slug> — one magazine: identity block and the issue grid.
+export default async function MagazinePage({ params }: Params) {
+  const { slug } = await params;
+  const pool = getPool();
+  const magazine = await getMagazineBySlug(pool, decodeURIComponent(slug));
+  if (!magazine) notFound();
+  const issues = await listIssues(pool, magazine.id);
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      <Link href="/magazines" className="text-sm text-neutral-500 hover:underline">&larr; Magazines</Link>
+      <h1 className="mt-3 text-2xl font-semibold tracking-tight">{magazine.title}</h1>
+      <div className="mt-2 flex flex-wrap gap-2 text-xs">
+        {magazine.publisher && (
+          <span className="rounded bg-neutral-100 px-1.5 py-0.5 font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+            {magazine.publisher}
+          </span>
+        )}
+        {magazine.country && (
+          <span className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">{magazine.country}</span>
+        )}
+        {magazine.language && (
+          <span className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">{magazine.language}</span>
+        )}
+        {magazine.aliases.length > 0 && (
+          <span className="text-neutral-500">also known as {magazine.aliases.join(", ")}</span>
+        )}
+      </div>
+      {magazine.notes && <p className="mt-3 max-w-prose text-sm text-neutral-600 dark:text-neutral-400">{magazine.notes}</p>}
+
+      {issues.length === 0 ? (
+        <p className="mt-10 text-sm text-neutral-500">No issues indexed yet.</p>
+      ) : (
+        <ul className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+          {issues.map((i) => (
+            <li key={i.slug}>
+              <Link
+                href={issueHref(magazine.slug, i.slug)}
+                className="block rounded-md border border-neutral-300 p-3 transition-colors hover:border-neutral-400 dark:border-neutral-700 dark:hover:border-neutral-500"
+              >
+                {i.cover_sha ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={magThumbUrl(i.cover_sha, 500)}
+                    alt={`${i.label} cover`}
+                    className="aspect-[3/4] w-full rounded-sm bg-neutral-100 object-cover dark:bg-neutral-800"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="flex aspect-[3/4] w-full items-center justify-center rounded-sm bg-neutral-100 text-xs text-neutral-400 dark:bg-neutral-800">
+                    rendering…
+                  </div>
+                )}
+                <div className="mt-2 truncate text-sm font-medium">{i.label}</div>
+                <div className="text-xs text-neutral-500">
+                  {i.cover_date ? i.cover_date.slice(0, i.cover_date_precision === "year" ? 4 : 7) : "undated"}
+                  {" · "}
+                  {i.extract_count} {i.extract_count === 1 ? "extract" : "extracts"}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/hp-web/src/app/magazines/page.tsx
+++ b/hp-web/src/app/magazines/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Suspense } from "react";
+import { getPool } from "@/lib/db";
+import { magazineHref, magThumbUrl } from "@/lib/mag/hrefs";
+import { listMagazines } from "@/lib/mag/queries";
+import MagSearch from "./MagSearch";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Magazines",
+  description: "Searchable index of gaming magazine content: reviews, previews, interviews, ads, charts.",
+};
+
+// /magazines — every indexed magazine with its first cover and issue count,
+// plus full-text search across all extracts.
+export default async function MagazinesPage() {
+  const magazines = await listMagazines(getPool());
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      <Link href="/" className="text-sm text-neutral-500 hover:underline">&larr; Search</Link>
+      <h1 className="mt-3 text-2xl font-semibold tracking-tight">Magazines</h1>
+      <p className="mt-1 text-sm text-neutral-500">
+        Page-by-page index of gaming print media: every review, preview, interview, ad, chart, and tip,
+        searchable in the original language and in English.
+      </p>
+
+      <Suspense>
+        <MagSearch magazines={magazines.map((m) => ({ slug: m.slug, title: m.title }))} />
+      </Suspense>
+
+      {magazines.length === 0 ? (
+        <p className="mt-10 text-sm text-neutral-500">Nothing indexed yet.</p>
+      ) : (
+        <ul className="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+          {magazines.map((m) => (
+            <li key={m.slug}>
+              <Link
+                href={magazineHref(m.slug)}
+                className="block rounded-md border border-neutral-300 p-3 transition-colors hover:border-neutral-400 dark:border-neutral-700 dark:hover:border-neutral-500"
+              >
+                {m.cover_sha ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={magThumbUrl(m.cover_sha, 500)}
+                    alt={`${m.title} cover`}
+                    className="aspect-[3/4] w-full rounded-sm bg-neutral-100 object-cover dark:bg-neutral-800"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="flex aspect-[3/4] w-full items-center justify-center rounded-sm bg-neutral-100 text-xs text-neutral-400 dark:bg-neutral-800" >
+                    no cover yet
+                  </div>
+                )}
+                <div className="mt-2 truncate text-sm font-medium">{m.title}</div>
+                <div className="text-xs text-neutral-500">
+                  {m.issue_count} {m.issue_count === 1 ? "issue" : "issues"}
+                  {m.country ? ` · ${m.country}` : ""}
+                  {m.language ? ` · ${m.language}` : ""}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/hp-web/src/app/page.tsx
+++ b/hp-web/src/app/page.tsx
@@ -11,10 +11,23 @@ interface Hit {
   sim?: number | null;
 }
 
+interface MagHit {
+  id: number;
+  kind: string;
+  title: string | null;
+  section: string | null;
+  issue_slug: string;
+  issue_label: string;
+  cover_date: string | null;
+  magazine_slug: string;
+  magazine_title: string;
+}
+
 export default function Home() {
   const [q, setQ] = useState("");
   const [mode, setMode] = useState<string>("");
   const [hits, setHits] = useState<Hit[]>([]);
+  const [magHits, setMagHits] = useState<MagHit[]>([]);
   const [loading, setLoading] = useState(false);
   const [searched, setSearched] = useState(false);
 
@@ -22,10 +35,18 @@ export default function Home() {
     if (!term.trim()) return;
     setLoading(true);
     try {
+      // Magazine hits ride alongside; a hash-looking query skips them.
+      const magPromise = /^[0-9a-fA-F]{8,}$/.test(term.trim())
+        ? Promise.resolve<MagHit[]>([])
+        : fetch(`/api/mag/search?q=${encodeURIComponent(term)}&limit=5`)
+            .then((r) => r.json())
+            .then((d) => (d.results as MagHit[]) ?? [])
+            .catch(() => []);
       const res = await fetch(`/api/search?q=${encodeURIComponent(term)}`);
       const data = await res.json();
       setMode(data.mode ?? "");
       setHits(data.results ?? []);
+      setMagHits(await magPromise);
       setSearched(true);
     } finally {
       setLoading(false);
@@ -52,6 +73,7 @@ export default function Home() {
         <h1 className="text-2xl font-semibold tracking-tight">Prism</h1>
         <span className="flex gap-4 text-sm text-neutral-500">
           <Link href="/builds" className="hover:underline">Browse builds &rarr;</Link>
+          <Link href="/magazines" className="hover:underline">Magazines &rarr;</Link>
           <Link href="/moderate" className="hover:underline">Moderation &rarr;</Link>
         </span>
       </div>
@@ -99,7 +121,39 @@ export default function Home() {
             </ul>
           </>
         )}
-        {!loading && searched && hits.length === 0 && (
+        {!loading && magHits.length > 0 && (
+          <div className="mt-8">
+            <p className="mb-2 text-xs uppercase tracking-wide text-neutral-400">In magazines</p>
+            <ul className="divide-y divide-neutral-200 dark:divide-neutral-800">
+              {magHits.map((h) => (
+                <li key={h.id} className="py-3">
+                  <Link
+                    href={`/magazines/${h.magazine_slug}/${h.issue_slug}#x-${h.id}`}
+                    className="font-medium hover:underline"
+                  >
+                    {h.title || h.section || h.kind.replace("_", " ")}
+                  </Link>
+                  <div className="mt-0.5 flex gap-3 text-xs text-neutral-500">
+                    <span className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">
+                      {h.kind.replace("_", " ")}
+                    </span>
+                    <span>
+                      {h.magazine_title} {h.issue_label}
+                      {h.cover_date ? ` · ${h.cover_date.slice(0, 7)}` : ""}
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <Link
+              href={`/magazines?q=${encodeURIComponent(q)}`}
+              className="mt-2 inline-block text-xs text-sky-700 hover:underline dark:text-sky-300"
+            >
+              All magazine matches &rarr;
+            </Link>
+          </div>
+        )}
+        {!loading && searched && hits.length === 0 && magHits.length === 0 && (
           <p className="text-sm text-neutral-500">No matches.</p>
         )}
       </div>

--- a/hp-web/src/app/people/[slug]/page.tsx
+++ b/hp-web/src/app/people/[slug]/page.tsx
@@ -1,0 +1,111 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getPool } from "@/lib/db";
+import { extractAnchor, issueHref, magThumbUrl } from "@/lib/mag/hrefs";
+import { getPersonBySlug, getPersonCoverage, type CoverageItem } from "@/lib/mag/queries";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { slug } = await params;
+  const person = await getPersonBySlug(getPool(), decodeURIComponent(slug));
+  if (!person) return {};
+  return { title: person.name, description: `Magazine appearances of ${person.name}` };
+}
+
+const ROLE_GROUPS: { title: string; roles: string[] }[] = [
+  { title: "Interviews", roles: ["interviewee"] },
+  { title: "Written and drawn", roles: ["author", "artist", "reviewer", "interviewer"] },
+  { title: "Coverage", roles: ["subject"] },
+  { title: "Mentions", roles: ["mentioned"] },
+];
+
+function CoverageList({ items }: { items: CoverageItem[] }) {
+  return (
+    <ul className="mt-2 space-y-2">
+      {items.map((h) => (
+        <li key={`${h.id}-${h.role}`}>
+          <Link
+            href={`${issueHref(h.magazine_slug, h.issue_slug)}#${extractAnchor(h.id)}`}
+            className="flex gap-3 rounded-md border border-neutral-200 p-2 hover:border-neutral-400 dark:border-neutral-800 dark:hover:border-neutral-600"
+          >
+            {h.crop_sha256 && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={magThumbUrl(h.crop_sha256, 500)}
+                alt=""
+                className="h-16 w-16 shrink-0 rounded-sm bg-neutral-100 object-cover dark:bg-neutral-800"
+                loading="lazy"
+              />
+            )}
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium">{h.title || h.section || h.kind.replace("_", " ")}</div>
+              <div className="text-xs text-neutral-500">
+                {h.magazine_title} · {h.issue_label}
+                {h.cover_date ? ` · ${h.cover_date.slice(0, 7)}` : ""} ·{" "}
+                <span className="rounded bg-neutral-100 px-1 py-0.5 dark:bg-neutral-800">{h.kind.replace("_", " ")}</span>
+              </div>
+              {h.summary_en && (
+                <div className="mt-0.5 line-clamp-2 text-xs text-neutral-600 dark:text-neutral-400">{h.summary_en}</div>
+              )}
+            </div>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// /people/<slug> — a person, persona, or organization across the magazine
+// index: interviews first, then bylines, then coverage and mentions.
+export default async function PersonPage({ params }: Params) {
+  const { slug } = await params;
+  const pool = getPool();
+  const person = await getPersonBySlug(pool, decodeURIComponent(slug));
+  if (!person) notFound();
+  const coverage = await getPersonCoverage(pool, person.id);
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <Link href="/magazines" className="text-sm text-neutral-500 hover:underline">&larr; Magazines</Link>
+      <h1 className="mt-3 text-2xl font-semibold tracking-tight">
+        {person.name}
+        {person.name_original && person.name_original !== person.name && (
+          <span className="ml-2 text-lg font-normal text-neutral-500">{person.name_original}</span>
+        )}
+      </h1>
+      <div className="mt-2 flex flex-wrap gap-2 text-xs">
+        {person.kind !== "person" && (
+          <span className="rounded bg-violet-100 px-1.5 py-0.5 font-medium text-violet-900 dark:bg-violet-900/40 dark:text-violet-200">
+            {person.kind}
+          </span>
+        )}
+        {person.aliases.length > 0 && <span className="text-neutral-500">also credited as {person.aliases.join(", ")}</span>}
+      </div>
+      {person.notes && <p className="mt-3 max-w-prose text-sm text-neutral-600 dark:text-neutral-400">{person.notes}</p>}
+
+      {coverage.length === 0 ? (
+        <p className="mt-10 text-sm text-neutral-500">No indexed appearances yet.</p>
+      ) : (
+        ROLE_GROUPS.map((g) => {
+          const items = coverage.filter((c) => g.roles.includes(c.role));
+          if (items.length === 0) return null;
+          return (
+            <section key={g.title} className="mt-8">
+              <h2 className="text-lg font-medium">
+                {g.title} <span className="text-sm font-normal text-neutral-400">{items.length}</span>
+              </h2>
+              <CoverageList items={items} />
+            </section>
+          );
+        })
+      )}
+    </main>
+  );
+}

--- a/hp-web/src/lib/mag/hrefs.ts
+++ b/hp-web/src/lib/mag/hrefs.ts
@@ -1,0 +1,29 @@
+// Magazine URL helpers. Client-safe: no server-only imports (client
+// components build these links too). Blob URLs go through the app routes,
+// which 307 to the public gateway when one is configured.
+
+export function magazineHref(magSlug: string): string {
+  return `/magazines/${magSlug}`;
+}
+
+export function issueHref(magSlug: string, issueSlug: string): string {
+  return `/magazines/${magSlug}/${issueSlug}`;
+}
+
+/** Fragment id of one extract on its issue page (lightbox deep links use the
+ *  same convention as build media: navigation state lives in the URL). */
+export function extractAnchor(id: number): string {
+  return `x-${id}`;
+}
+
+export function magBlobUrl(sha256: string): string {
+  return `/api/mag/blob/${sha256}`;
+}
+
+export function magThumbUrl(sha256: string, w: 500 | 1000 = 500): string {
+  return `/api/mag/blob/${sha256}/thumb?w=${w}`;
+}
+
+export function personHref(slug: string): string {
+  return `/people/${slug}`;
+}

--- a/hp-web/src/lib/mag/kinds.ts
+++ b/hp-web/src/lib/mag/kinds.ts
@@ -1,0 +1,508 @@
+// Magazine extract taxonomy and ingest-payload validation.
+//
+// The taxonomy is deliberately app-side (no DB CHECK): the corpus keeps
+// producing new content shapes (survey: 143 issues, ~15 languages), and adding
+// a kind must stay a one-array edit. Validation here is structural — kinds,
+// regions, links, sizes — while `data` stays a schemaless JSONB payload with
+// only targeted shape checks, because score grids, chart entries, and ad
+// product lists differ per magazine and evolve per issue.
+//
+// Client-safe: no server-only imports (the moderation UI validates edits too).
+
+/** One extract = one addressable unit: a capsule review, a tip, a letter, an
+ *  ad, a chart. Derived from the phase-1 survey of EGM 022 (US), Beep!
+ *  MegaDrive 1991-08 (JP), and Supergame 01 (BR). */
+export const EXTRACT_KINDS = [
+  "cover", // front/back cover compositions
+  "toc",
+  "masthead", // staff/colophon blocks
+  "editorial",
+  "letters", // one reader letter + reply (or a letters solicitation)
+  "news",
+  "rumor", // gossip columns (Quartermann)
+  "preview", // upcoming-game coverage, fact-file features
+  "review", // scored or qualitative; data.subject_type: game|hardware|accessory|music
+  "feature", // long-form: company profiles, hardware launches, event specials
+  "interview",
+  "strategy", // walkthroughs, maps, move catalogs
+  "tips", // one trick/code/password with credit
+  "chart", // sales/reader/arcade/port-request rankings
+  "high_scores",
+  "calendar", // release calendars, availability lists
+  "contest", // house contests, giveaways/presents; data.subkind
+  "poster", // pin-ups/posters, text-free art pages
+  "comic",
+  "fiction", // novelizations, serials (may embed real directory data)
+  "column", // recurring branded opinion/essay
+  "ad", // data.ad_type: product|retail_mailorder|classified|house|consumer|school|service
+  "ad_index", // advertiser index tables
+  "next_issue",
+  "form", // standalone coupons/entry forms/questionnaires
+  "other", // tv listings, vox pop, lifestyle, quizzes
+] as const;
+
+export type ExtractKind = (typeof EXTRACT_KINDS)[number];
+
+export function isExtractKind(v: unknown): v is ExtractKind {
+  return typeof v === "string" && (EXTRACT_KINDS as readonly string[]).includes(v);
+}
+
+export const PERSON_ROLES = [
+  "interviewee",
+  "interviewer",
+  "author",
+  "artist",
+  "subject",
+  "mentioned",
+  "reviewer",
+] as const;
+export type PersonRole = (typeof PERSON_ROLES)[number];
+
+export const GAME_ROLES = ["subject", "mentioned", "listed"] as const;
+export type GameRole = (typeof GAME_ROLES)[number];
+
+export const PERSON_KINDS = ["person", "persona", "organization"] as const;
+export type PersonKind = (typeof PERSON_KINDS)[number];
+
+export const TAG_KINDS = ["company", "event", "hardware", "series", "topic"] as const;
+export type TagKind = (typeof TAG_KINDS)[number];
+
+export const EXTRACT_STATUSES = ["auto", "amended", "rejected"] as const;
+export type ExtractStatus = (typeof EXTRACT_STATUSES)[number];
+
+// Size caps. text_original is verbatim-everything by policy (price lists
+// included), so it gets real room; data holds structured entry arrays for the
+// same pages.
+export const MAX_TEXT_LEN = 200_000;
+export const MAX_SUMMARY_LEN = 2_000;
+export const MAX_TITLE_LEN = 500;
+export const MAX_SECTION_LEN = 200;
+export const MAX_DATA_BYTES = 200_000;
+export const MAX_REGIONS = 12;
+export const MAX_GAME_LINKS = 300; // reader-race charts list 108+ games
+export const MAX_PERSON_LINKS = 50;
+export const MAX_SYSTEM_LINKS = 20;
+export const MAX_TAG_LINKS = 50;
+export const MAX_BATCH = 50;
+export const MAX_CLIENT_KEY_LEN = 200;
+
+export interface RegionInput {
+  pdf_index: number;
+  /** Normalized 0-1 over the rendered page, origin top-left. */
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface GameLinkInput {
+  name: string;
+  system?: string;
+  role?: GameRole;
+  title_printed?: string;
+}
+
+export interface PersonLinkInput {
+  name: string;
+  slug?: string;
+  name_original?: string;
+  kind?: PersonKind;
+  role?: PersonRole;
+}
+
+export interface TagLinkInput {
+  name: string;
+  kind?: TagKind;
+}
+
+export interface ExtractInput {
+  client_key: string;
+  kind: ExtractKind;
+  section?: string;
+  seq?: number;
+  title?: string;
+  language: string;
+  text_original: string;
+  text_en?: string;
+  translation?: "machine" | "human";
+  summary_en?: string;
+  data?: Record<string, unknown>;
+  is_fictional?: boolean;
+  sponsored?: boolean;
+  content_warning?: string;
+  regions: RegionInput[];
+  games?: GameLinkInput[];
+  people?: PersonLinkInput[];
+  systems?: string[];
+  tags?: TagLinkInput[];
+}
+
+export type Validated<T> = { ok: true; value: T } | { ok: false; error: string };
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function optString(v: unknown, max: number, label: string): string | undefined {
+  if (v === undefined || v === null) return undefined;
+  if (typeof v !== "string") throw new Error(`${label} must be a string`);
+  const t = v.trim();
+  if (!t) return undefined;
+  if (t.length > max) throw new Error(`${label} too long (${t.length} > ${max})`);
+  return t;
+}
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+/** bcp47-ish: "en", "ja", "pt-br". Lowercased; no registry validation. */
+export function normalizeLang(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const t = v.trim().toLowerCase();
+  return /^[a-z]{2,3}(-[a-z0-9]{2,8})*$/.test(t) ? t : null;
+}
+
+function validateRegion(v: unknown, i: number): RegionInput {
+  if (!isRecord(v)) throw new Error(`regions[${i}] must be an object`);
+  const idx = v.pdf_index;
+  if (typeof idx !== "number" || !Number.isInteger(idx) || idx < 1 || idx > 10_000) {
+    throw new Error(`regions[${i}].pdf_index must be a positive page number`);
+  }
+  for (const k of ["x", "y", "w", "h"] as const) {
+    if (typeof v[k] !== "number" || !Number.isFinite(v[k] as number)) {
+      throw new Error(`regions[${i}].${k} must be a finite number`);
+    }
+  }
+  // Clamp instead of reject: vision bboxes run a hair out of range routinely,
+  // and a 1.02 that meant 1.0 should not fail a 400-page ingest.
+  const x = clamp01(v.x as number);
+  const y = clamp01(v.y as number);
+  const w = Math.min(clamp01(v.w as number), 1 - x);
+  const h = Math.min(clamp01(v.h as number), 1 - y);
+  if (w < 0.005 || h < 0.005) throw new Error(`regions[${i}] is degenerate after clamping`);
+  return { pdf_index: idx, x, y, w, h };
+}
+
+/** Validate one extract of an ingest batch. Returns a normalized copy
+ *  (trimmed strings, clamped regions) or the first structural error. */
+export function validateExtractInput(v: unknown): Validated<ExtractInput> {
+  try {
+    if (!isRecord(v)) throw new Error("extract must be an object");
+
+    const client_key = optString(v.client_key, MAX_CLIENT_KEY_LEN, "client_key");
+    if (!client_key) throw new Error("client_key is required");
+    if (!isExtractKind(v.kind)) throw new Error(`unknown kind: ${String(v.kind)}`);
+
+    const language = normalizeLang(v.language);
+    if (!language) throw new Error("language must be a bcp47 code like en, ja, pt-br");
+
+    if (typeof v.text_original !== "string") throw new Error("text_original must be a string");
+    if (v.text_original.length > MAX_TEXT_LEN) {
+      throw new Error(`text_original too long (${v.text_original.length} > ${MAX_TEXT_LEN})`);
+    }
+    const text_en = v.text_en === undefined || v.text_en === null ? undefined : v.text_en;
+    if (text_en !== undefined && typeof text_en !== "string") throw new Error("text_en must be a string");
+    if (typeof text_en === "string" && text_en.length > MAX_TEXT_LEN) {
+      throw new Error(`text_en too long (${text_en.length} > ${MAX_TEXT_LEN})`);
+    }
+    let translation: "machine" | "human" | undefined;
+    if (v.translation !== undefined && v.translation !== null) {
+      if (v.translation !== "machine" && v.translation !== "human") {
+        throw new Error("translation must be machine or human");
+      }
+      translation = v.translation;
+    }
+    if (text_en && !translation) translation = "machine";
+
+    let data: Record<string, unknown> | undefined;
+    if (v.data !== undefined && v.data !== null) {
+      if (!isRecord(v.data)) throw new Error("data must be an object");
+      const bytes = JSON.stringify(v.data).length;
+      if (bytes > MAX_DATA_BYTES) throw new Error(`data too large (${bytes} > ${MAX_DATA_BYTES})`);
+      // Targeted shape checks on the conventional array fields, so a skill
+      // bug (scores as a map, entries as strings) fails loudly at ingest.
+      for (const k of ["scores", "axes", "entries", "products", "prizes"] as const) {
+        const arr = v.data[k];
+        if (arr === undefined) continue;
+        if (!Array.isArray(arr)) throw new Error(`data.${k} must be an array`);
+        if (arr.some((e) => !isRecord(e))) throw new Error(`data.${k} entries must be objects`);
+      }
+      data = v.data;
+    }
+
+    if (!Array.isArray(v.regions) || v.regions.length === 0) {
+      throw new Error("regions must be a non-empty array");
+    }
+    if (v.regions.length > MAX_REGIONS) throw new Error(`too many regions (> ${MAX_REGIONS})`);
+    const regions = v.regions.map(validateRegion);
+
+    const games: GameLinkInput[] = [];
+    if (v.games !== undefined && v.games !== null) {
+      if (!Array.isArray(v.games)) throw new Error("games must be an array");
+      if (v.games.length > MAX_GAME_LINKS) throw new Error(`too many game links (> ${MAX_GAME_LINKS})`);
+      for (const [i, g] of v.games.entries()) {
+        if (!isRecord(g)) throw new Error(`games[${i}] must be an object`);
+        const name = optString(g.name, 300, `games[${i}].name`);
+        if (!name) throw new Error(`games[${i}].name is required`);
+        const role = g.role ?? "subject";
+        if (!(GAME_ROLES as readonly string[]).includes(role as string)) {
+          throw new Error(`games[${i}].role must be one of ${GAME_ROLES.join("|")}`);
+        }
+        games.push({
+          name,
+          system: optString(g.system, 100, `games[${i}].system`) ?? "",
+          role: role as GameRole,
+          title_printed: optString(g.title_printed, 300, `games[${i}].title_printed`),
+        });
+      }
+    }
+
+    const people: PersonLinkInput[] = [];
+    if (v.people !== undefined && v.people !== null) {
+      if (!Array.isArray(v.people)) throw new Error("people must be an array");
+      if (v.people.length > MAX_PERSON_LINKS) throw new Error(`too many person links (> ${MAX_PERSON_LINKS})`);
+      for (const [i, p] of v.people.entries()) {
+        if (!isRecord(p)) throw new Error(`people[${i}] must be an object`);
+        const name = optString(p.name, 200, `people[${i}].name`);
+        if (!name) throw new Error(`people[${i}].name is required`);
+        const kind = p.kind ?? "person";
+        if (!(PERSON_KINDS as readonly string[]).includes(kind as string)) {
+          throw new Error(`people[${i}].kind must be one of ${PERSON_KINDS.join("|")}`);
+        }
+        const role = p.role ?? "mentioned";
+        if (!(PERSON_ROLES as readonly string[]).includes(role as string)) {
+          throw new Error(`people[${i}].role must be one of ${PERSON_ROLES.join("|")}`);
+        }
+        people.push({
+          name,
+          slug: optString(p.slug, 200, `people[${i}].slug`),
+          name_original: optString(p.name_original, 200, `people[${i}].name_original`),
+          kind: kind as PersonKind,
+          role: role as PersonRole,
+        });
+      }
+    }
+
+    let systems: string[] = [];
+    if (v.systems !== undefined && v.systems !== null) {
+      if (!Array.isArray(v.systems)) throw new Error("systems must be an array");
+      if (v.systems.length > MAX_SYSTEM_LINKS) throw new Error(`too many systems (> ${MAX_SYSTEM_LINKS})`);
+      systems = v.systems.map((s, i) => {
+        const t = optString(s, 100, `systems[${i}]`);
+        if (!t) throw new Error(`systems[${i}] is empty`);
+        return t;
+      });
+    }
+
+    const tags: TagLinkInput[] = [];
+    if (v.tags !== undefined && v.tags !== null) {
+      if (!Array.isArray(v.tags)) throw new Error("tags must be an array");
+      if (v.tags.length > MAX_TAG_LINKS) throw new Error(`too many tags (> ${MAX_TAG_LINKS})`);
+      for (const [i, t] of v.tags.entries()) {
+        if (!isRecord(t)) throw new Error(`tags[${i}] must be an object`);
+        const name = optString(t.name, 200, `tags[${i}].name`);
+        if (!name) throw new Error(`tags[${i}].name is required`);
+        const kind = t.kind ?? "topic";
+        if (!(TAG_KINDS as readonly string[]).includes(kind as string)) {
+          throw new Error(`tags[${i}].kind must be one of ${TAG_KINDS.join("|")}`);
+        }
+        tags.push({ name, kind: kind as TagKind });
+      }
+    }
+
+    let seq: number | undefined;
+    if (v.seq !== undefined && v.seq !== null) {
+      if (typeof v.seq !== "number" || !Number.isInteger(v.seq) || v.seq < 0 || v.seq > 1_000_000) {
+        throw new Error("seq must be a non-negative integer");
+      }
+      seq = v.seq;
+    }
+
+    return {
+      ok: true,
+      value: {
+        client_key,
+        kind: v.kind,
+        section: optString(v.section, MAX_SECTION_LEN, "section"),
+        seq,
+        title: optString(v.title, MAX_TITLE_LEN, "title"),
+        language,
+        text_original: v.text_original,
+        text_en,
+        translation,
+        summary_en: optString(v.summary_en, MAX_SUMMARY_LEN, "summary_en"),
+        data,
+        is_fictional: v.is_fictional === true,
+        sponsored: v.sponsored === true,
+        content_warning: optString(v.content_warning, 500, "content_warning"),
+        regions,
+        games,
+        people,
+        systems,
+        tags,
+      },
+    };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+export interface IssueInput {
+  magazine: string; // magazine slug
+  slug: string;
+  label: string;
+  volume?: string;
+  number?: string;
+  whole_number?: string;
+  cover_date?: string; // ISO date
+  cover_date_precision?: "day" | "month" | "year";
+  price_raw?: string;
+  publisher_raw?: string;
+  page_count?: number;
+  binding?: "ltr" | "rtl";
+  source_url?: string;
+  supplements?: { title: string; present: boolean }[];
+  notes?: string;
+  /** Printed page labels by pdf index: {"4": "4", "56": "supp:6"}. */
+  page_labels?: Record<string, string>;
+}
+
+/** Issue tokens keep URLs tame: "022", "1991-08", "01", "ace-50-supplement". */
+export function isIssueSlug(v: unknown): v is string {
+  return typeof v === "string" && /^[a-z0-9][a-z0-9-]{0,63}$/.test(v);
+}
+
+export function validateIssueInput(v: unknown): Validated<IssueInput> {
+  try {
+    if (!isRecord(v)) throw new Error("issue must be an object");
+    const magazine = optString(v.magazine, 100, "magazine");
+    if (!magazine) throw new Error("magazine (slug) is required");
+    if (!isIssueSlug(v.slug)) throw new Error("slug must be [a-z0-9-], 1-64 chars");
+    const label = optString(v.label, 200, "label");
+    if (!label) throw new Error("label is required");
+
+    let cover_date: string | undefined;
+    if (v.cover_date !== undefined && v.cover_date !== null) {
+      if (typeof v.cover_date !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(v.cover_date)) {
+        throw new Error("cover_date must be YYYY-MM-DD");
+      }
+      cover_date = v.cover_date;
+    }
+    let precision: "day" | "month" | "year" | undefined;
+    if (v.cover_date_precision !== undefined && v.cover_date_precision !== null) {
+      if (v.cover_date_precision !== "day" && v.cover_date_precision !== "month" && v.cover_date_precision !== "year") {
+        throw new Error("cover_date_precision must be day|month|year");
+      }
+      precision = v.cover_date_precision;
+    }
+    if (cover_date && !precision) precision = "day";
+
+    let binding: "ltr" | "rtl" | undefined;
+    if (v.binding !== undefined && v.binding !== null) {
+      if (v.binding !== "ltr" && v.binding !== "rtl") throw new Error("binding must be ltr|rtl");
+      binding = v.binding;
+    }
+
+    let page_count: number | undefined;
+    if (v.page_count !== undefined && v.page_count !== null) {
+      if (typeof v.page_count !== "number" || !Number.isInteger(v.page_count) || v.page_count < 1 || v.page_count > 10_000) {
+        throw new Error("page_count must be a positive integer");
+      }
+      page_count = v.page_count;
+    }
+
+    let supplements: { title: string; present: boolean }[] | undefined;
+    if (v.supplements !== undefined && v.supplements !== null) {
+      if (!Array.isArray(v.supplements)) throw new Error("supplements must be an array");
+      supplements = v.supplements.map((s, i) => {
+        if (!isRecord(s)) throw new Error(`supplements[${i}] must be an object`);
+        const title = optString(s.title, 300, `supplements[${i}].title`);
+        if (!title) throw new Error(`supplements[${i}].title is required`);
+        return { title, present: s.present === true };
+      });
+    }
+
+    let page_labels: Record<string, string> | undefined;
+    if (v.page_labels !== undefined && v.page_labels !== null) {
+      if (!isRecord(v.page_labels)) throw new Error("page_labels must be an object");
+      page_labels = {};
+      for (const [k, val] of Object.entries(v.page_labels)) {
+        if (!/^\d{1,4}$/.test(k)) throw new Error(`page_labels key "${k}" must be a pdf index`);
+        const lab = optString(val, 40, `page_labels[${k}]`);
+        if (lab) page_labels[k] = lab;
+      }
+    }
+
+    return {
+      ok: true,
+      value: {
+        magazine,
+        slug: v.slug,
+        label,
+        volume: optString(v.volume, 50, "volume"),
+        number: optString(v.number, 50, "number"),
+        whole_number: optString(v.whole_number, 50, "whole_number"),
+        cover_date,
+        cover_date_precision: precision,
+        price_raw: optString(v.price_raw, 300, "price_raw"),
+        publisher_raw: optString(v.publisher_raw, 300, "publisher_raw"),
+        page_count,
+        binding,
+        source_url: optString(v.source_url, 1000, "source_url"),
+        supplements,
+        notes: optString(v.notes, 5000, "notes"),
+        page_labels,
+      },
+    };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+export interface MagazineInput {
+  slug?: string;
+  title: string;
+  aliases?: string[];
+  country?: string;
+  language?: string;
+  publisher?: string;
+  pages_public?: boolean;
+  notes?: string;
+}
+
+export function validateMagazineInput(v: unknown): Validated<MagazineInput> {
+  try {
+    if (!isRecord(v)) throw new Error("magazine must be an object");
+    const title = optString(v.title, 200, "title");
+    if (!title) throw new Error("title is required");
+    const slug = optString(v.slug, 100, "slug");
+    if (slug && !/^[a-z0-9][a-z0-9-]{0,63}$/.test(slug)) throw new Error("slug must be [a-z0-9-]");
+    let aliases: string[] | undefined;
+    if (v.aliases !== undefined && v.aliases !== null) {
+      if (!Array.isArray(v.aliases)) throw new Error("aliases must be an array");
+      aliases = v.aliases.map((a, i) => {
+        const t = optString(a, 200, `aliases[${i}]`);
+        if (!t) throw new Error(`aliases[${i}] is empty`);
+        return t;
+      });
+    }
+    const language = v.language === undefined || v.language === null ? undefined : normalizeLang(v.language);
+    if (language === null) throw new Error("language must be a bcp47 code");
+    return {
+      ok: true,
+      value: {
+        slug,
+        title,
+        aliases,
+        country: optString(v.country, 10, "country"),
+        language,
+        publisher: optString(v.publisher, 200, "publisher"),
+        pages_public: typeof v.pages_public === "boolean" ? v.pages_public : undefined,
+        notes: optString(v.notes, 5000, "notes"),
+      },
+    };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/hp-web/src/lib/mag/queries.ts
+++ b/hp-web/src/lib/mag/queries.ts
@@ -1,0 +1,925 @@
+// Magazine metadata queries: magazines/issues/pages, extract ingest (batch,
+// idempotent by client_key, moderation-preserving), moderation (amend with
+// audit trail, reject/restore), and the public read side (issue pages, game
+// coverage, person pages, search).
+//
+// Ingest ground rule: re-ingest may only replace status='auto' rows —
+// amended/rejected extracts are moderator data and survive any re-run (the
+// WHERE clauses here enforce it; it is not a convention the caller can miss).
+
+import { createHash } from "node:crypto";
+import type { Pool, PoolClient } from "pg";
+import { slugify } from "../slug";
+import { upsertGame } from "../queries";
+import type {
+  ExtractInput,
+  IssueInput,
+  MagazineInput,
+  PersonKind,
+  TagKind,
+} from "./kinds";
+
+// ── row types ────────────────────────────────────────────────────────────────
+
+export interface MagazineRow {
+  id: number;
+  slug: string;
+  title: string;
+  aliases: string[];
+  country: string;
+  language: string;
+  publisher: string;
+  pages_public: boolean;
+  notes: string;
+}
+
+export interface MagazineListItem extends MagazineRow {
+  issue_count: number;
+  cover_sha: string | null;
+}
+
+export interface IssueRow {
+  id: number;
+  magazine_id: number;
+  slug: string;
+  label: string;
+  volume: string | null;
+  number: string | null;
+  whole_number: string | null;
+  cover_date: string | null;
+  cover_date_precision: "day" | "month" | "year" | null;
+  price_raw: string | null;
+  publisher_raw: string | null;
+  page_count: number | null;
+  binding: "ltr" | "rtl";
+  pdf_sha256: string | null;
+  pdf_size: number | null;
+  source_url: string | null;
+  supplements: { title: string; present: boolean }[];
+  status: string;
+  notes: string;
+}
+
+export interface IssueWithMagazine extends IssueRow {
+  magazine_slug: string;
+  magazine_title: string;
+  pages_public: boolean;
+}
+
+export interface IssueListItem extends IssueRow {
+  cover_sha: string | null;
+  extract_count: number;
+}
+
+export interface PageRow {
+  id: number;
+  issue_id: number;
+  pdf_index: number;
+  printed_label: string | null;
+  width: number | null;
+  height: number | null;
+  image_sha256: string | null;
+}
+
+export interface RegionView {
+  id: number;
+  seq: number;
+  pdf_index: number;
+  printed_label: string | null;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  crop_sha256: string | null;
+  page_sha256: string | null;
+  page_width: number | null;
+  page_height: number | null;
+}
+
+export interface GameLinkView {
+  game_id: number;
+  name: string;
+  system: string;
+  slug: string | null;
+  role: string;
+  title_printed: string | null;
+}
+
+export interface PersonLinkView {
+  person_id: number;
+  slug: string;
+  name: string;
+  name_original: string | null;
+  kind: string;
+  role: string;
+}
+
+export interface TagView {
+  slug: string;
+  kind: string;
+  name: string;
+}
+
+export interface ExtractView {
+  id: number;
+  issue_id: number;
+  kind: string;
+  section: string | null;
+  seq: number;
+  title: string | null;
+  language: string;
+  text_original: string;
+  text_en: string | null;
+  translation: "machine" | "human" | null;
+  summary_en: string | null;
+  data: Record<string, unknown>;
+  is_fictional: boolean;
+  sponsored: boolean;
+  content_warning: string | null;
+  status: string;
+  regions: RegionView[];
+  games: GameLinkView[];
+  people: PersonLinkView[];
+  systems: string[];
+  tags: TagView[];
+}
+
+const EXTRACT_COLS = `e.id::int AS id, e.issue_id::int AS issue_id, e.kind, e.section, e.seq::int AS seq,
+  e.title, e.language, e.text_original, e.text_en, e.translation, e.summary_en, e.data,
+  e.is_fictional, e.sponsored, e.content_warning, e.status`;
+
+/** The aggregated sub-selects every ExtractView needs. Keyed off alias `e`. */
+const EXTRACT_AGG = `
+  COALESCE((SELECT json_agg(json_build_object(
+      'id', r.id::int, 'seq', r.seq::int, 'pdf_index', p.pdf_index::int,
+      'printed_label', p.printed_label,
+      'x', r.x, 'y', r.y, 'w', r.w, 'h', r.h,
+      'crop_sha256', r.crop_sha256, 'page_sha256', p.image_sha256,
+      'page_width', p.width::int, 'page_height', p.height::int) ORDER BY r.seq)
+    FROM extract_region r JOIN magazine_page p ON p.id=r.page_id
+    WHERE r.extract_id=e.id), '[]') AS regions,
+  COALESCE((SELECT json_agg(json_build_object(
+      'game_id', g.id::int, 'name', g.name, 'system', g.system, 'slug', g.slug,
+      'role', eg.role, 'title_printed', eg.title_printed) ORDER BY g.name)
+    FROM extract_game eg JOIN games g ON g.id=eg.game_id
+    WHERE eg.extract_id=e.id), '[]') AS games,
+  COALESCE((SELECT json_agg(json_build_object(
+      'person_id', pe.id::int, 'slug', pe.slug, 'name', pe.name,
+      'name_original', pe.name_original, 'kind', pe.kind, 'role', ep.role) ORDER BY pe.name)
+    FROM extract_person ep JOIN people pe ON pe.id=ep.person_id
+    WHERE ep.extract_id=e.id), '[]') AS people,
+  COALESCE((SELECT json_agg(es.system ORDER BY es.system)
+    FROM extract_system es WHERE es.extract_id=e.id), '[]') AS systems,
+  COALESCE((SELECT json_agg(json_build_object('slug', t.slug, 'kind', t.kind, 'name', t.name) ORDER BY t.name)
+    FROM extract_tag et JOIN mag_tag t ON t.id=et.tag_id
+    WHERE et.extract_id=e.id), '[]') AS tags`;
+
+// ── magazines ────────────────────────────────────────────────────────────────
+
+export async function upsertMagazine(pool: Pool, input: MagazineInput): Promise<MagazineRow> {
+  const slug = input.slug ?? slugify(input.title);
+  if (!slug) throw new Error("magazine title yields an empty slug; pass slug explicitly");
+  const r = await pool.query(
+    `INSERT INTO magazines (slug, title, aliases, country, language, publisher, pages_public, notes)
+     VALUES ($1, $2, COALESCE($3::text[], '{}'::text[]), COALESCE($4, ''), COALESCE($5, ''), COALESCE($6, ''), COALESCE($7::boolean, TRUE), COALESCE($8, ''))
+     ON CONFLICT (slug) DO UPDATE SET
+       title        = excluded.title,
+       aliases      = COALESCE($3::text[], magazines.aliases),
+       country      = COALESCE($4, magazines.country),
+       language     = COALESCE($5, magazines.language),
+       publisher    = COALESCE($6, magazines.publisher),
+       pages_public = COALESCE($7::boolean, magazines.pages_public),
+       notes        = COALESCE($8, magazines.notes)
+     RETURNING id::int AS id, slug, title, aliases, country, language, publisher, pages_public, notes`,
+    [
+      slug,
+      input.title,
+      input.aliases ?? null,
+      input.country ?? null,
+      input.language ?? null,
+      input.publisher ?? null,
+      input.pages_public ?? null,
+      input.notes ?? null,
+    ]
+  );
+  return r.rows[0] as MagazineRow;
+}
+
+export async function getMagazineBySlug(pool: Pool, slug: string): Promise<MagazineRow | null> {
+  const r = await pool.query(
+    `SELECT id::int AS id, slug, title, aliases, country, language, publisher, pages_public, notes
+     FROM magazines WHERE slug=$1`,
+    [slug]
+  );
+  return (r.rows[0] as MagazineRow) ?? null;
+}
+
+export async function listMagazines(pool: Pool): Promise<MagazineListItem[]> {
+  const r = await pool.query(
+    `SELECT m.id::int AS id, m.slug, m.title, m.aliases, m.country, m.language, m.publisher,
+            m.pages_public, m.notes,
+            (SELECT count(*) FROM magazine_issue i WHERE i.magazine_id=m.id)::int AS issue_count,
+            (SELECT p.image_sha256 FROM magazine_issue i
+               JOIN magazine_page p ON p.issue_id=i.id AND p.pdf_index=1
+             WHERE i.magazine_id=m.id AND p.image_sha256 IS NOT NULL
+             ORDER BY i.cover_date ASC NULLS LAST, i.slug LIMIT 1) AS cover_sha
+     FROM magazines m
+     ORDER BY lower(m.title)`
+  );
+  return r.rows as MagazineListItem[];
+}
+
+// ── issues ───────────────────────────────────────────────────────────────────
+
+const ISSUE_COLS = `i.id::int AS id, i.magazine_id::int AS magazine_id, i.slug, i.label, i.volume,
+  i.number, i.whole_number, i.cover_date::text AS cover_date, i.cover_date_precision,
+  i.price_raw, i.publisher_raw, i.page_count::int AS page_count, i.binding,
+  i.pdf_sha256, i.pdf_size::float8 AS pdf_size, i.source_url, i.supplements, i.status, i.notes`;
+
+export async function upsertIssue(pool: Pool, magazineId: number, input: IssueInput): Promise<IssueRow> {
+  const r = await pool.query(
+    `INSERT INTO magazine_issue (magazine_id, slug, label, volume, number, whole_number,
+        cover_date, cover_date_precision, price_raw, publisher_raw, page_count, binding,
+        source_url, supplements, notes)
+     VALUES ($1,$2,$3,$4,$5,$6,$7::date,$8,$9,$10,$11::int,COALESCE($12,'ltr'),$13,COALESCE($14::jsonb,'[]'::jsonb),COALESCE($15,''))
+     ON CONFLICT (magazine_id, slug) DO UPDATE SET
+       label        = excluded.label,
+       volume       = COALESCE($4,  magazine_issue.volume),
+       number       = COALESCE($5,  magazine_issue.number),
+       whole_number = COALESCE($6,  magazine_issue.whole_number),
+       cover_date   = COALESCE($7::date,  magazine_issue.cover_date),
+       cover_date_precision = COALESCE($8, magazine_issue.cover_date_precision),
+       price_raw    = COALESCE($9,  magazine_issue.price_raw),
+       publisher_raw= COALESCE($10, magazine_issue.publisher_raw),
+       page_count   = COALESCE($11::int, magazine_issue.page_count),
+       binding      = COALESCE($12, magazine_issue.binding),
+       source_url   = COALESCE($13, magazine_issue.source_url),
+       supplements  = COALESCE($14::jsonb, magazine_issue.supplements),
+       notes        = COALESCE($15, magazine_issue.notes),
+       updated_at   = now()
+     RETURNING ${ISSUE_COLS.replaceAll("i.", "magazine_issue.")}`,
+    [
+      magazineId,
+      input.slug,
+      input.label,
+      input.volume ?? null,
+      input.number ?? null,
+      input.whole_number ?? null,
+      input.cover_date ?? null,
+      input.cover_date_precision ?? null,
+      input.price_raw ?? null,
+      input.publisher_raw ?? null,
+      input.page_count ?? null,
+      input.binding ?? null,
+      input.source_url ?? null,
+      input.supplements ? JSON.stringify(input.supplements) : null,
+      input.notes ?? null,
+    ]
+  );
+  const issue = r.rows[0] as IssueRow;
+  if (input.page_labels) {
+    for (const [idx, label] of Object.entries(input.page_labels)) {
+      await pool.query(
+        `INSERT INTO magazine_page (issue_id, pdf_index, printed_label) VALUES ($1,$2,$3)
+         ON CONFLICT (issue_id, pdf_index) DO UPDATE SET printed_label=$3`,
+        [issue.id, parseInt(idx, 10), label]
+      );
+    }
+  }
+  return issue;
+}
+
+export async function getIssue(pool: Pool, magSlug: string, issueSlug: string): Promise<IssueWithMagazine | null> {
+  const r = await pool.query(
+    `SELECT ${ISSUE_COLS}, m.slug AS magazine_slug, m.title AS magazine_title, m.pages_public
+     FROM magazine_issue i JOIN magazines m ON m.id=i.magazine_id
+     WHERE m.slug=$1 AND i.slug=$2`,
+    [magSlug, issueSlug]
+  );
+  return (r.rows[0] as IssueWithMagazine) ?? null;
+}
+
+export async function getIssueById(pool: Pool, id: number): Promise<IssueWithMagazine | null> {
+  const r = await pool.query(
+    `SELECT ${ISSUE_COLS}, m.slug AS magazine_slug, m.title AS magazine_title, m.pages_public
+     FROM magazine_issue i JOIN magazines m ON m.id=i.magazine_id
+     WHERE i.id=$1`,
+    [id]
+  );
+  return (r.rows[0] as IssueWithMagazine) ?? null;
+}
+
+export async function listIssues(pool: Pool, magazineId: number): Promise<IssueListItem[]> {
+  const r = await pool.query(
+    `SELECT ${ISSUE_COLS},
+            (SELECT p.image_sha256 FROM magazine_page p
+             WHERE p.issue_id=i.id AND p.pdf_index=1) AS cover_sha,
+            (SELECT count(*) FROM magazine_extract e
+             WHERE e.issue_id=i.id AND e.status<>'rejected')::int AS extract_count
+     FROM magazine_issue i
+     WHERE i.magazine_id=$1
+     ORDER BY i.cover_date ASC NULLS LAST, i.slug`,
+    [magazineId]
+  );
+  return r.rows as IssueListItem[];
+}
+
+export async function setIssuePdf(pool: Pool, issueId: number, sha256: string, size: number): Promise<void> {
+  await pool.query(
+    `UPDATE magazine_issue SET pdf_sha256=$2, pdf_size=$3,
+        status = CASE WHEN status='new' THEN 'rendering' ELSE status END,
+        updated_at=now()
+     WHERE id=$1`,
+    [issueId, sha256, size]
+  );
+}
+
+export async function setIssueStatus(pool: Pool, issueId: number, status: string): Promise<void> {
+  await pool.query("UPDATE magazine_issue SET status=$2, updated_at=now() WHERE id=$1", [issueId, status]);
+}
+
+export async function listIssuePages(pool: Pool, issueId: number): Promise<PageRow[]> {
+  const r = await pool.query(
+    `SELECT id::int AS id, issue_id::int AS issue_id, pdf_index::int AS pdf_index, printed_label,
+            width::int AS width, height::int AS height, image_sha256
+     FROM magazine_page WHERE issue_id=$1 ORDER BY pdf_index`,
+    [issueId]
+  );
+  return r.rows as PageRow[];
+}
+
+// ── people and tags ──────────────────────────────────────────────────────────
+
+export interface PersonRow {
+  id: number;
+  slug: string;
+  name: string;
+  name_original: string | null;
+  kind: string;
+  aliases: string[];
+  notes: string;
+}
+
+/** Deterministic slug for names that survive slugify empty (CJK without a
+ *  provided romanization): p-<first 8 hex of sha256(name)>. */
+export function personSlugFor(name: string, provided?: string): string {
+  if (provided) return provided;
+  const s = slugify(name);
+  if (s) return s;
+  return "p-" + createHash("sha256").update(name).digest("hex").slice(0, 8);
+}
+
+export async function upsertPerson(
+  pool: Pool,
+  p: { name: string; slug?: string; name_original?: string; kind?: PersonKind }
+): Promise<PersonRow> {
+  const slug = personSlugFor(p.name, p.slug);
+  const r = await pool.query(
+    `INSERT INTO people (slug, name, name_original, kind)
+     VALUES ($1, $2, $3, COALESCE($4, 'person'))
+     ON CONFLICT (slug) DO UPDATE SET
+       name_original = COALESCE(people.name_original, excluded.name_original)
+     RETURNING id::int AS id, slug, name, name_original, kind, aliases, notes`,
+    [slug, p.name, p.name_original ?? null, p.kind ?? null]
+  );
+  return r.rows[0] as PersonRow;
+}
+
+export async function getPersonBySlug(pool: Pool, slug: string): Promise<PersonRow | null> {
+  const r = await pool.query(
+    "SELECT id::int AS id, slug, name, name_original, kind, aliases, notes FROM people WHERE slug=$1",
+    [slug]
+  );
+  return (r.rows[0] as PersonRow) ?? null;
+}
+
+export async function upsertTag(pool: Pool, kind: TagKind, name: string): Promise<{ id: number; slug: string }> {
+  const base = slugify(name) || createHash("sha256").update(name).digest("hex").slice(0, 8);
+  const slug = `${kind}-${base}`;
+  const r = await pool.query(
+    `INSERT INTO mag_tag (slug, kind, name) VALUES ($1, $2, $3)
+     ON CONFLICT (slug) DO UPDATE SET name=excluded.name
+     RETURNING id::int AS id, slug`,
+    [slug, kind, name]
+  );
+  return r.rows[0] as { id: number; slug: string };
+}
+
+// ── extract ingest ───────────────────────────────────────────────────────────
+
+export type IngestResult =
+  | { client_key: string; id: number; action: "inserted" | "updated" }
+  | { client_key: string; skipped: "moderated" | "error"; error?: string };
+
+/** Ingest one validated extract. Entities are upserted outside the
+ *  transaction (idempotent either way); the extract row, its regions, and
+ *  its links commit atomically. An existing amended/rejected row under the
+ *  same client_key is left untouched. */
+export async function ingestExtract(pool: Pool, issueId: number, e: ExtractInput): Promise<IngestResult> {
+  try {
+    const gameIds: { id: number; role: string; title_printed: string | null }[] = [];
+    for (const g of e.games ?? []) {
+      const row = await upsertGame(pool, g.name, g.system ?? "");
+      if (!gameIds.some((x) => x.id === row.id)) {
+        gameIds.push({ id: row.id, role: g.role ?? "subject", title_printed: g.title_printed ?? null });
+      }
+    }
+    const personIds: { id: number; role: string }[] = [];
+    for (const p of e.people ?? []) {
+      const row = await upsertPerson(pool, p);
+      personIds.push({ id: row.id, role: p.role ?? "mentioned" });
+    }
+    const tagIds: number[] = [];
+    for (const t of e.tags ?? []) {
+      const row = await upsertTag(pool, t.kind ?? "topic", t.name);
+      if (!tagIds.includes(row.id)) tagIds.push(row.id);
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const result = await ingestExtractTx(client, issueId, e, gameIds, personIds, tagIds);
+      await client.query("COMMIT");
+      return result;
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
+  } catch (err) {
+    return {
+      client_key: e.client_key,
+      skipped: "error",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function ingestExtractTx(
+  client: PoolClient,
+  issueId: number,
+  e: ExtractInput,
+  gameIds: { id: number; role: string; title_printed: string | null }[],
+  personIds: { id: number; role: string }[],
+  tagIds: number[]
+): Promise<IngestResult> {
+  const existing = await client.query(
+    "SELECT id::int AS id, status FROM magazine_extract WHERE issue_id=$1 AND client_key=$2 FOR UPDATE",
+    [issueId, e.client_key]
+  );
+  const prior = existing.rows[0] as { id: number; status: string } | undefined;
+  if (prior && prior.status !== "auto") {
+    return { client_key: e.client_key, skipped: "moderated" };
+  }
+
+  // Page rows for every referenced pdf index (render may not have run yet).
+  const pageIds = new Map<number, number>();
+  for (const idx of new Set(e.regions.map((r) => r.pdf_index))) {
+    const p = await client.query(
+      `INSERT INTO magazine_page (issue_id, pdf_index) VALUES ($1,$2)
+       ON CONFLICT (issue_id, pdf_index) DO UPDATE SET pdf_index=excluded.pdf_index
+       RETURNING id::int AS id`,
+      [issueId, idx]
+    );
+    pageIds.set(idx, (p.rows[0] as { id: number }).id);
+  }
+
+  const cols = [
+    e.kind,
+    e.section ?? null,
+    e.seq ?? 0,
+    e.title ?? null,
+    e.language,
+    e.text_original,
+    e.text_en ?? null,
+    e.translation ?? null,
+    e.summary_en ?? null,
+    JSON.stringify(e.data ?? {}),
+    e.is_fictional ?? false,
+    e.sponsored ?? false,
+    e.content_warning ?? null,
+  ];
+
+  let id: number;
+  let action: "inserted" | "updated";
+  if (prior) {
+    const u = await client.query(
+      `UPDATE magazine_extract SET kind=$3, section=$4, seq=$5, title=$6, language=$7,
+          text_original=$8, text_en=$9, translation=$10, summary_en=$11, data=$12,
+          is_fictional=$13, sponsored=$14, content_warning=$15, updated_at=now()
+       WHERE id=$1 AND status='auto' AND issue_id=$2
+       RETURNING id::int AS id`,
+      [prior.id, issueId, ...cols]
+    );
+    if (!u.rows[0]) return { client_key: e.client_key, skipped: "moderated" };
+    id = prior.id;
+    action = "updated";
+    await client.query("DELETE FROM extract_region WHERE extract_id=$1", [id]);
+    await client.query("DELETE FROM extract_game WHERE extract_id=$1", [id]);
+    await client.query("DELETE FROM extract_person WHERE extract_id=$1", [id]);
+    await client.query("DELETE FROM extract_system WHERE extract_id=$1", [id]);
+    await client.query("DELETE FROM extract_tag WHERE extract_id=$1", [id]);
+  } else {
+    const ins = await client.query(
+      `INSERT INTO magazine_extract (issue_id, client_key, kind, section, seq, title, language,
+          text_original, text_en, translation, summary_en, data, is_fictional, sponsored, content_warning)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+       RETURNING id::int AS id`,
+      [issueId, e.client_key, ...cols]
+    );
+    id = (ins.rows[0] as { id: number }).id;
+    action = "inserted";
+  }
+
+  for (const [i, r] of e.regions.entries()) {
+    await client.query(
+      `INSERT INTO extract_region (extract_id, page_id, seq, x, y, w, h) VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+      [id, pageIds.get(r.pdf_index), i, r.x, r.y, r.w, r.h]
+    );
+  }
+  for (const g of gameIds) {
+    await client.query(
+      `INSERT INTO extract_game (extract_id, game_id, role, title_printed) VALUES ($1,$2,$3,$4)
+       ON CONFLICT (extract_id, game_id) DO NOTHING`,
+      [id, g.id, g.role, g.title_printed]
+    );
+  }
+  for (const p of personIds) {
+    await client.query(
+      `INSERT INTO extract_person (extract_id, person_id, role) VALUES ($1,$2,$3)
+       ON CONFLICT DO NOTHING`,
+      [id, p.id, p.role]
+    );
+  }
+  for (const s of e.systems ?? []) {
+    await client.query(
+      `INSERT INTO extract_system (extract_id, system) VALUES ($1,$2) ON CONFLICT DO NOTHING`,
+      [id, s]
+    );
+  }
+  for (const t of tagIds) {
+    await client.query(
+      `INSERT INTO extract_tag (extract_id, tag_id) VALUES ($1,$2) ON CONFLICT DO NOTHING`,
+      [id, t]
+    );
+  }
+  return { client_key: e.client_key, id, action };
+}
+
+/** Ingest reset that provably cannot touch moderated rows. */
+export async function deleteAutoExtracts(pool: Pool, issueId: number): Promise<number> {
+  const r = await pool.query("DELETE FROM magazine_extract WHERE issue_id=$1 AND status='auto'", [issueId]);
+  return r.rowCount ?? 0;
+}
+
+// ── extract reads ────────────────────────────────────────────────────────────
+
+function toView(row: Record<string, unknown>): ExtractView {
+  return row as unknown as ExtractView;
+}
+
+export async function getExtract(pool: Pool, id: number): Promise<ExtractView | null> {
+  const r = await pool.query(
+    `SELECT ${EXTRACT_COLS}, ${EXTRACT_AGG} FROM magazine_extract e WHERE e.id=$1`,
+    [id]
+  );
+  return r.rows[0] ? toView(r.rows[0]) : null;
+}
+
+export async function getIssueExtracts(
+  pool: Pool,
+  issueId: number,
+  includeRejected = false
+): Promise<ExtractView[]> {
+  const r = await pool.query(
+    `SELECT ${EXTRACT_COLS}, ${EXTRACT_AGG}
+     FROM magazine_extract e
+     WHERE e.issue_id=$1 AND ${includeRejected ? "TRUE" : "e.status <> 'rejected'"}
+     ORDER BY e.seq, e.id`,
+    [issueId]
+  );
+  return r.rows.map(toView);
+}
+
+// ── moderation ───────────────────────────────────────────────────────────────
+
+/** Fields a moderator may patch. Regions are patched separately (they carry
+ *  derived crops). */
+export const AMENDABLE_FIELDS = [
+  "kind",
+  "section",
+  "seq",
+  "title",
+  "language",
+  "text_original",
+  "text_en",
+  "translation",
+  "summary_en",
+  "data",
+  "is_fictional",
+  "sponsored",
+  "content_warning",
+] as const;
+export type AmendableField = (typeof AMENDABLE_FIELDS)[number];
+
+export interface AmendPatch {
+  fields?: Partial<Record<AmendableField, unknown>>;
+  /** Full region replacement: resets crops (they regenerate). */
+  regions?: { pdf_index: number; x: number; y: number; w: number; h: number }[];
+  note?: string;
+}
+
+export async function amendExtract(
+  pool: Pool,
+  id: number,
+  patch: AmendPatch,
+  editor: string
+): Promise<ExtractView | null> {
+  const current = await getExtract(pool, id);
+  if (!current) return null;
+
+  const change: Record<string, [unknown, unknown]> = {};
+  const sets: string[] = [];
+  const params: unknown[] = [id];
+  for (const f of AMENDABLE_FIELDS) {
+    if (!patch.fields || !(f in patch.fields)) continue;
+    const next = patch.fields[f] ?? null;
+    const prev = (current as unknown as Record<string, unknown>)[f] ?? null;
+    if (JSON.stringify(prev) === JSON.stringify(next)) continue;
+    change[f] = [prev, next];
+    params.push(f === "data" ? JSON.stringify(next ?? {}) : next);
+    sets.push(`${f}=$${params.length}`);
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    if (sets.length) {
+      await client.query(
+        `UPDATE magazine_extract SET ${sets.join(", ")},
+            status = CASE WHEN status='rejected' THEN 'rejected' ELSE 'amended' END,
+            updated_at=now()
+         WHERE id=$1`,
+        params
+      );
+    } else if (patch.regions) {
+      await client.query(
+        `UPDATE magazine_extract SET
+            status = CASE WHEN status='rejected' THEN 'rejected' ELSE 'amended' END,
+            updated_at=now()
+         WHERE id=$1`,
+        [id]
+      );
+    }
+    if (patch.regions) {
+      change["regions"] = [
+        current.regions.map((r) => ({ pdf_index: r.pdf_index, x: r.x, y: r.y, w: r.w, h: r.h })),
+        patch.regions,
+      ];
+      await client.query("DELETE FROM extract_region WHERE extract_id=$1", [id]);
+      for (const [i, r] of patch.regions.entries()) {
+        const p = await client.query(
+          `INSERT INTO magazine_page (issue_id, pdf_index) VALUES ($1,$2)
+           ON CONFLICT (issue_id, pdf_index) DO UPDATE SET pdf_index=excluded.pdf_index
+           RETURNING id::int AS id`,
+          [current.issue_id, r.pdf_index]
+        );
+        await client.query(
+          "INSERT INTO extract_region (extract_id, page_id, seq, x, y, w, h) VALUES ($1,$2,$3,$4,$5,$6,$7)",
+          [id, (p.rows[0] as { id: number }).id, i, r.x, r.y, r.w, r.h]
+        );
+      }
+    }
+    if (Object.keys(change).length) {
+      await client.query(
+        "INSERT INTO extract_revision (extract_id, editor, change, note) VALUES ($1,$2,$3,$4)",
+        [id, editor, JSON.stringify(change), patch.note ?? null]
+      );
+    }
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+  return getExtract(pool, id);
+}
+
+export async function setExtractRejected(
+  pool: Pool,
+  id: number,
+  rejected: boolean,
+  editor: string,
+  note?: string
+): Promise<ExtractView | null> {
+  const current = await getExtract(pool, id);
+  if (!current) return null;
+  const next = rejected ? "rejected" : "amended";
+  if (current.status === next) return current;
+  await pool.query("UPDATE magazine_extract SET status=$2, updated_at=now() WHERE id=$1", [id, next]);
+  await pool.query("INSERT INTO extract_revision (extract_id, editor, change, note) VALUES ($1,$2,$3,$4)", [
+    id,
+    editor,
+    JSON.stringify({ status: [current.status, next] }),
+    note ?? null,
+  ]);
+  return getExtract(pool, id);
+}
+
+export interface RevisionRow {
+  id: number;
+  extract_id: number;
+  editor: string;
+  change: Record<string, [unknown, unknown]>;
+  note: string | null;
+  created_at: string;
+}
+
+export async function listExtractRevisions(pool: Pool, extractId: number): Promise<RevisionRow[]> {
+  const r = await pool.query(
+    `SELECT id::int AS id, extract_id::int AS extract_id, editor, change, note, created_at::text AS created_at
+     FROM extract_revision WHERE extract_id=$1 ORDER BY id DESC`,
+    [extractId]
+  );
+  return r.rows as RevisionRow[];
+}
+
+// ── cross-entity reads (game pages, person pages, search) ────────────────────
+
+export interface CoverageItem {
+  id: number;
+  kind: string;
+  section: string | null;
+  title: string | null;
+  language: string;
+  summary_en: string | null;
+  data: Record<string, unknown>;
+  status: string;
+  role: string;
+  title_printed: string | null;
+  issue_id: number;
+  issue_slug: string;
+  issue_label: string;
+  cover_date: string | null;
+  magazine_slug: string;
+  magazine_title: string;
+  crop_sha256: string | null;
+}
+
+const COVERAGE_COLS = `e.id::int AS id, e.kind, e.section, e.title, e.language, e.summary_en, e.data, e.status,
+  i.id::int AS issue_id, i.slug AS issue_slug, i.label AS issue_label, i.cover_date::text AS cover_date,
+  m.slug AS magazine_slug, m.title AS magazine_title,
+  (SELECT r.crop_sha256 FROM extract_region r WHERE r.extract_id=e.id AND r.crop_sha256 IS NOT NULL
+   ORDER BY r.seq LIMIT 1) AS crop_sha256`;
+
+export async function getGameCoverage(pool: Pool, gameId: number): Promise<CoverageItem[]> {
+  const r = await pool.query(
+    `SELECT ${COVERAGE_COLS}, eg.role, eg.title_printed
+     FROM extract_game eg
+     JOIN magazine_extract e ON e.id=eg.extract_id AND e.status <> 'rejected'
+     JOIN magazine_issue i ON i.id=e.issue_id
+     JOIN magazines m ON m.id=i.magazine_id
+     WHERE eg.game_id=$1
+     ORDER BY i.cover_date ASC NULLS LAST, e.seq`,
+    [gameId]
+  );
+  return r.rows as CoverageItem[];
+}
+
+export async function getPersonCoverage(pool: Pool, personId: number): Promise<CoverageItem[]> {
+  const r = await pool.query(
+    `SELECT ${COVERAGE_COLS}, ep.role, NULL::text AS title_printed
+     FROM extract_person ep
+     JOIN magazine_extract e ON e.id=ep.extract_id AND e.status <> 'rejected'
+     JOIN magazine_issue i ON i.id=e.issue_id
+     JOIN magazines m ON m.id=i.magazine_id
+     WHERE ep.person_id=$1
+     ORDER BY i.cover_date ASC NULLS LAST, e.seq`,
+    [personId]
+  );
+  return r.rows as CoverageItem[];
+}
+
+export interface MagSearchFilters {
+  magazine?: string;
+  kind?: string;
+  system?: string;
+  language?: string;
+  person?: string;
+  game?: string;
+  from?: string; // YYYY-MM-DD on cover_date
+  to?: string;
+  limit?: number;
+}
+
+export interface MagSearchHit extends CoverageItem {
+  snippet: string | null;
+  rank: number;
+}
+
+/** Extract search. A quoted query ("...") is an exact substring match via
+ *  trigram (also the only useful path for CJK); anything else is FTS over the
+ *  original ('simple') and English sides, ranked. */
+export async function searchExtracts(pool: Pool, q: string, f: MagSearchFilters = {}): Promise<MagSearchHit[]> {
+  const term = q.trim();
+  if (!term) return [];
+  const exact = /^".+"$/.test(term);
+  const needle = exact ? term.slice(1, -1) : term;
+
+  const params: unknown[] = [];
+  const p = (v: unknown) => {
+    params.push(v);
+    return `$${params.length}`;
+  };
+
+  const wheres: string[] = ["e.status <> 'rejected'"];
+  if (f.magazine) wheres.push(`m.slug = ${p(f.magazine)}`);
+  if (f.kind) wheres.push(`e.kind = ${p(f.kind)}`);
+  if (f.language) wheres.push(`e.language = ${p(f.language)}`);
+  if (f.system) {
+    wheres.push(`EXISTS (SELECT 1 FROM extract_system es WHERE es.extract_id=e.id AND es.system = ${p(f.system)})`);
+  }
+  if (f.person) {
+    wheres.push(
+      `EXISTS (SELECT 1 FROM extract_person ep JOIN people pe ON pe.id=ep.person_id
+        WHERE ep.extract_id=e.id AND pe.slug = ${p(f.person)})`
+    );
+  }
+  if (f.game) {
+    wheres.push(
+      `EXISTS (SELECT 1 FROM extract_game eg JOIN games g ON g.id=eg.game_id
+        WHERE eg.extract_id=e.id AND g.slug = ${p(f.game)})`
+    );
+  }
+  if (f.from) wheres.push(`i.cover_date >= ${p(f.from)}`);
+  if (f.to) wheres.push(`i.cover_date <= ${p(f.to)}`);
+
+  const limit = Math.min(100, Math.max(1, f.limit ?? 30));
+
+  if (exact) {
+    const like = "%" + needle.replace(/([\\%_])/g, "\\$1") + "%";
+    const lp = p(like);
+    wheres.push(`(e.text_original ILIKE ${lp} OR e.text_en ILIKE ${lp} OR e.title ILIKE ${lp})`);
+    const r = await pool.query(
+      `SELECT ${COVERAGE_COLS}, 'subject' AS role, NULL::text AS title_printed,
+              e.text_original AS _orig, e.text_en AS _en,
+              1.0::float8 AS rank
+       FROM magazine_extract e
+       JOIN magazine_issue i ON i.id=e.issue_id
+       JOIN magazines m ON m.id=i.magazine_id
+       WHERE ${wheres.join(" AND ")}
+       ORDER BY i.cover_date ASC NULLS LAST, e.seq
+       LIMIT ${p(limit)}`,
+      params
+    );
+    return (r.rows as (MagSearchHit & { _orig: string; _en: string | null })[]).map(
+      ({ _orig, _en, ...h }) => ({
+        ...h,
+        snippet: snippetFrom(_orig, needle) ?? snippetFrom(_en ?? "", needle) ?? snippetFrom(h.title ?? "", needle),
+      })
+    );
+  }
+
+  const tq = p(needle);
+  wheres.push(
+    `(to_tsvector('simple', coalesce(e.title,'') || ' ' || e.text_original) @@ plainto_tsquery('simple', ${tq})
+      OR to_tsvector('english', coalesce(e.title,'') || ' ' || coalesce(e.text_en,'') || ' ' || coalesce(e.summary_en,'')) @@ plainto_tsquery('english', ${tq})
+      OR e.title ILIKE ${p("%" + needle.replace(/([\\%_])/g, "\\$1") + "%")})`
+  );
+  const r = await pool.query(
+    `SELECT ${COVERAGE_COLS}, 'subject' AS role, NULL::text AS title_printed,
+            ts_headline('simple', left(coalesce(e.text_en, e.text_original), 3000),
+                        plainto_tsquery('simple', ${tq}),
+                        'MaxFragments=1, MaxWords=25, MinWords=8, StartSel=[[, StopSel=]]') AS snippet,
+            (ts_rank(to_tsvector('simple', coalesce(e.title,'') || ' ' || e.text_original), plainto_tsquery('simple', ${tq}))
+             + ts_rank(to_tsvector('english', coalesce(e.title,'') || ' ' || coalesce(e.text_en,'') || ' ' || coalesce(e.summary_en,'')), plainto_tsquery('english', ${tq})))::float8 AS rank
+     FROM magazine_extract e
+     JOIN magazine_issue i ON i.id=e.issue_id
+     JOIN magazines m ON m.id=i.magazine_id
+     WHERE ${wheres.join(" AND ")}
+     ORDER BY rank DESC, i.cover_date ASC NULLS LAST
+     LIMIT ${p(limit)}`,
+    params
+  );
+  return r.rows as MagSearchHit[];
+}
+
+/** App-side snippet for exact mode: ±60 chars around the first hit, using the
+ *  same [[...]] highlight convention ts_headline is configured with above. */
+function snippetFrom(text: string, needle: string): string | null {
+  const i = text.toLowerCase().indexOf(needle.toLowerCase());
+  if (i < 0) return null;
+  const start = Math.max(0, i - 60);
+  const end = Math.min(text.length, i + needle.length + 60);
+  return (
+    (start > 0 ? "…" : "") +
+    text.slice(start, i) +
+    "[[" +
+    text.slice(i, i + needle.length) +
+    "]]" +
+    text.slice(i + needle.length, end) +
+    (end < text.length ? "…" : "")
+  );
+}

--- a/hp-web/src/lib/mag/store.ts
+++ b/hp-web/src/lib/mag/store.ts
@@ -1,0 +1,369 @@
+// Magazine asset pipeline: page renders and region crops, derived on the
+// server from the issue's source PDF so every ingest stores one PDF instead
+// of hundreds of images (the bucket gateway sustains ~3.5 PUT/s).
+//
+// Page renders are JPEG (scans are photographic; PNG would be ~10x the bytes
+// at corpus scale). Region crops are PNG per the extraction spec. Both live
+// in the blob store under the mag/ namespace, content-addressed, and served
+// through the public gateway like build media. The source PDF also lives
+// under mag/ but is moderator-only — no public route ever hands out its URL.
+//
+// Rendering follows the transcode pattern: in-process jobs keyed by issue,
+// progress read from the DB (pages/regions with blobs vs without), so a
+// restart resumes by re-running the job over whatever is missing. Ghostscript
+// and ffmpeg are soft dependencies, like gs.ts/ffmpeg.ts.
+
+import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdtemp, readdir, readFile, rename, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { Pool } from "pg";
+import { storeBlobFromFile, withBlobFile } from "../blobstore";
+import { hashFile } from "../media";
+import { gsAvailable } from "../gs";
+
+const execFileP = promisify(execFile);
+
+const GS_BIN = process.env.GHOSTSCRIPT_BIN || "gs";
+const FFMPEG_BIN = process.env.FFMPEG_BIN || "ffmpeg";
+const QPDF_BIN = process.env.QPDF_BIN || "qpdf";
+
+/** Store namespace for all magazine blobs (see blobstore key layout). */
+export const MAG_NS = "mag/";
+
+/** Target long edge of a page render, px. Magazine scans are ~150-300dpi;
+ *  2200px keeps small print legible in crops without ballooning the corpus. */
+const TARGET_LONG_EDGE = 2200;
+const MIN_DPI = 72;
+const MAX_DPI = 300;
+const JPEG_QUALITY = 85;
+
+/** Pages per Ghostscript invocation: bounds each timeout, and makes progress
+ *  observable in the DB between chunks. */
+const RENDER_CHUNK = 16;
+const RENDER_CHUNK_TIMEOUT_MS = 30_000 + RENDER_CHUNK * 15_000;
+const PAGE_COUNT_TIMEOUT_MS = 120_000;
+const CROP_TIMEOUT_MS = 60_000;
+
+/** Crop padding, fraction of the page dimension on each side — vision-model
+ *  boxes run tight, and a hair of margin keeps descenders and frames whole. */
+const CROP_PAD = 0.01;
+
+/** Public URL for a magazine image blob (page render or crop): the bucket
+ *  gateway when configured, else the app route. Same contract as mediaUrl. */
+export function magImageUrl(sha256: string): string {
+  const base = process.env.ASSET_PUBLIC_BASE;
+  if (base) return `${base.replace(/\/+$/, "")}/mag/${sha256.slice(0, 2)}/${sha256}`;
+  return `/api/mag/blob/${sha256}`;
+}
+
+/** JPEG pixel dimensions from the SOF marker; null when the bytes are not a
+ *  parseable JPEG. Enough of a decoder to size Ghostscript's output. */
+export function jpegSize(buf: Buffer): { width: number; height: number } | null {
+  if (buf.length < 4 || buf[0] !== 0xff || buf[1] !== 0xd8) return null;
+  let off = 2;
+  while (off + 9 < buf.length) {
+    if (buf[off] !== 0xff) {
+      off++;
+      continue;
+    }
+    const marker = buf[off + 1];
+    if (marker === 0xd8 || (marker >= 0xd0 && marker <= 0xd9)) {
+      off += 2;
+      continue;
+    }
+    const len = buf.readUInt16BE(off + 2);
+    if (len < 2) return null;
+    // SOF0-SOF15 minus DHT(C4)/JPG(C8)/DAC(CC): frame header with dimensions.
+    if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+      return { height: buf.readUInt16BE(off + 5), width: buf.readUInt16BE(off + 7) };
+    }
+    off += 2 + len;
+  }
+  return null;
+}
+
+/** Page count of a local PDF. qpdf when present (exact, instant), else a
+ *  Ghostscript nullpage pass ("Processing pages 1 through N"). Ghostscript
+ *  10.x dropped the PostScript pdfpagecount operator, so banner parsing is
+ *  the portable fallback. */
+export async function pdfPageCount(input: string): Promise<number> {
+  try {
+    const { stdout } = await execFileP(QPDF_BIN, ["--show-npages", input], {
+      timeout: PAGE_COUNT_TIMEOUT_MS,
+    });
+    const n = parseInt(stdout.trim(), 10);
+    if (Number.isInteger(n) && n > 0) return n;
+  } catch {
+    // qpdf missing or unhappy; fall through to gs.
+  }
+  if (!(await gsAvailable())) throw new Error("no pdf page counter available (qpdf or ghostscript)");
+  // No -q here: the "Processing pages 1 through N" banner IS the output.
+  const { stdout, stderr } = await execFileP(
+    GS_BIN,
+    ["-dSAFER", "-dBATCH", "-dNOPAUSE", "-P-", "-sDEVICE=nullpage", input],
+    { timeout: PAGE_COUNT_TIMEOUT_MS, maxBuffer: 16_000_000 }
+  );
+  const banner = `${stdout}\n${stderr}`;
+  const through = /Processing pages \d+ through (\d+)/.exec(banner);
+  if (through) return parseInt(through[1], 10);
+  let last = 0;
+  for (const m of banner.matchAll(/^Page (\d+)$/gm)) last = Math.max(last, parseInt(m[1], 10));
+  if (last > 0) return last;
+  throw new Error("could not determine pdf page count");
+}
+
+/** Render pages [first..last] of a local PDF into `dir` as p-<n>.jpg (n is
+ *  the absolute pdf index). Returns the rendered indexes in order. */
+async function gsRenderRange(input: string, dir: string, first: number, last: number, dpi: number): Promise<number[]> {
+  if (!(await gsAvailable())) throw new Error("ghostscript not available");
+  await execFileP(
+    GS_BIN,
+    [
+      "-dSAFER", "-dBATCH", "-dNOPAUSE", "-q", "-P-", "-sstdout=%stderr",
+      "-sDEVICE=jpeg", `-dJPEGQ=${JPEG_QUALITY}`,
+      `-r${dpi}`,
+      "-dTextAlphaBits=4", "-dGraphicsAlphaBits=4",
+      `-dFirstPage=${first}`, `-dLastPage=${last}`,
+      // %d restarts at 1 per invocation; rename to absolute indexes below.
+      "-sOutputFile=" + join(dir, "out-%d.jpg"),
+      input,
+    ],
+    { timeout: RENDER_CHUNK_TIMEOUT_MS, maxBuffer: 16_000_000 }
+  );
+  const produced: number[] = [];
+  for (const name of (await readdir(dir)).sort()) {
+    const m = /^out-(\d+)\.jpg$/.exec(name);
+    if (!m) continue;
+    const abs = first + parseInt(m[1], 10) - 1;
+    await rename(join(dir, name), join(dir, `p-${abs}.jpg`));
+    produced.push(abs);
+  }
+  return produced.sort((a, b) => a - b);
+}
+
+/** Probe the DPI that lands the long edge near TARGET_LONG_EDGE: render page
+ *  1 at 150dpi, measure, rescale once, clamp. One DPI per issue keeps the
+ *  render uniform (page sizes within an issue are uniform in practice). */
+async function probeDpi(input: string): Promise<number> {
+  const dir = await mkdtemp(join(tmpdir(), `magprobe-${randomBytes(4).toString("hex")}-`));
+  try {
+    await gsRenderRange(input, dir, 1, 1, 150);
+    const size = jpegSize(await readFile(join(dir, "p-1.jpg")));
+    if (!size) return 150;
+    const long = Math.max(size.width, size.height);
+    if (!long) return 150;
+    return Math.max(MIN_DPI, Math.min(MAX_DPI, Math.round((150 * TARGET_LONG_EDGE) / long)));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** Crop a rectangle (normalized page coords) out of a rendered page into a
+ *  PNG at `out`, with CROP_PAD margin. Throws when ffmpeg is missing or the
+ *  rectangle degenerates. */
+export async function cropRegionPng(
+  pageFile: string,
+  page: { width: number; height: number },
+  region: { x: number; y: number; w: number; h: number },
+  out: string
+): Promise<void> {
+  const x0 = Math.max(0, region.x - CROP_PAD);
+  const y0 = Math.max(0, region.y - CROP_PAD);
+  const x1 = Math.min(1, region.x + region.w + CROP_PAD);
+  const y1 = Math.min(1, region.y + region.h + CROP_PAD);
+  const px = Math.round(x0 * page.width);
+  const py = Math.round(y0 * page.height);
+  const pw = Math.max(8, Math.min(page.width - px, Math.round((x1 - x0) * page.width)));
+  const ph = Math.max(8, Math.min(page.height - py, Math.round((y1 - y0) * page.height)));
+  if (pw < 8 || ph < 8) throw new Error("degenerate crop");
+  await execFileP(
+    FFMPEG_BIN,
+    [
+      "-hide_banner", "-loglevel", "error", "-y",
+      "-i", pageFile,
+      "-vf", `crop=${pw}:${ph}:${px}:${py}`,
+      "-frames:v", "1", "-c:v", "png", "-f", "image2",
+      out,
+    ],
+    { timeout: CROP_TIMEOUT_MS, maxBuffer: 4_000_000 }
+  );
+  if ((await stat(out)).size === 0) throw new Error("empty crop");
+}
+
+// ── issue asset job ──────────────────────────────────────────────────────────
+
+const issueJobs = new Map<number, Promise<void>>();
+const issueJobErrors = new Map<number, string>();
+
+export interface IssueAssetStatus {
+  state: "idle" | "working" | "failed";
+  error?: string;
+  pages_total: number;
+  pages_rendered: number;
+  crops_total: number;
+  crops_done: number;
+}
+
+/** Progress from the DB — restart-safe, no in-memory bookkeeping needed
+ *  beyond the running-job map. */
+export async function issueAssetStatus(pool: Pool, issueId: number): Promise<IssueAssetStatus> {
+  const r = await pool.query(
+    `SELECT
+       coalesce((SELECT page_count FROM magazine_issue WHERE id=$1), 0)::int AS declared,
+       (SELECT count(*) FROM magazine_page WHERE issue_id=$1 AND image_sha256 IS NOT NULL)::int AS pages_rendered,
+       (SELECT count(*) FROM extract_region r JOIN magazine_extract e ON e.id=r.extract_id
+         WHERE e.issue_id=$1)::int AS crops_total,
+       (SELECT count(*) FROM extract_region r JOIN magazine_extract e ON e.id=r.extract_id
+         WHERE e.issue_id=$1 AND r.crop_sha256 IS NOT NULL)::int AS crops_done`,
+    [issueId]
+  );
+  const row = r.rows[0] as { declared: number; pages_rendered: number; crops_total: number; crops_done: number };
+  const working = issueJobs.has(issueId);
+  const error = issueJobErrors.get(issueId);
+  return {
+    state: working ? "working" : error ? "failed" : "idle",
+    ...(error && !working ? { error } : {}),
+    pages_total: row.declared,
+    pages_rendered: row.pages_rendered,
+    crops_total: row.crops_total,
+    crops_done: row.crops_done,
+  };
+}
+
+/** Whether anything is left for the job to do (used by the status route to
+ *  self-heal after a restart, like the transcode status route). */
+export async function issueAssetsPending(pool: Pool, issueId: number): Promise<boolean> {
+  const s = await issueAssetStatus(pool, issueId);
+  if (s.state === "working") return false;
+  const pdf = await pool.query("SELECT pdf_sha256 FROM magazine_issue WHERE id=$1", [issueId]);
+  const hasPdf = !!pdf.rows[0]?.pdf_sha256;
+  const pagesPending = hasPdf && (s.pages_total === 0 || s.pages_rendered < s.pages_total);
+  return pagesPending || s.crops_done < s.crops_total;
+}
+
+/** Kick (or join) the render+crop job for an issue. Idempotent per process;
+ *  progress is durable in the DB, so re-kicking after a crash just finishes
+ *  the remainder. */
+export function ensureIssueAssets(pool: Pool, issueId: number): Promise<void> {
+  let job = issueJobs.get(issueId);
+  if (!job) {
+    issueJobErrors.delete(issueId);
+    job = runIssueAssets(pool, issueId)
+      .catch((e) => {
+        issueJobErrors.set(issueId, e instanceof Error ? e.message : String(e));
+        throw e;
+      })
+      .finally(() => issueJobs.delete(issueId));
+    issueJobs.set(issueId, job);
+    // Detach: callers that only kick must not crash on a background failure.
+    job.catch(() => {});
+  }
+  return job;
+}
+
+async function runIssueAssets(pool: Pool, issueId: number): Promise<void> {
+  const issue = await pool.query(
+    "SELECT id::int AS id, pdf_sha256, page_count FROM magazine_issue WHERE id=$1",
+    [issueId]
+  );
+  const row = issue.rows[0] as { id: number; pdf_sha256: string | null; page_count: number | null } | undefined;
+  if (!row) throw new Error("issue not found");
+  if (row.pdf_sha256) await renderMissingPages(pool, issueId, row.pdf_sha256);
+  await cropMissingRegions(pool, issueId);
+}
+
+async function renderMissingPages(pool: Pool, issueId: number, pdfSha: string): Promise<void> {
+  const done = await withBlobFile(
+    pdfSha,
+    async (input) => {
+      const total = await pdfPageCount(input);
+      await pool.query(
+        "UPDATE magazine_issue SET page_count=$2, updated_at=now() WHERE id=$1 AND (page_count IS NULL OR page_count<>$2)",
+        [issueId, total]
+      );
+      const have = await pool.query(
+        "SELECT pdf_index FROM magazine_page WHERE issue_id=$1 AND image_sha256 IS NOT NULL",
+        [issueId]
+      );
+      const rendered = new Set<number>(have.rows.map((r: { pdf_index: number }) => Number(r.pdf_index)));
+      if (rendered.size >= total) return true;
+
+      const dpi = await probeDpi(input);
+      for (let first = 1; first <= total; first += RENDER_CHUNK) {
+        const last = Math.min(total, first + RENDER_CHUNK - 1);
+        let all = true;
+        for (let p = first; p <= last; p++) if (!rendered.has(p)) all = false;
+        if (all) continue;
+        const dir = await mkdtemp(join(tmpdir(), `magrender-${randomBytes(4).toString("hex")}-`));
+        try {
+          const produced = await gsRenderRange(input, dir, first, last, dpi);
+          for (const abs of produced) {
+            if (rendered.has(abs)) continue;
+            const file = join(dir, `p-${abs}.jpg`);
+            const size = jpegSize(await readFile(file));
+            if (!size) throw new Error(`page ${abs}: unparseable render`);
+            const sha = await hashFile(file);
+            await storeBlobFromFile(sha, file, { ns: MAG_NS, keepSource: true });
+            await pool.query(
+              `INSERT INTO magazine_page (issue_id, pdf_index, width, height, image_sha256, rendered_at)
+               VALUES ($1,$2,$3,$4,$5,now())
+               ON CONFLICT (issue_id, pdf_index) DO UPDATE
+                 SET width=$3, height=$4, image_sha256=$5, rendered_at=now()`,
+              [issueId, abs, size.width, size.height, sha]
+            );
+          }
+        } finally {
+          await rm(dir, { recursive: true, force: true });
+        }
+      }
+      return true;
+    },
+    MAG_NS
+  );
+  if (done === null) throw new Error("issue pdf blob missing from store");
+}
+
+async function cropMissingRegions(pool: Pool, issueId: number): Promise<void> {
+  const pending = await pool.query(
+    `SELECT r.id::int AS id, r.x, r.y, r.w, r.h,
+            p.image_sha256 AS page_sha, p.width::int AS width, p.height::int AS height
+     FROM extract_region r
+     JOIN magazine_extract e ON e.id = r.extract_id
+     JOIN magazine_page p ON p.id = r.page_id
+     WHERE e.issue_id=$1 AND r.crop_sha256 IS NULL AND p.image_sha256 IS NOT NULL
+     ORDER BY r.id`,
+    [issueId]
+  );
+  for (const region of pending.rows as {
+    id: number; x: number; y: number; w: number; h: number;
+    page_sha: string; width: number; height: number;
+  }[]) {
+    const dir = await mkdtemp(join(tmpdir(), `magcrop-${randomBytes(4).toString("hex")}-`));
+    try {
+      const out = join(dir, "crop.png");
+      const ok = await withBlobFile(
+        region.page_sha,
+        async (pageFile) => {
+          await cropRegionPng(pageFile, region, region, out);
+          return true;
+        },
+        MAG_NS
+      );
+      if (ok === null) continue; // page blob missing; a later render pass will restore it
+      const sha = await hashFile(out);
+      await storeBlobFromFile(sha, out, { ns: MAG_NS, keepSource: true });
+      await pool.query("UPDATE extract_region SET crop_sha256=$2 WHERE id=$1 AND crop_sha256 IS NULL", [
+        region.id,
+        sha,
+      ]);
+    } catch {
+      // One bad region (hostile bbox, truncated page) must not stall the
+      // issue; it stays NULL and shows as pending in the status counts.
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+}

--- a/hp-web/src/lib/mag/upload.ts
+++ b/hp-web/src/lib/mag/upload.ts
@@ -1,0 +1,89 @@
+// Chunked upload sessions for magazine source PDFs — the build-media session
+// pattern (media.ts) with a mag-pdf shape: two files under .staging/, no DB
+// row until the bytes are complete, replayable finalize, per-token in-process
+// lock. Sessions are moderator-created; the corpus tops out around 600MB per
+// issue, so the cap leaves headroom without inviting abuse.
+
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { randomBytes } from "node:crypto";
+import { assetStoreDir } from "../blobstore";
+
+export const PDF_MAX_BYTES = 1024 * 1024 * 1024; // 1 GiB
+export const PDF_MAX_CHUNK = 32 * 1024 * 1024;
+
+const SESSION_TTL_MS = 24 * 3600_000;
+
+export interface MagPdfSession {
+  issue: number;
+  size: number;
+  author: string;
+  /** Set once the blob is stored and the issue row updated; kept so a client
+   *  that never saw the reply gets the same answer instead of a 404. */
+  done?: { sha256: string };
+}
+
+export function isMagToken(v: string): boolean {
+  return /^[0-9a-f]{32}$/.test(v);
+}
+
+export function newMagToken(): string {
+  return randomBytes(16).toString("hex");
+}
+
+export function magStagingPath(token: string): string {
+  return path.join(assetStoreDir(), ".staging", `magpdf-${token}.part`);
+}
+
+function magSessionPath(token: string): string {
+  return path.join(assetStoreDir(), ".staging", `magpdf-${token}.json`);
+}
+
+export async function createMagSession(token: string, session: MagPdfSession): Promise<void> {
+  const dir = path.join(assetStoreDir(), ".staging");
+  await fsp.mkdir(dir, { recursive: true });
+  await reapStaleMagSessions(dir).catch(() => {});
+  await updateMagSession(token, session);
+  await fsp.writeFile(magStagingPath(token), Buffer.alloc(0));
+}
+
+export async function readMagSession(token: string): Promise<MagPdfSession | null> {
+  try {
+    return JSON.parse(await fsp.readFile(magSessionPath(token), "utf8")) as MagPdfSession;
+  } catch {
+    return null;
+  }
+}
+
+/** Temp-write + rename like updateMediaSession: a crash mid-write must leave
+ *  the previous sidecar, not truncated JSON. */
+export async function updateMagSession(token: string, session: MagPdfSession): Promise<void> {
+  const dest = magSessionPath(token);
+  const tmp = `${dest}.tmp${process.pid}`;
+  await fsp.writeFile(tmp, JSON.stringify(session));
+  await fsp.rename(tmp, dest);
+}
+
+export async function dropMagSession(token: string): Promise<void> {
+  await fsp.rm(magSessionPath(token), { force: true });
+  await fsp.rm(magStagingPath(token), { force: true });
+}
+
+/** Retire a finished session: payload gone, sidecar kept with the answer. */
+export async function finishMagSession(token: string, session: MagPdfSession, sha256: string): Promise<void> {
+  await updateMagSession(token, { ...session, done: { sha256 } });
+  await fsp.rm(magStagingPath(token), { force: true });
+}
+
+async function reapStaleMagSessions(dir: string): Promise<void> {
+  const cutoff = Date.now() - SESSION_TTL_MS;
+  for (const name of await fsp.readdir(dir)) {
+    if (!name.startsWith("magpdf-")) continue;
+    const p = path.join(dir, name);
+    try {
+      if ((await fsp.stat(p)).mtimeMs < cutoff) await fsp.rm(p, { force: true });
+    } catch {
+      // Raced with another reaper or an active finalize; leave it.
+    }
+  }
+}

--- a/hp-web/tests/mag-kinds.test.ts
+++ b/hp-web/tests/mag-kinds.test.ts
@@ -1,0 +1,146 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  EXTRACT_KINDS,
+  isExtractKind,
+  normalizeLang,
+  validateExtractInput,
+  validateIssueInput,
+  validateMagazineInput,
+} from "../src/lib/mag/kinds";
+
+const REGION = { pdf_index: 3, x: 0.1, y: 0.2, w: 0.5, h: 0.3 };
+
+function base(over: Record<string, unknown> = {}) {
+  return {
+    client_key: "p3-review-sonic",
+    kind: "review",
+    language: "en",
+    text_original: "Sonic is fast.",
+    regions: [REGION],
+    ...over,
+  };
+}
+
+test("taxonomy contains the survey-derived kinds", () => {
+  for (const k of ["review", "preview", "tips", "chart", "high_scores", "ad", "ad_index", "comic", "poster"]) {
+    assert.ok(isExtractKind(k), k);
+  }
+  assert.ok(!isExtractKind("advertisement"));
+  assert.equal(new Set(EXTRACT_KINDS).size, EXTRACT_KINDS.length);
+});
+
+test("normalizeLang lowercases and validates bcp47-ish tags", () => {
+  assert.equal(normalizeLang("EN"), "en");
+  assert.equal(normalizeLang("pt-BR"), "pt-br");
+  assert.equal(normalizeLang("ja"), "ja");
+  assert.equal(normalizeLang("english"), null);
+  assert.equal(normalizeLang(""), null);
+  assert.equal(normalizeLang(42), null);
+});
+
+test("a valid extract passes and is normalized", () => {
+  const v = validateExtractInput(
+    base({
+      section: "  Review Crew  ",
+      title: "Sonic the Hedgehog",
+      text_en: undefined,
+      data: { scores: [{ reviewer: "Steve", value: 9, scale: 10 }] },
+      games: [{ name: "Sonic the Hedgehog", system: "Sega Mega Drive", role: "subject", title_printed: "SONIC" }],
+      people: [{ name: "Sushi-X", kind: "persona", role: "reviewer" }],
+      systems: ["Sega Mega Drive"],
+      tags: [{ kind: "company", name: "Sega" }],
+    })
+  );
+  assert.ok(v.ok, v.ok ? "" : v.error);
+  if (!v.ok) return;
+  assert.equal(v.value.section, "Review Crew");
+  assert.equal(v.value.games?.[0].system, "Sega Mega Drive");
+  assert.equal(v.value.people?.[0].kind, "persona");
+  assert.equal(v.value.is_fictional, false);
+});
+
+test("unknown kind, missing client_key, bad language are rejected", () => {
+  assert.ok(!validateExtractInput(base({ kind: "advert" })).ok);
+  assert.ok(!validateExtractInput(base({ client_key: "" })).ok);
+  assert.ok(!validateExtractInput(base({ language: "English please" })).ok);
+});
+
+test("machine translation is implied when text_en is present", () => {
+  const v = validateExtractInput(base({ language: "ja", text_original: "ソニック", text_en: "Sonic" }));
+  assert.ok(v.ok);
+  if (v.ok) assert.equal(v.value.translation, "machine");
+});
+
+test("regions clamp out-of-range coords and reject degenerate boxes", () => {
+  const v = validateExtractInput(base({ regions: [{ pdf_index: 1, x: -0.05, y: 0.5, w: 1.2, h: 0.6 }] }));
+  assert.ok(v.ok, v.ok ? "" : v.error);
+  if (v.ok) {
+    const r = v.value.regions[0];
+    assert.equal(r.x, 0);
+    assert.equal(r.w, 1);
+    assert.equal(r.y, 0.5);
+    assert.equal(r.h, 0.5);
+  }
+  assert.ok(!validateExtractInput(base({ regions: [] })).ok);
+  assert.ok(!validateExtractInput(base({ regions: [{ pdf_index: 1, x: 0.999, y: 0, w: 0.9, h: 0.5 }] })).ok);
+  assert.ok(!validateExtractInput(base({ regions: [{ pdf_index: 0, x: 0, y: 0, w: 1, h: 1 }] })).ok);
+});
+
+test("conventional data arrays must be arrays of objects", () => {
+  assert.ok(!validateExtractInput(base({ data: { scores: { steve: 9 } } })).ok);
+  assert.ok(!validateExtractInput(base({ data: { entries: ["1. Sonic"] } })).ok);
+  assert.ok(validateExtractInput(base({ data: { entries: [{ rank: 1 }], anything_else: "free" } })).ok);
+});
+
+test("games and people links validate roles and kinds", () => {
+  assert.ok(!validateExtractInput(base({ games: [{ name: "X", role: "hero" }] })).ok);
+  assert.ok(!validateExtractInput(base({ people: [{ name: "X", kind: "robot" }] })).ok);
+  assert.ok(!validateExtractInput(base({ games: [{ system: "SMS" }] })).ok);
+  const v = validateExtractInput(base({ games: [{ name: "Columns" }] }));
+  assert.ok(v.ok);
+  if (v.ok) {
+    assert.equal(v.value.games?.[0].role, "subject");
+    assert.equal(v.value.games?.[0].system, "");
+  }
+});
+
+test("issue input validates slug, date precision, and page labels", () => {
+  const good = validateIssueInput({
+    magazine: "egm",
+    slug: "022",
+    label: "Issue 22",
+    cover_date: "1991-05-01",
+    cover_date_precision: "month",
+    page_labels: { "4": "4", "56": "supp:6" },
+    supplements: [{ title: "Robocop 2 Strategy Guide", present: true }],
+  });
+  assert.ok(good.ok, good.ok ? "" : good.error);
+  if (good.ok) {
+    assert.equal(good.value.page_labels?.["56"], "supp:6");
+    assert.equal(good.value.supplements?.[0].present, true);
+  }
+  assert.ok(!validateIssueInput({ magazine: "egm", slug: "Issue 22", label: "x" }).ok);
+  assert.ok(!validateIssueInput({ magazine: "egm", slug: "022", label: "x", cover_date: "May 1991" }).ok);
+  assert.ok(!validateIssueInput({ magazine: "egm", slug: "022", label: "x", page_labels: { abc: "1" } }).ok);
+});
+
+test("cover_date defaults to day precision when unstated", () => {
+  const v = validateIssueInput({ magazine: "beep", slug: "1991-08", label: "1991-08", cover_date: "1991-08-01" });
+  assert.ok(v.ok);
+  if (v.ok) assert.equal(v.value.cover_date_precision, "day");
+});
+
+test("magazine input validates and passes the pages_public toggle through", () => {
+  const v = validateMagazineInput({ title: "Beep! MegaDrive", language: "ja", country: "JP", pages_public: false });
+  assert.ok(v.ok);
+  if (v.ok) {
+    assert.equal(v.value.pages_public, false);
+    assert.equal(v.value.language, "ja");
+  }
+  const noToggle = validateMagazineInput({ title: "EGM" });
+  assert.ok(noToggle.ok);
+  if (noToggle.ok) assert.equal(noToggle.value.pages_public, undefined);
+  assert.ok(!validateMagazineInput({ title: "" }).ok);
+  assert.ok(!validateMagazineInput({ title: "X", slug: "Bad Slug" }).ok);
+});

--- a/hp-web/tests/mag-store.test.ts
+++ b/hp-web/tests/mag-store.test.ts
@@ -1,0 +1,132 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { cropRegionPng, jpegSize, magImageUrl, pdfPageCount } from "../src/lib/mag/store";
+
+const execFileP = promisify(execFile);
+
+let gsChecked: Promise<boolean> | null = null;
+function haveGs(): Promise<boolean> {
+  gsChecked ??= execFileP(process.env.GHOSTSCRIPT_BIN || "gs", ["-h"], { timeout: 5000 })
+    .then(({ stdout }) => /ghostscript/i.test(stdout))
+    .catch(() => false);
+  return gsChecked;
+}
+
+let ffmpegChecked: Promise<boolean> | null = null;
+function haveFfmpeg(): Promise<boolean> {
+  ffmpegChecked ??= execFileP(process.env.FFMPEG_BIN || "ffmpeg", ["-version"], { timeout: 5000 })
+    .then(() => true)
+    .catch(() => false);
+  return ffmpegChecked;
+}
+
+/** Minimal marker stream: SOI, APP0 filler, SOF0 with the given dimensions. */
+function fakeJpeg(width: number, height: number): Buffer {
+  const app0 = Buffer.from([0xff, 0xe0, 0x00, 0x04, 0x00, 0x00]);
+  const sof = Buffer.alloc(2 + 2 + 15);
+  sof[0] = 0xff;
+  sof[1] = 0xc0;
+  sof.writeUInt16BE(17, 2);
+  sof[4] = 8;
+  sof.writeUInt16BE(height, 5);
+  sof.writeUInt16BE(width, 7);
+  return Buffer.concat([Buffer.from([0xff, 0xd8]), app0, sof, Buffer.from([0xff, 0xd9])]);
+}
+
+test("jpegSize reads SOF dimensions and rejects non-JPEGs", () => {
+  assert.deepEqual(jpegSize(fakeJpeg(512, 256)), { width: 512, height: 256 });
+  assert.deepEqual(jpegSize(fakeJpeg(2200, 3003)), { width: 2200, height: 3003 });
+  assert.equal(jpegSize(Buffer.from("not a jpeg")), null);
+  assert.equal(jpegSize(Buffer.from([0x89, 0x50, 0x4e, 0x47])), null);
+});
+
+test("magImageUrl prefers the public gateway and falls back to the app route", () => {
+  const saved = process.env.ASSET_PUBLIC_BASE;
+  try {
+    process.env.ASSET_PUBLIC_BASE = "https://prism.example.org/";
+    assert.equal(magImageUrl("ab".repeat(32)), `https://prism.example.org/mag/ab/${"ab".repeat(32)}`);
+    delete process.env.ASSET_PUBLIC_BASE;
+    assert.equal(magImageUrl("ab".repeat(32)), `/api/mag/blob/${"ab".repeat(32)}`);
+  } finally {
+    if (saved === undefined) delete process.env.ASSET_PUBLIC_BASE;
+    else process.env.ASSET_PUBLIC_BASE = saved;
+  }
+});
+
+test("pdfPageCount counts pages of a generated pdf", async (t) => {
+  if (!(await haveGs())) return t.skip("ghostscript not installed");
+  const dir = await mkdtemp(join(tmpdir(), "magtest-"));
+  try {
+    const pdf = join(dir, "three.pdf");
+    await execFileP(process.env.GHOSTSCRIPT_BIN || "gs", [
+      "-dBATCH", "-dNOPAUSE", "-q", "-sDEVICE=pdfwrite", `-sOutputFile=${pdf}`,
+      "-c", "showpage showpage showpage",
+    ]);
+    assert.equal(await pdfPageCount(pdf), 3);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+function pngSize(buf: Buffer): { width: number; height: number } {
+  assert.equal(buf.readUInt32BE(0), 0x89504e47);
+  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+test("cropRegionPng crops the padded rectangle", async (t) => {
+  if (!(await haveFfmpeg())) return t.skip("ffmpeg not installed");
+  const dir = await mkdtemp(join(tmpdir(), "magtest-"));
+  try {
+    const page = join(dir, "page.jpg");
+    await execFileP(process.env.FFMPEG_BIN || "ffmpeg", [
+      "-hide_banner", "-loglevel", "error", "-y",
+      "-f", "lavfi", "-i", "color=c=red:s=1000x1400", "-frames:v", "1", page,
+    ]);
+    const out = join(dir, "crop.png");
+    await cropRegionPng(page, { width: 1000, height: 1400 }, { x: 0.1, y: 0.1, w: 0.5, h: 0.25 }, out);
+    const size = pngSize(await readFile(out));
+    // 0.5 of 1000 plus 1% padding each side = 520; 0.25 of 1400 + padding = 378.
+    assert.equal(size.width, 520);
+    assert.equal(size.height, 378);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("cropRegionPng clamps at page edges", async (t) => {
+  if (!(await haveFfmpeg())) return t.skip("ffmpeg not installed");
+  const dir = await mkdtemp(join(tmpdir(), "magtest-"));
+  try {
+    const page = join(dir, "page.jpg");
+    await execFileP(process.env.FFMPEG_BIN || "ffmpeg", [
+      "-hide_banner", "-loglevel", "error", "-y",
+      "-f", "lavfi", "-i", "color=c=blue:s=800x600", "-frames:v", "1", page,
+    ]);
+    const out = join(dir, "crop.png");
+    await cropRegionPng(page, { width: 800, height: 600 }, { x: 0.9, y: 0.9, w: 0.1, h: 0.1 }, out);
+    const size = pngSize(await readFile(out));
+    assert.ok(size.width >= 80 && size.width <= 96, `width ${size.width}`);
+    assert.ok(size.height >= 60 && size.height <= 72, `height ${size.height}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("cropRegionPng survives a page file that is not an image", async (t) => {
+  if (!(await haveFfmpeg())) return t.skip("ffmpeg not installed");
+  const dir = await mkdtemp(join(tmpdir(), "magtest-"));
+  try {
+    const page = join(dir, "page.jpg");
+    await writeFile(page, "definitely not a jpeg");
+    await assert.rejects(
+      cropRegionPng(page, { width: 100, height: 100 }, { x: 0, y: 0, w: 1, h: 1 }, join(dir, "out.png"))
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/hp-web/tests/mag-upload.test.ts
+++ b/hp-web/tests/mag-upload.test.ts
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createMagSession,
+  dropMagSession,
+  finishMagSession,
+  isMagToken,
+  magStagingPath,
+  newMagToken,
+  readMagSession,
+  updateMagSession,
+} from "../src/lib/mag/upload";
+
+test("mag pdf session lifecycle: create, append, finish keeps the answer", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "magupload-"));
+  const saved = process.env.ASSET_STORE_DIR;
+  process.env.ASSET_STORE_DIR = dir;
+  try {
+    const token = newMagToken();
+    assert.ok(isMagToken(token));
+    assert.ok(!isMagToken("xyz"));
+
+    await createMagSession(token, { issue: 7, size: 10, author: "token" });
+    const s = await readMagSession(token);
+    assert.deepEqual(s, { issue: 7, size: 10, author: "token" });
+    assert.equal((await stat(magStagingPath(token))).size, 0);
+
+    await writeFile(magStagingPath(token), Buffer.from("0123456789"));
+    assert.equal((await readFile(magStagingPath(token))).length, 10);
+
+    await updateMagSession(token, { issue: 7, size: 10, author: "token" });
+    await finishMagSession(token, { issue: 7, size: 10, author: "token" }, "ab".repeat(32));
+
+    // Payload gone, sidecar replays the finished answer.
+    await assert.rejects(stat(magStagingPath(token)));
+    const done = await readMagSession(token);
+    assert.equal(done?.done?.sha256, "ab".repeat(32));
+
+    await dropMagSession(token);
+    assert.equal(await readMagSession(token), null);
+  } finally {
+    if (saved === undefined) delete process.env.ASSET_STORE_DIR;
+    else process.env.ASSET_STORE_DIR = saved;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("readMagSession returns null for unknown tokens", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "magupload-"));
+  const saved = process.env.ASSET_STORE_DIR;
+  process.env.ASSET_STORE_DIR = dir;
+  try {
+    assert.equal(await readMagSession(newMagToken()), null);
+  } finally {
+    if (saved === undefined) delete process.env.ASSET_STORE_DIR;
+    else process.env.ASSET_STORE_DIR = saved;
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Adds a searchable gaming magazine index: normalized magazines and issues, server side page renders and per extract crops derived from the source PDF, and per section extracts carrying bounding boxes, verbatim original text, English translations, and entity links into the shared games table plus people, systems, and tags.

A moderator API handles ingest (chunked PDF upload, idempotent batches that never overwrite amended or rejected extracts) with an amend and reject audit trail. New surfaces: /magazines with full text and quoted exact search, an issue browser with region overlays, /people pages, magazine coverage on game pages, and issue OG cards. Migration 012 is additive, apply per db/migrations.