### PR TITLE
Search filenames from the search box

### DIFF
--- a/hp-web/scripts/bot.ts
+++ b/hp-web/scripts/bot.ts
@@ -1,14 +1,14 @@
 // prism Discord bot. "!prism <query>" searches public builds by hash
 // (sha256/md5/sha1, build- or file-level), build name, and filename, and
 // replies with links to the build pages. Read-only; private builds are
-// excluded by search()/searchFiles() themselves (visibleSql).
+// excluded by searchAll() itself (visibleSql).
 //
 // Usage: npm run bot   (env DISCORD_TOKEN, DATABASE_URL, optional SITE_URL)
 // The Discord application needs the Message Content intent enabled.
 
 import { Client, EmbedBuilder, Events, GatewayIntentBits, Partials } from "discord.js";
 import pg from "pg";
-import { search, searchFiles } from "../src/lib/queries";
+import { searchAll } from "../src/lib/queries";
 import { buildHref } from "../src/lib/slug";
 import { loadDotEnv } from "./dotenv";
 
@@ -36,16 +36,11 @@ interface Hit {
   file?: string;
 }
 
-/** Hash lookup when the term looks like one; otherwise name/FTS matches
- *  first, then builds matched only through a filename. */
+/** Hash lookup when the term looks like one, otherwise name and filename
+ *  matches ranked together by similarity. One extra result so formatReply
+ *  can tell when the list overflows. */
 async function findBuilds(term: string): Promise<Hit[]> {
-  const r = await search(pool, term, MAX_RESULTS + 1);
-  if (r.mode === "hash") return r.results;
-  const byFile = await searchFiles(pool, term, MAX_RESULTS + 1);
-  const seen = new Set(r.results.map((x) => x.sha256));
-  const hits: Hit[] = [...r.results];
-  for (const f of byFile) if (!seen.has(f.sha256)) hits.push(f);
-  return hits;
+  return (await searchAll(pool, term, MAX_RESULTS + 1)).results;
 }
 
 /** Neutralize markdown in build names used as link text. Only characters

--- a/hp-web/src/app/api/search/route.ts
+++ b/hp-web/src/app/api/search/route.ts
@@ -1,14 +1,14 @@
 import type { NextRequest } from "next/server";
 import { getPool } from "@/lib/db";
-import { search } from "@/lib/queries";
+import { searchAll } from "@/lib/queries";
 import { getModerator } from "@/lib/auth";
 import { rateLimit, clientKey } from "@/lib/ratelimit";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-// GET /api/search?q=... — filename FTS/fuzzy, or exact hash lookup.
-// Moderators (wiki session or token) also see private builds.
+// GET /api/search?q=... — build-name FTS/fuzzy plus filenames inside builds,
+// or exact hash lookup. Moderators (wiki session or token) also see private builds.
 export async function GET(request: NextRequest) {
   if (!rateLimit(`search:${clientKey(request)}`, 60, 60_000)) {
     return Response.json({ error: "rate limit exceeded" }, { status: 429 });
@@ -16,6 +16,6 @@ export async function GET(request: NextRequest) {
   const term = (request.nextUrl.searchParams.get("q")?.trim() ?? "").slice(0, 256);
   if (!term) return Response.json({ mode: "text", results: [] });
   const mod = await getModerator(request);
-  const result = await search(getPool(), term, 50, !!mod);
+  const result = await searchAll(getPool(), term, 50, !!mod);
   return Response.json(result);
 }

--- a/hp-web/src/app/page.tsx
+++ b/hp-web/src/app/page.tsx
@@ -9,6 +9,8 @@ interface Hit {
   name: string;
   system: string;
   sim?: number | null;
+  /** Set when the build matched through a file inside it. */
+  file?: string;
 }
 
 export default function Home() {
@@ -56,7 +58,7 @@ export default function Home() {
         </span>
       </div>
       <p className="mt-1 text-sm text-neutral-500">
-        Search known builds by filename or hash.
+        Search known builds by title, filename, or hash.
       </p>
 
       <form onSubmit={runSearch} className="mt-6 flex gap-2">
@@ -92,6 +94,11 @@ export default function Home() {
                       {h.system || "unknown"}
                     </span>
                     <span className="font-mono">{h.sha256.slice(0, 16)}…</span>
+                    {h.file && (
+                      <span className="min-w-0 truncate font-mono" title={h.file}>
+                        {h.file}
+                      </span>
+                    )}
                     {h.sim != null && <span>sim {h.sim.toFixed(2)}</span>}
                   </div>
                 </li>

--- a/hp-web/src/lib/queries.ts
+++ b/hp-web/src/lib/queries.ts
@@ -411,7 +411,14 @@ export async function findByEmbedding(
 
 export interface SearchResult {
   mode: "hash" | "text";
-  results: Array<{ sha256: string; name: string; system: string; sim?: number | null }>;
+  results: Array<{
+    sha256: string;
+    name: string;
+    system: string;
+    sim?: number | null;
+    /** Set when the build matched only through a file inside it. */
+    file?: string;
+  }>;
 }
 
 /** Filename FTS/fuzzy search, or exact hash lookup when the term looks like a hash. */
@@ -494,6 +501,30 @@ export async function searchFiles(
     [t, pat, limit]
   );
   return r.rows.map((x) => ({ ...x, sim: Number(x.sim) }));
+}
+
+/** search() plus searchFiles(). Hash lookups pass through. Text terms merge
+ *  both arms ranked by trigram similarity, one row per build. When a build
+ *  matches both ways the higher-sim representation wins, so a near-exact
+ *  filename (with the file attached) outranks the text_doc FTS matches whose
+ *  name-sim is ~0 and would otherwise fill the cap. */
+export async function searchAll(
+  pool: Pool,
+  term: string,
+  limit = 50,
+  includePrivate = false
+): Promise<SearchResult> {
+  const byName = await search(pool, term, limit, includePrivate);
+  if (byName.mode === "hash") return byName;
+  const byFile = await searchFiles(pool, term, limit, includePrivate);
+  const best = new Map(byName.results.map((x) => [x.sha256, x]));
+  for (const f of byFile) {
+    const cur = best.get(f.sha256);
+    if (cur && (cur.sim ?? 0) >= f.sim) continue;
+    best.set(f.sha256, { sha256: f.sha256, name: f.name, system: f.system, sim: f.sim, file: f.file });
+  }
+  const results = [...best.values()].sort((a, b) => (b.sim ?? 0) - (a.sim ?? 0)).slice(0, limit);
+  return { mode: "text", results };
 }
 
 export type SubmissionKind = "build" | "duplicate";

--- a/hp-web/tests/lib.test.ts
+++ b/hp-web/tests/lib.test.ts
@@ -275,10 +275,74 @@ test("orderAssets accepts a per-kind cap map (missing kind = uncapped)", () => {
   assert.deepEqual(counts, { image: 30, audio: 20, text: 12 });
 });
 
+// --- combined build/file search --------------------------------------------------
+
+import { searchAll } from "../src/lib/queries";
+import type { Pool } from "pg";
+
+/** Routes search()'s name/hash query and searchFiles()'s file query to canned
+ *  rows, keyed on SQL fragments unique to each. */
+function searchPool(nameRows: unknown[], fileRows: unknown[] | null, hashRows: unknown[] = []) {
+  return {
+    query: async (sql: string) => {
+      if (sql.includes("similarity(f.name")) {
+        if (!fileRows) throw new Error("file query should not run");
+        return { rows: fileRows };
+      }
+      if (sql.includes("similarity(name")) return { rows: nameRows };
+      return { rows: hashRows };
+    },
+  } as unknown as Pool;
+}
+
+const hit = (n: number, extra = {}) => ({ sha256: String(n).repeat(64), name: `build${n}`, system: "PS2", ...extra });
+
+test("searchAll ranks name and file hits together, one row per build", async () => {
+  const pool = searchPool(
+    [hit(1, { sim: 0.9 }), hit(2, { sim: 0.1 })],
+    [hit(2, { file: "DUP.BIN", sim: "0.8" }), hit(3, { file: "MAINMENU.TEX", sim: "0.4" })]
+  );
+  const r = await searchAll(pool, "menu");
+  assert.equal(r.mode, "text");
+  assert.deepEqual(
+    r.results.map((x) => [x.name, x.file, x.sim]),
+    [
+      ["build1", undefined, 0.9],
+      ["build2", "DUP.BIN", 0.8], // file match beats its own weak name match
+      ["build3", "MAINMENU.TEX", 0.4],
+    ]
+  );
+});
+
+test("searchAll lets filename matches displace weaker FTS matches under the cap", async () => {
+  // text_doc FTS matches carry sim ~0, so a near-exact filename must outrank
+  // them instead of being appended past the limit.
+  const pool = searchPool(
+    [hit(1, { sim: 0.05 }), hit(2, { sim: 0 })],
+    [hit(3, { file: "MAINMENU.TEX", sim: "0.7" })]
+  );
+  const r = await searchAll(pool, "mainmenu.tex", 2);
+  assert.deepEqual(r.results.map((x) => [x.name, x.file]), [
+    ["build3", "MAINMENU.TEX"],
+    ["build1", undefined],
+  ]);
+});
+
+test("searchAll passes hash lookups through without a file query", async () => {
+  const pool = searchPool([], null, [hit(7)]);
+  const r = await searchAll(pool, "deadbeef".repeat(8));
+  assert.equal(r.mode, "hash");
+  assert.deepEqual(r.results.map((x) => x.name), ["build7"]);
+});
+
+test("searchAll skips the file query for terms too short for trigrams", async () => {
+  const r = await searchAll(searchPool([hit(1, { sim: 0.3 })], null), "ab");
+  assert.deepEqual(r.results.map((x) => x.name), ["build1"]);
+});
+
 // --- submission asset uploads ---------------------------------------------------
 
 import { referencedAssets, MAX_ASSET_BLOB_BYTES, MAX_VIDEO_BLOB_BYTES } from "../src/lib/submission-assets";
-import type { Pool } from "pg";
 
 function fakePool(subRow?: { record: BuildRecord; status: string }, buildRow?: { record: BuildRecord }) {
   return {


### PR DESCRIPTION
The home search box now matches filenames inside builds, using the existing searchFiles query that only the Discord bot used. Name and filename hits merge into one list ranked by trigram similarity, and rows matched through a file show that filename.

The bot shares the new searchAll helper, which also fixes its old ordering where text_doc FTS noise could fill the list before any filename match surfaced. Hash lookups are unchanged.