### PR TITLE
Add magazine ingest skill

### DIFF
--- a/skills/magazine-ingest/SKILL.md
+++ b/skills/magazine-ingest/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: magazine-ingest
+description: Extract structured metadata from a scanned gaming-magazine PDF (issue identity, per-page extracts with bounding boxes, translations) and post it to the prism magazine index. Use when asked to "ingest a magazine", "extract magazine metadata", "analyze this magazine pdf", "add this issue to the magazine index", "process this magazine scan", "sweep this issue", "do the next magazine", "upload the magazine extracts", or to resume, QA, or re-run a previous magazine ingest.
+---
+
+# Ingest a scanned gaming magazine
+
+Five resumable passes turn one PDF into a fully indexed issue on the prism web
+app: render, identity, sweep, translation, QA, upload. Every pass checkpoints
+into a per-issue work dir, so an interrupted session resumes by re-running the
+pass, nothing already done reruns.
+
+Scripts live in `skills/magazine-ingest/scripts/` (run them from the repo
+root; to make this a triggerable agent skill, copy this directory into your
+agent's skills directory). The two image
+scripts need Pillow; run them as
+
+```sh
+uv run --no-project --with pillow python3 skills/magazine-ingest/scripts/render.py ...
+uv run --no-project --with pillow python3 skills/magazine-ingest/scripts/crop.py ...
+```
+
+(plain `python3` works when Pillow is installed). `post.py` is stdlib-only:
+`python3 skills/magazine-ingest/scripts/post.py ...`.
+
+## Work dir
+
+One dir per issue, somewhere that survives the whole run, the session
+scratchpad or `/tmp`, e.g. `<scratchpad>/mag/<issue-slug>/`:
+
+```
+<workdir>/
+  pages/p-<n>.jpg     analysis render, n = 1-based pdf index, long edge ~1600px
+  grid/p-<n>.jpg      same render + labeled 10x10 coordinate grid
+  issue.json          pass-1 identity (+ issue_id once created server-side)
+  pages-NNN.jsonl     pass-2 checkpoints, one extract per line
+                      (NNN = zero-padded first pdf index of the batch)
+  qa/                 pass-4 sample crops
+```
+
+## Pass 0, setup (render)
+
+NEVER Read a magazine PDF directly: many exceed the 100MB Read cap, and pages
+must be viewed as rendered images anyway. Always read the rendered JPEGs.
+
+```sh
+uv run --no-project --with pillow python3 skills/magazine-ingest/scripts/render.py <pdf> <workdir>
+```
+
+Renders every page to `pages/p-<n>.jpg` plus a gridded copy in `grid/`.
+Flags: `--pages A-B` for a range, `--grid-only` to redraw grids,
+`--dpi-target` (default 1600). Prefers `pdftoppm` (poppler); falls back to
+Ghostscript resolved from `$GHOSTSCRIPT_BIN`, then `gs`, then
+`/opt/homebrew/opt/ghostscript/bin/gs`, each candidate's `-h` banner must
+actually say Ghostscript (on macOS a bare `gs` is often git-spice).
+Idempotent: already-rendered pages are skipped.
+
+## Pass 1, identity (issue.json)
+
+Read the cover, TOC, masthead/colophon, and back cover renders. Write
+`<workdir>/issue.json`:
+
+```json
+{
+  "magazine": {
+    "slug": "supergame", "title": "Supergame", "aliases": ["SuperGame"],
+    "country": "BR", "language": "pt-br", "publisher": "Editora Nova Cultural"
+  },
+  "issue": {
+    "slug": "01", "label": "Ano 1 No 1", "volume": "1", "number": "1",
+    "whole_number": "1",
+    "cover_date": "1991-08-01", "cover_date_precision": "month",
+    "price_raw": "Cr$ 480,00", "publisher_raw": "Editora Nova Cultural Ltda.",
+    "binding": "ltr", "page_count": 68,
+    "source_url": "https://.../Supergame_BR_01.pdf",
+    "supplements": [{ "title": "Poster gigante", "present": true }],
+    "page_labels": { "3": "3", "4": "4", "56": "supp:2" }
+  }
+}
+```
+
+Field notes (wire format: `IssueInput`/`MagazineInput` in
+`hp-web/src/lib/mag/kinds.ts`):
+
+- `magazine.slug`: lowercase `[a-z0-9-]`, stable across every issue of the
+  magazine. `country` is the ISO code, `language` bcp47 lowercase.
+- `issue.slug`: `[a-z0-9-]` ≤64, `"022"`, `"1991-08"`, `"01"` style.
+  `label` is the printed issue designation, verbatim.
+- `cover_date` is full ISO `YYYY-MM-DD`; **month precision is normal** for
+  magazines (day `01` as placeholder + `"cover_date_precision": "month"`).
+- `price_raw` verbatim as printed, currency marks intact.
+- `binding`: `rtl` for right-to-left page order (Japanese magazines), else
+  `ltr`.
+- `source_url`: when the scan corpus ships a `manifest.tsv` (columns: url,
+  filename, size), look the scan's filename up there.
+- `supplements`: bound-in extras (posters, mini-guides, supplement booklets);
+  `present: false` when the printed issue had it but this scan lacks it.
+- `page_labels`: printed page label per pdf index (string keys, 1-based).
+  **Verify the printed-number-to-pdf-index rule on 4-5 spot pages** spread
+  through the issue before writing labels down, cover offsets, unnumbered ad
+  pages, and pages missing from the scan all shift the rule. Bound-in
+  supplements with their own pagination get scoped labels: `"supp:N"`.
+
+## Pass 2, sweep (pages-NNN.jsonl)
+
+Work in batches of 6-10 pages. Per batch: read the analysis images
+`pages/p-<n>.jpg`, consult `grid/p-<n>.jpg` for coordinates, and write one
+JSON line per extract (the wire format below) to `<workdir>/pages-NNN.jsonl`.
+The file is the checkpoint: a batch whose file exists and is complete never
+reruns.
+
+- One extract = one addressable unit: one capsule review, one tip, one
+  letter, one ad, one chart. A review roundup page is many extracts; a
+  six-page interview is one.
+- Every page gets full coverage, everything on the page belongs to some
+  extract. Page furniture (folios, running headers/footers, decorative rules)
+  is never extracted and never blocks coverage.
+- Do not extract-then-forget: keep `seq` and `client_key` assigned as you go
+  (conventions below).
+
+## Pass 3, translation
+
+- `summary_en` (1-2 sentences, English) is REQUIRED for every extract in
+  every language, English included.
+- For non-English issues, fill `text_en` with a full English translation for
+  every extract and set `"translation": "machine"`.
+- Sweep subagents should fill `summary_en` (and `text_en` on non-English
+  issues) inline during pass 2; pass 3 is then a gap-fill sweep over the
+  checkpoints for anything missing.
+
+## Pass 4, QA
+
+```sh
+uv run --no-project --with pillow python3 skills/magazine-ingest/scripts/crop.py <workdir> <workdir>/pages-*.jsonl --sample 0.1
+```
+
+cuts every region of ~10% of the extracts (stable sample) into
+`<workdir>/qa/<client_key>-r<i>.png` and prints a manifest line per crop
+(client_key, kind, title, path). Then:
+
+- Re-read each crop image and confirm it contains what its extract claims
+  (right piece, headline and images inside the box). Widen or fix boxes that
+  miss: edit the JSONL line, then re-crop just that file with `--all` to
+  confirm.
+- Cross-check ad extracts against the advertiser index when the magazine
+  prints one (EGM does): every advertiser/page in the `ad_index` extract
+  should have a matching `ad` extract.
+- List pages with zero extracts and TOC sections with no extracts;
+  investigate each one (blank page? furniture-only? page missing from the
+  scan? missed sweep?). Fix or note the reason before uploading.
+
+## Pass 5, upload
+
+`post.py` subcommands, in order (auth and `--base` below):
+
+```sh
+P=skills/magazine-ingest/scripts/post.py
+python3 $P magazine <workdir>/issue.json          # upsert magazine by slug
+python3 $P issue    <workdir>/issue.json          # upsert issue; writes issue_id back
+python3 $P pdf      <workdir>/issue.json <pdf>    # chunked upload + sha256 verify
+python3 $P extracts <workdir>/issue.json <workdir>/pages-*.jsonl
+python3 $P status   <workdir>/issue.json --wait   # poll until pages+crops done
+```
+
+- `magazine` must run before `issue`, a typo'd magazine slug 404s instead of
+  minting a magazine. Optional magazine/issue fields that are omitted keep
+  their stored values, so re-upserts cannot blank a moderator's edits.
+- `pdf` opens a session (`POST .../pdf {size}` -> token), PUTs 8MB chunks to
+  `.../pdf/<token>?offset=N`, resumes from the server's offset on 409,
+  retries each chunk up to 5 times with backoff on 5xx/timeouts, and verifies
+  the returned sha256 against the local file. Server caps: 1 GiB per PDF,
+  32MB per chunk.
+- `extracts` posts batches of up to 50 (server MAX_BATCH), prints per-item
+  results, writes `<input>.results.jsonl` next to each input, and exits
+  nonzero if any item errored (`skipped: "moderated"` is fine).
+- `status --wait` polls every 5s until `pages_rendered = pages_total` and
+  `crops_done = crops_total`, then prints the final status and the issue URL.
+
+Finish with a report to the user: extract counts by kind, every skipped/error
+item, and the issue URL `/magazines/<magazine-slug>/<issue-slug>`.
+
+## Extract wire format
+
+Must match `hp-web/src/lib/mag/kinds.ts` exactly (`ExtractInput`), read it
+if in doubt. One JSONL line per extract:
+
+```json
+{
+  "client_key": "p23-review-sonic-the-hedgehog",
+  "kind": "review", "section": "Review Crew", "seq": 2301,
+  "title": "Sonic The Hedgehog", "language": "en",
+  "text_original": "…verbatim transcription…",
+  "text_en": "…full translation (non-English only)…", "translation": "machine",
+  "summary_en": "One to two English sentences.",
+  "data": { "…kind-specific payload…": "see Policy" },
+  "is_fictional": false, "sponsored": false, "content_warning": "…",
+  "regions": [{ "pdf_index": 23, "x": 0.05, "y": 0.1, "w": 0.44, "h": 0.38 }],
+  "games": [{ "name": "Sonic the Hedgehog", "system": "Sega Mega Drive",
+              "role": "subject", "title_printed": "SONIC THE HEDGEHOG" }],
+  "people": [{ "name": "Sushi-X", "kind": "persona", "role": "reviewer" }],
+  "systems": ["Sega Mega Drive"],
+  "tags": [{ "kind": "company", "name": "Sega" }]
+}
+```
+
+- `client_key`: `p<pdf_index>-<kind>-<short-slug>` (pdf index of the first
+  region). Stable across re-runs, derive it from the content, never from a
+  counter, and unique within the issue (disambiguate with `-2`, `-3` when a
+  page has two same-kind, same-slug units). ≤200 chars. Re-posting the same
+  key updates the row (idempotent).
+- `kind`, one of: `cover`, `toc`, `masthead`, `editorial`, `letters`, `news`,
+  `rumor`, `preview`, `review`, `feature`, `interview`, `strategy`, `tips`,
+  `chart`, `high_scores`, `calendar`, `contest`, `poster`, `comic`,
+  `fiction`, `column`, `ad`, `ad_index`, `next_issue`, `form`, `other`.
+- `seq`: global reading order within the issue, page order, then
+  top-to-bottom, left-to-right on the page. rtl-bound magazines still use pdf
+  page order. Convention that stays stable across parallel batches:
+  `seq = pdf_index_of_first_region * 100 + position_on_page` (0-99).
+- `section`: the printed department/section name when there is one
+  ("Review Crew", "ファンレター").
+- Bounding boxes (`regions`): normalized 0-1, origin top-left of the page
+  render, read off the gridded copy. Cover the WHOLE visual unit, headline,
+  body, images, credited photos. Multi-page pieces (spread ads, articles with
+  jumps) are ONE extract with multiple ordered regions. Max 12 regions per
+  extract (server cap), split a longer piece into `-pt1`/`-pt2` extracts at
+  a sensible boundary, keeping seq order.
+- Size caps (server): text_original/text_en 200k chars, summary_en 2k, title
+  500, section 200, data 200KB JSON, games ≤300, people ≤50, systems ≤20,
+  tags ≤50, batch ≤50.
+
+## Policy
+
+### Verbatim transcription
+
+- Transcription is verbatim: printed errors stay ("Komani", "PSYCHIC
+  WORLDS"), no `[sic]`, no silent fixes. Canonical names live in the entity
+  links: `games[].name` is canonical, `title_printed` carries what the page
+  printed.
+- FULL verbatim transcription everywhere, including mail-order price lists
+  and dense tables. They are real data: transcribe them in `text_original`
+  AND put the structured rows in `data.entries`.
+
+### Kind-specific data payloads
+
+Omit whatever the page does not show (score-less magazines exist). The
+conventional arrays (`scores`, `axes`, `entries`, `products`, `prizes`) must
+be arrays of objects, the server rejects other shapes.
+
+- review: `data.scores` `[{reviewer, value, scale}]`, `data.average`
+  `{value, scale}`, radar charts as `data.axes` `[{name, value, scale}]`,
+  `data.subject_type` game|hardware|accessory|music.
+- fact boxes (on previews/reviews): `data.fact_box` `{maker, system_printed,
+  release_raw, price_raw, cart_size_mbit, genre_printed, levels, difficulty,
+  players, backup, completion_pct}`.
+- chart: `data.entries` `[{rank, prev_rank, title_printed, points, comment}]`
+  + `data.chart_type`, `data.source`, `data.period`.
+- high_scores: `data.entries` `[{player, location, title_printed, event,
+  value, value_type}]` + `data.source`.
+- ad: `data.advertiser`, `data.ad_type`
+  (product|retail_mailorder|classified|house|consumer|school|service),
+  `data.products` `[{title_printed, system_printed, release_raw, price_raw}]`,
+  `data.phones`, `data.reader_service_no`, `data.agency`.
+- interview: `data.interviewees`, `data.interviewer`, `data.format`,
+  `data.series`.
+- contest: `data.subkind`, `data.prizes`, `data.deadlines`,
+  `data.entry_method`, `data.legal`.
+- provenance for charts/tips/scores: `data.source`, `shop_survey`,
+  `reader_mail`, `hotline`, `club`, `press_release`.
+
+### System canonicalization
+
+`games[].system` and `systems[]` use the prism games table's exact strings:
+
+`"Sega Mega Drive"` (Genesis/Mega Drive/メガドライブ), `"Sega Master System"`,
+`"Game Gear"`, `"Sega CD"` (Mega-CD), `"Sega 32X"`, `"NES"` (also Famicom),
+`"SNES"` (also Super Famicom), `"Game Boy"`, `"TurboGrafx-16"` (also PC
+Engine), `"TurboGrafx-CD"`, `"Atari Lynx"`, `"Neo Geo"`, `"Arcade"`,
+`"Amiga"`, `"PC"`.
+
+Keep the printed regional name in the text and in
+`system_printed`/`title_printed` fields.
+
+### Game links
+
+`role`: `subject` (the piece is about it), `mentioned` (referenced in
+passing), `listed` (one row of a chart/calendar/price list).
+
+### People links
+
+- Create `people` links only for staff, industry figures, and stable
+  pseudonymous personas (`kind: "persona"`, Sushi-X, Quartermann,
+  超人バロムI, O Chefe). Organizations like the U.S. National Video Game Team
+  get `kind: "organization"`.
+- CJK names need a romanized lowercase slug (e.g. `"masayuki-yamamoto"`) plus
+  `name_original` in the native script.
+- NEVER create people links for private individuals: readers credited on
+  letters, tips, high scores, and fan art stay in `text_original`/`data`
+  only.
+
+### Flags
+
+- `is_fictional`: deliberate fake/humor content and fiction serials.
+- `sponsored`: co-branded editorial ("EGM and Vic Tokai present").
+- `content_warning`: short text for period slurs and similar.
+
+### Language
+
+- `language` per extract, bcp47 lowercase: `"en"`, `"ja"`, `"pt-br"`. An
+  English pull-quote inside a Japanese magazine is still part of a `"ja"`
+  extract.
+
+## Cost and fan-out
+
+A 40-page issue runs ~300k tokens; a 140-page Japanese issue up to ~1M
+(translation included). Sweep batches may be delegated to parallel subagents,
+one batch per agent (opus-class models are sufficient for sweeps), each
+writing its own `pages-NNN.jsonl` in the shared work dir, with the
+orchestrator merging and sanity-checking the checkpoints. The identity pass
+(1) and QA pass (4) always stay with the orchestrator. Give each subagent the
+work-dir path, its page range, the wire format, and the policy sections
+above.
+
+## Auth and target
+
+`post.py` resolves the moderation token from the `PRISM_MODERATION_TOKEN`
+env var, then `~/.config/prism/moderation-token`. The token is sent as
+`x-moderation-token` and never printed.
+
+`--base` sets the app URL, default `https://hiddenpalace.org` (the
+production instance; `PRISM_WEB_URL` env overrides the default), or
+`--base http://localhost:6800` for local runs.
+
+## Failure modes
+
+- **Per-item batch results**, each extract lands or fails independently:
+  `{client_key, id, action: inserted|updated}` or `{client_key, skipped:
+  moderated|error, error}`. One malformed item never sinks the batch; fix the
+  JSONL line and re-post (client_keys are idempotent).
+- **`skipped: "moderated"`**, a moderator amended or rejected that row;
+  re-ingest only replaces `status='auto'` rows. This is CORRECT, not an
+  error. Leave those rows alone.
+- **Resume after interruption**, rendered pages, `issue.json`, and the
+  JSONL checkpoints persist; re-run the interrupted pass. Re-posting whole
+  checkpoint files is safe: already-ingested keys report `updated`. For a
+  clean from-scratch re-ingest, `post.py reset` (a confirmed
+  `DELETE .../extracts?only=auto`) then re-post; moderated rows survive by
+  design.
+- **PDF upload interrupted**, within a run, 409s resume at the server's
+  offset. A re-run of `post.py pdf` starts a fresh session from byte 0;
+  harmless (blobs are content-addressed) but a full re-upload.
+- **Rendering stalls after a server restart**, the status poll self-heals:
+  GET status re-kicks the render/crop job when work is pending and nothing is
+  running. Keep `status --wait` polling; nothing else to do. If the job
+  repeatedly reports `state: "failed"` with the same error, stop and report
+  it.
+- **HTTP 401**, moderation token missing/stale; set
+  `PRISM_MODERATION_TOKEN` or create the token file.
+- **`issue` returns 404 "no such magazine"**, run `post.py magazine` first
+  (deliberate: a typo'd slug must not mint a magazine).
+- **HTTP 400 on an extract**, the server names the invalid field (unknown
+  kind, bad language tag, degenerate region after clamping, oversized text).
+  Fix that line, re-post the file.
+- **HTTP 413**, batch >50 (post.py already splits) or PDF over the 1 GiB
+  cap. **HTTP 415 "not a pdf"**, the first chunk lacked the `%PDF-` magic;
+  wrong file.

--- a/skills/magazine-ingest/scripts/crop.py
+++ b/skills/magazine-ingest/scripts/crop.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Cut QA sample crops from rendered pages using extract bboxes. See SKILL.md.
+
+  crop.py <workdir> <extracts.jsonl...> [--sample 0.1] [--all] [--out DIR]
+
+Samples ~10% of the extracts (stable per client_key, so re-runs pick the same
+ones), cuts every region of each sampled extract from <workdir>/pages/p-<n>.jpg
+with 1% padding, and writes <out>/<client_key>-r<i>.png (i = 0-based region
+index; default out dir <workdir>/qa). Prints one manifest line per crop:
+
+  client_key<TAB>kind<TAB>title<TAB>path
+
+Run under `uv run --no-project --with pillow python3 crop.py ...`; plain
+python3 works too when Pillow is installed.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
+PAD = 0.01  # normalized padding on every side
+
+def note(msg):
+    print(msg, file=sys.stderr)
+
+def die(msg, code=1):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+def read_extracts(paths):
+    """[(source, extract)] from JSONL files; malformed lines are fatal —
+    the QA pass must not silently skip what pass 2 wrote."""
+    out = []
+    for path in paths:
+        try:
+            with open(path, encoding="utf-8") as f:
+                lines = f.readlines()
+        except OSError as e:
+            die(f"cannot read {path}: {e}")
+        for i, line in enumerate(lines, 1):
+            if not line.strip():
+                continue
+            try:
+                v = json.loads(line)
+            except json.JSONDecodeError as e:
+                die(f"{path}:{i}: bad JSON: {e}")
+            if not isinstance(v, dict) or not v.get("client_key"):
+                die(f"{path}:{i}: extract must be an object with a client_key")
+            out.append((f"{path}:{i}", v))
+    return out
+
+def sampled(client_key, fraction):
+    """Stable inclusion: hash of the key under the threshold. Re-runs and
+    appended files keep the same picks."""
+    h = int.from_bytes(hashlib.sha1(client_key.encode()).digest()[:8], "big")
+    return h / 2**64 < fraction
+
+def safe_name(key):
+    return re.sub(r"[^A-Za-z0-9._-]", "_", key)[:150]
+
+def crop_region(pages_dir, out_dir, extract, i, region):
+    n = region.get("pdf_index")
+    if not isinstance(n, int) or n < 1:
+        return None, f"regions[{i}].pdf_index invalid"
+    src = os.path.join(pages_dir, f"p-{n}.jpg")
+    if not os.path.exists(src):
+        return None, f"no page render {src}"
+    try:
+        x, y = float(region["x"]), float(region["y"])
+        w, h = float(region["w"]), float(region["h"])
+    except (KeyError, TypeError, ValueError):
+        return None, f"regions[{i}] bbox malformed"
+    x0 = max(0.0, x - PAD)
+    y0 = max(0.0, y - PAD)
+    x1 = min(1.0, x + w + PAD)
+    y1 = min(1.0, y + h + PAD)
+    if x1 - x0 <= 0 or y1 - y0 <= 0:
+        return None, f"regions[{i}] is degenerate"
+    with Image.open(src) as im:
+        pw, ph = im.size
+        box = (round(x0 * pw), round(y0 * ph),
+               max(round(x0 * pw) + 1, round(x1 * pw)),
+               max(round(y0 * ph) + 1, round(y1 * ph)))
+        dst = os.path.join(out_dir, f"{safe_name(extract['client_key'])}-r{i}.png")
+        im.crop(box).save(dst)
+    return dst, None
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("workdir", help="work dir holding pages/p-<n>.jpg")
+    p.add_argument("jsonl", nargs="+", help="pass-2 checkpoint files (pages-*.jsonl)")
+    p.add_argument("--sample", type=float, default=0.1, metavar="FRAC",
+                   help="fraction of extracts to crop (default 0.1)")
+    p.add_argument("--all", action="store_true", help="crop every extract")
+    p.add_argument("--out", metavar="DIR", help="output dir (default <workdir>/qa)")
+    args = p.parse_args()
+
+    if Image is None:
+        die("Pillow is required: run under `uv run --no-project --with pillow python3 ...`")
+    if not args.all and not 0 < args.sample <= 1:
+        die("--sample must be in (0, 1]")
+
+    pages_dir = os.path.join(args.workdir, "pages")
+    if not os.path.isdir(pages_dir):
+        die(f"no pages dir: {pages_dir} (run render.py first)")
+    out_dir = args.out or os.path.join(args.workdir, "qa")
+    os.makedirs(out_dir, exist_ok=True)
+
+    extracts = read_extracts(args.jsonl)
+    if not extracts:
+        die("no extracts in the given files")
+    picked = [e for e in extracts if args.all or sampled(e[1]["client_key"], args.sample)]
+    if not picked:
+        picked = [extracts[0]]  # never sample zero
+    note(f"{len(picked)} of {len(extracts)} extracts sampled")
+
+    errors = 0
+    crops = 0
+    for source, extract in picked:
+        regions = extract.get("regions")
+        if not isinstance(regions, list) or not regions:
+            note(f"ERROR {source}: {extract['client_key']}: no regions")
+            errors += 1
+            continue
+        for i, region in enumerate(regions):
+            if not isinstance(region, dict):
+                note(f"ERROR {source}: {extract['client_key']}: regions[{i}] not an object")
+                errors += 1
+                continue
+            path, err = crop_region(pages_dir, out_dir, extract, i, region)
+            if err:
+                note(f"ERROR {source}: {extract['client_key']}: {err}")
+                errors += 1
+                continue
+            print(f"{extract['client_key']}\t{extract.get('kind', '?')}\t"
+                  f"{extract.get('title') or ''}\t{path}")
+            crops += 1
+
+    note(f"{crops} crops written to {out_dir}" + (f", {errors} errors" if errors else ""))
+    if errors:
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/skills/magazine-ingest/scripts/post.py
+++ b/skills/magazine-ingest/scripts/post.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Post magazine metadata to the prism web app's ingestion API. See SKILL.md.
+
+Subcommands (all take --base and authenticate with x-moderation-token; the
+token is never printed):
+
+  magazine <issue.json>             upsert the magazine block
+  issue    <issue.json>             upsert the issue block; stores issue_id back
+  pdf      <issue.json> <file.pdf>  chunked source-PDF upload (resumable)
+  extracts <issue.json> <jsonl...>  ingest extracts in batches of 50
+  status   <issue.json> [--wait]    render/crop progress (--wait polls to done)
+  reset    <issue.json>             delete status='auto' extracts (y/N confirm)
+
+issue.json is the pass-1 identity file: {"magazine": {...}, "issue": {...}}
+plus "issue_id" once `issue` has run. Stdlib only (urllib), no external deps.
+
+Token resolution: PRISM_MODERATION_TOKEN env, then ~/.config/prism/
+moderation-token.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+
+DEFAULT_BASE = os.environ.get("PRISM_WEB_URL", "https://hiddenpalace.org")
+TOKEN_FILE = os.path.expanduser("~/.config/prism/moderation-token")
+UA = "prism-magazine-ingest/1 (mag ingest tooling)"
+CHUNK = 8 * 1024 * 1024
+BATCH = 50  # server MAX_BATCH
+CHUNK_RETRIES = 5
+POLL_SECONDS = 5
+
+class Fail(Exception):
+    pass
+
+class NetFail(Fail):
+    """Transient transport failure (timeout, connection error) — retryable."""
+
+def note(msg):
+    print(msg, file=sys.stderr)
+
+def die(msg, code=1):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+def moderation_token():
+    tok = os.environ.get("PRISM_MODERATION_TOKEN", "").strip()
+    if tok:
+        return tok
+    try:
+        with open(TOKEN_FILE) as f:
+            tok = f.read().strip()
+        if tok:
+            return tok
+    except OSError:
+        pass
+    die(f"no moderation token: set PRISM_MODERATION_TOKEN or create {TOKEN_FILE}")
+
+# ── HTTP ─────────────────────────────────────────────────────────────────────
+
+_SSL_CTX = "unset"  # "unset" -> probe; None -> library default; else a context
+
+def _urlopen(req, timeout):
+    """urlopen with a one-time CA fallback: system Pythons without certifi
+    (macOS) can still verify against the OS bundle."""
+    global _SSL_CTX
+    if _SSL_CTX != "unset":
+        return urllib.request.urlopen(req, timeout=timeout, context=_SSL_CTX)
+    try:
+        r = urllib.request.urlopen(req, timeout=timeout)
+        _SSL_CTX = None
+        return r
+    except urllib.error.URLError as e:
+        if "CERTIFICATE_VERIFY_FAILED" not in str(e):
+            raise
+        for cafile in ("/etc/ssl/cert.pem", "/opt/homebrew/etc/ca-certificates/cert.pem"):
+            if not os.path.exists(cafile):
+                continue
+            ctx = ssl.create_default_context(cafile=cafile)
+            try:
+                r = urllib.request.urlopen(req, timeout=timeout, context=ctx)
+            except urllib.error.URLError:
+                continue
+            _SSL_CTX = ctx
+            return r
+        raise Fail("TLS certificate verification failed and no system CA bundle "
+                   "worked; try a Python with certifi or --base http://...") from e
+
+def request(method, url, tok, body=None, raw=None, timeout=120):
+    """(status, text). HTTP error statuses are returned, not raised;
+    transport-level failures raise NetFail."""
+    headers = {"User-Agent": UA, "x-moderation-token": tok}
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    elif raw is not None:
+        data = raw
+        headers["Content-Type"] = "application/octet-stream"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with _urlopen(req, timeout) as r:
+            return r.getcode(), r.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")
+    except (urllib.error.URLError, TimeoutError, ConnectionError, OSError) as e:
+        raise NetFail(f"{method} {url}: {e}") from e
+
+def api(base, path, tok, method="GET", body=None, timeout=120):
+    status, out = request(method, base + path, tok, body=body, timeout=timeout)
+    if status != 200:
+        raise Fail(f"{method} {path} -> HTTP {status}: {out[:500]}")
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as e:
+        raise Fail(f"{method} {path} -> non-JSON response: {out[:200]}") from e
+
+# ── issue.json ───────────────────────────────────────────────────────────────
+
+def load_doc(path):
+    try:
+        with open(path, encoding="utf-8") as f:
+            doc = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        die(f"cannot read {path}: {e}")
+    if not isinstance(doc, dict):
+        die(f"{path} must hold a JSON object")
+    return doc
+
+def save_doc(path, doc):
+    tmp = f"{path}.tmp{os.getpid()}"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(doc, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    os.replace(tmp, path)
+
+def block(doc, path, key):
+    v = doc.get(key)
+    if not isinstance(v, dict):
+        die(f'{path} has no "{key}" object (pass 1 writes it)')
+    return v
+
+def issue_id(doc, path):
+    v = doc.get("issue_id")
+    if not isinstance(v, int):
+        die(f'{path} has no issue_id — run `post.py issue {path}` first')
+    return v
+
+def issue_url(base, doc):
+    mag = doc.get("magazine", {}).get("slug")
+    slug = doc.get("issue", {}).get("slug")
+    return f"{base}/magazines/{mag}/{slug}" if mag and slug else None
+
+# ── subcommands ──────────────────────────────────────────────────────────────
+
+def cmd_magazine(args, tok):
+    doc = load_doc(args.issue_json)
+    magazine = block(doc, args.issue_json, "magazine")
+    r = api(args.base, "/api/mag/magazines", tok, "POST", magazine)
+    print(json.dumps(r.get("magazine", r), indent=2, ensure_ascii=False))
+
+def cmd_issue(args, tok):
+    doc = load_doc(args.issue_json)
+    payload = dict(block(doc, args.issue_json, "issue"))
+    payload.setdefault("magazine", doc.get("magazine", {}).get("slug"))
+    if not payload.get("magazine"):
+        die(f"{args.issue_json}: no magazine slug (issue.magazine or magazine.slug)")
+    r = api(args.base, "/api/mag/issues", tok, "POST", payload)
+    issue = r.get("issue")
+    if not isinstance(issue, dict) or not isinstance(issue.get("id"), int):
+        raise Fail(f"unexpected issue response: {json.dumps(r)[:300]}")
+    doc["issue_id"] = issue["id"]
+    save_doc(args.issue_json, doc)
+    print(f"issue id {issue['id']}: {issue.get('magazine_slug')}/{issue.get('slug')} "
+          f"({issue.get('label')})")
+    note(f"issue_id stored in {args.issue_json}")
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while chunk := f.read(1024 * 1024):
+            h.update(chunk)
+    return h.hexdigest()
+
+def put_chunk(args, tok, ident, token, offset, chunk):
+    """One chunk with retry/backoff; returns the parsed 200 body or a 409
+    offset to adopt. Anything else raises."""
+    url = f"{args.base}/api/mag/issues/{ident}/pdf/{token}?offset={offset}"
+    for attempt in range(1, CHUNK_RETRIES + 1):
+        try:
+            status, out = request("PUT", url, tok, raw=chunk, timeout=300)
+        except NetFail as e:
+            status, out = None, str(e)
+        if status == 200:
+            try:
+                return json.loads(out), None
+            except json.JSONDecodeError:
+                raise Fail(f"PUT chunk -> non-JSON response: {out[:200]}")
+        if status == 409:
+            try:
+                truth = json.loads(out)["offset"]
+            except (json.JSONDecodeError, KeyError):
+                raise Fail(f"PUT chunk -> HTTP 409 without an offset: {out[:200]}")
+            return None, int(truth)
+        if status is not None and status < 500:
+            raise Fail(f"PUT chunk @{offset} -> HTTP {status}: {out[:300]}")
+        if attempt == CHUNK_RETRIES:
+            raise Fail(f"PUT chunk @{offset} failed after {CHUNK_RETRIES} tries: "
+                       f"{'HTTP ' + str(status) if status else out}")
+        wait = 2 ** attempt
+        note(f"chunk @{offset}: {'HTTP ' + str(status) if status else 'network error'}; "
+             f"retry {attempt}/{CHUNK_RETRIES - 1} in {wait}s")
+        time.sleep(wait)
+
+def cmd_pdf(args, tok):
+    doc = load_doc(args.issue_json)
+    ident = issue_id(doc, args.issue_json)
+    if not os.path.isfile(args.pdf):
+        die(f"no such file: {args.pdf}")
+    size = os.path.getsize(args.pdf)
+    if size == 0:
+        die(f"{args.pdf} is empty")
+    r = api(args.base, f"/api/mag/issues/{ident}/pdf", tok, "POST", {"size": size})
+    token = r.get("token")
+    if not token:
+        raise Fail(f"no upload token in response: {json.dumps(r)[:200]}")
+    note(f"uploading {size} bytes in {CHUNK // (1024 * 1024)}MB chunks")
+
+    offset = 0
+    stale = 0
+    sha_remote = None
+    with open(args.pdf, "rb") as f:
+        while sha_remote is None:
+            f.seek(offset)
+            chunk = f.read(CHUNK)
+            if not chunk:
+                raise Fail(f"file ended at {offset} before the declared size {size}")
+            body, truth = put_chunk(args, tok, ident, token, offset, chunk)
+            if truth is not None:  # 409: the server knows the real offset
+                stale += 1
+                if stale > 3:
+                    raise Fail("upload session keeps disagreeing about the offset")
+                note(f"server says offset {truth}; resuming there")
+                offset = truth
+                continue
+            stale = 0
+            if body.get("done"):
+                sha_remote = body.get("sha256")
+                if not sha_remote:
+                    raise Fail(f"upload finished without a sha256: {json.dumps(body)[:200]}")
+            else:
+                offset = int(body.get("offset", offset + len(chunk)))
+                note(f"  {offset}/{size} bytes ({100 * offset // size}%)")
+
+    note("verifying sha256 locally...")
+    sha_local = sha256_file(args.pdf)
+    if sha_local != sha_remote:
+        raise Fail(f"sha256 mismatch: local {sha_local}, server {sha_remote}")
+    print(f"pdf uploaded: sha256 {sha_remote} ({size} bytes)")
+
+def cmd_extracts(args, tok):
+    doc = load_doc(args.issue_json)
+    ident = issue_id(doc, args.issue_json)
+    totals = {"inserted": 0, "updated": 0, "moderated": 0, "error": 0}
+    for path in args.jsonl:
+        # A glob like pages-*.jsonl also matches our own results logs from a
+        # previous run; feeding those back would just produce noise errors.
+        if path.endswith(".results.jsonl"):
+            note(f"{path}: skipping results log")
+            continue
+        items = []
+        try:
+            with open(path, encoding="utf-8") as f:
+                for i, line in enumerate(f, 1):
+                    if not line.strip():
+                        continue
+                    try:
+                        items.append(json.loads(line))
+                    except json.JSONDecodeError as e:
+                        note(f"ERROR {path}:{i}: bad JSON: {e}")
+                        totals["error"] += 1
+        except OSError as e:
+            die(f"cannot read {path}: {e}")
+        if not items:
+            note(f"{path}: nothing to post")
+            continue
+        results = []
+        for start in range(0, len(items), BATCH):
+            batch = items[start:start + BATCH]
+            r = api(args.base, f"/api/mag/issues/{ident}/extracts", tok, "POST",
+                    batch, timeout=300)
+            batch_results = r.get("results")
+            if not isinstance(batch_results, list):
+                raise Fail(f"unexpected extracts response: {json.dumps(r)[:300]}")
+            results.extend(batch_results)
+            for item in batch_results:
+                key = item.get("client_key", "?")
+                if "id" in item:
+                    totals[item["action"]] = totals.get(item["action"], 0) + 1
+                    print(f"{key}: {item['action']}")
+                else:
+                    reason = item.get("skipped", "error")
+                    totals[reason] = totals.get(reason, 0) + 1
+                    suffix = f" ({item['error']})" if item.get("error") else ""
+                    print(f"{key}: skipped: {reason}{suffix}")
+        log = path + ".results.jsonl"
+        with open(log, "w", encoding="utf-8") as f:
+            for item in results:
+                f.write(json.dumps(item, ensure_ascii=False) + "\n")
+        note(f"{path}: {len(results)} results logged to {log}")
+
+    print("totals: " + "  ".join(f"{k}={v}" for k, v in totals.items() if v))
+    if totals["error"]:
+        die(f"{totals['error']} extracts errored (moderated skips are fine; "
+            "errors are not) — fix and re-post, client_keys are idempotent", 2)
+
+def assets_complete(assets):
+    return (assets.get("pages_total", 0) > 0
+            and assets.get("pages_rendered", 0) >= assets["pages_total"]
+            and assets.get("crops_done", 0) >= assets.get("crops_total", 0))
+
+def cmd_status(args, tok):
+    doc = load_doc(args.issue_json)
+    ident = issue_id(doc, args.issue_json)
+    failures = 0
+    while True:
+        r = api(args.base, f"/api/mag/issues/{ident}/status", tok)
+        if not args.wait:
+            print(json.dumps(r, indent=2))
+            return
+        assets = r.get("assets", {})
+        extracts = r.get("extracts", {})
+        note(f"issue={r.get('issue')} state={assets.get('state')} "
+             f"pages {assets.get('pages_rendered')}/{assets.get('pages_total')} "
+             f"crops {assets.get('crops_done')}/{assets.get('crops_total')} "
+             f"extracts auto={extracts.get('auto')} amended={extracts.get('amended')} "
+             f"rejected={extracts.get('rejected')}")
+        if assets.get("state") == "failed" and assets.get("error"):
+            failures += 1
+            if failures >= 3:  # polling self-heals; a repeating error will not
+                raise Fail(f"asset job keeps failing: {assets['error']}")
+        else:
+            failures = 0
+        if assets_complete(assets):
+            print(json.dumps(r, indent=2))
+            url = issue_url(args.base, doc)
+            if url:
+                print(f"issue url: {url}")
+            return
+        time.sleep(POLL_SECONDS)
+
+def cmd_reset(args, tok):
+    doc = load_doc(args.issue_json)
+    ident = issue_id(doc, args.issue_json)
+    answer = input(f"delete ALL status='auto' extracts of issue {ident} "
+                   f"({issue_url(args.base, doc) or 'unknown slug'})? [y/N] ")
+    if answer.strip().lower() not in ("y", "yes"):
+        die("aborted (nothing deleted)")
+    r = api(args.base, f"/api/mag/issues/{ident}/extracts?only=auto", tok, "DELETE")
+    print(f"deleted: {r.get('deleted')} (moderated rows are never touched)")
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--base", default=DEFAULT_BASE,
+                   help=f"app base URL (default {DEFAULT_BASE}; "
+                        "http://localhost:6800 for local runs)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("magazine", help="upsert the magazine block")
+    sp.add_argument("issue_json")
+    sp.set_defaults(fn=cmd_magazine)
+
+    sp = sub.add_parser("issue", help="upsert the issue block, store issue_id")
+    sp.add_argument("issue_json")
+    sp.set_defaults(fn=cmd_issue)
+
+    sp = sub.add_parser("pdf", help="chunked source-PDF upload")
+    sp.add_argument("issue_json")
+    sp.add_argument("pdf")
+    sp.set_defaults(fn=cmd_pdf)
+
+    sp = sub.add_parser("extracts", help="ingest extract JSONL files in batches")
+    sp.add_argument("issue_json")
+    sp.add_argument("jsonl", nargs="+")
+    sp.set_defaults(fn=cmd_extracts)
+
+    sp = sub.add_parser("status", help="render/crop progress")
+    sp.add_argument("issue_json")
+    sp.add_argument("--wait", action="store_true",
+                    help=f"poll every {POLL_SECONDS}s until pages and crops are done")
+    sp.set_defaults(fn=cmd_status)
+
+    sp = sub.add_parser("reset", help="delete status='auto' extracts (confirmed)")
+    sp.add_argument("issue_json")
+    sp.set_defaults(fn=cmd_reset)
+
+    args = p.parse_args()
+    args.base = args.base.rstrip("/")
+    tok = moderation_token()
+    try:
+        args.fn(args, tok)
+    except Fail as e:
+        die(str(e))
+    except KeyboardInterrupt:
+        die("interrupted", 130)
+
+if __name__ == "__main__":
+    main()

--- a/skills/magazine-ingest/scripts/render.py
+++ b/skills/magazine-ingest/scripts/render.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Render magazine PDF pages to analysis JPEGs plus gridded copies. See SKILL.md.
+
+  render.py <pdf> <workdir> [--dpi-target 1600] [--grid-only] [--pages A-B]
+
+Writes <workdir>/pages/p-<n>.jpg (n = 1-based pdf index, long edge ~1600px)
+and <workdir>/grid/p-<n>.jpg (the same render with a semi-transparent 10x10
+grid and 0.1..0.9 coordinate labels for reading normalized bboxes).
+
+Renderer: pdftoppm (poppler) when available, else Ghostscript — resolved from
+$GHOSTSCRIPT_BIN, then `gs`, then /opt/homebrew/opt/ghostscript/bin/gs; each
+candidate's -h banner must actually say Ghostscript (on macOS a bare `gs` is
+often git-spice).
+
+Idempotent: pages already in pages/ are not re-rendered and grids already in
+grid/ are not redrawn (--grid-only forces grid redraw from existing pages).
+
+Run under `uv run --no-project --with pillow python3 render.py ...`; plain
+python3 works too when Pillow is installed.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:  # error at use time, so --help works anywhere
+    Image = None
+
+GS_FALLBACK = "/opt/homebrew/opt/ghostscript/bin/gs"
+GS_RENDER_DPI = 200  # then downscaled to the long-edge target with Pillow
+JPEG_QUALITY = 88
+
+def note(msg):
+    print(msg, file=sys.stderr)
+
+def die(msg, code=1):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+def need_pillow():
+    if Image is None:
+        die("Pillow is required: run under `uv run --no-project --with pillow python3 ...`")
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+# ── renderer resolution ──────────────────────────────────────────────────────
+
+def find_pdftoppm():
+    return shutil.which("pdftoppm")
+
+def is_ghostscript(binary):
+    """The -h banner of real Ghostscript names it; git-spice's does not."""
+    try:
+        r = run([binary, "-h"], timeout=15)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return "ghostscript" in (r.stdout + r.stderr).lower()
+
+def find_ghostscript():
+    env = os.environ.get("GHOSTSCRIPT_BIN", "").strip()
+    candidates = [env] if env else []
+    candidates += ["gs", GS_FALLBACK]
+    for c in candidates:
+        binary = c if os.path.sep in c else shutil.which(c)
+        if binary and is_ghostscript(binary):
+            return binary
+        if c == env:
+            note(f"warning: GHOSTSCRIPT_BIN={env!r} is not Ghostscript; trying fallbacks")
+    return None
+
+# ── page count ───────────────────────────────────────────────────────────────
+
+def ps_string(path):
+    return "(" + re.sub(r"([\\()])", r"\\\1", path) + ")"
+
+def page_count(pdf, gs):
+    pdfinfo = shutil.which("pdfinfo")
+    if pdfinfo:
+        r = run([pdfinfo, pdf], timeout=120)
+        m = re.search(r"^Pages:\s+(\d+)", r.stdout, re.M)
+        if m:
+            return int(m.group(1))
+    if gs:
+        script = f"{ps_string(pdf)} (r) file runpdfbegin pdfpagecount = quit"
+        for safety in ([f"--permit-file-read={pdf}"], ["-dNOSAFER"]):
+            r = run([gs, "-q", "-dNODISPLAY", *safety, "-c", script], timeout=300)
+            m = re.search(r"^\s*(\d+)\s*$", r.stdout, re.M)
+            if r.returncode == 0 and m:
+                return int(m.group(1))
+    return None
+
+# ── rendering ────────────────────────────────────────────────────────────────
+
+def contiguous_runs(pages):
+    runs, start, prev = [], None, None
+    for n in sorted(pages):
+        if start is None:
+            start = prev = n
+        elif n == prev + 1:
+            prev = n
+        else:
+            runs.append((start, prev))
+            start = prev = n
+    if start is not None:
+        runs.append((start, prev))
+    return runs
+
+def collect_rendered(tmp, pages_dir, wanted):
+    """Move tmp/page-<n>.jpg (renderer numbering) into pages/p-<n>.jpg."""
+    got = []
+    for name in sorted(os.listdir(tmp)):
+        m = re.search(r"(\d+)\.jpe?g$", name)
+        if not m:
+            continue
+        n = int(m.group(1))
+        if n not in wanted:
+            note(f"warning: unexpected render {name}; ignoring")
+            continue
+        os.replace(os.path.join(tmp, name), os.path.join(pages_dir, f"p-{n}.jpg"))
+        got.append(n)
+    return got
+
+def render_pdftoppm(binary, pdf, pages, pages_dir, target):
+    for first, last in contiguous_runs(pages):
+        note(f"pdftoppm: pages {first}-{last}")
+        tmp = os.path.join(pages_dir, ".tmp-render")
+        shutil.rmtree(tmp, ignore_errors=True)
+        os.makedirs(tmp)
+        base = [binary, "-f", str(first), "-l", str(last), "-jpeg",
+                "-scale-to", str(target), pdf, os.path.join(tmp, "page")]
+        r = run(base[:7] + ["-jpegopt", f"quality={JPEG_QUALITY}"] + base[7:], timeout=3600)
+        if r.returncode:  # older poppler without -jpegopt
+            r = run(base, timeout=3600)
+        if r.returncode:
+            die(f"pdftoppm failed on pages {first}-{last}: {r.stderr.strip()[:500]}")
+        got = collect_rendered(tmp, pages_dir, set(range(first, last + 1)))
+        shutil.rmtree(tmp, ignore_errors=True)
+        missing = set(range(first, last + 1)) - set(got)
+        if missing:
+            die(f"pdftoppm produced no output for pages {sorted(missing)}")
+
+def render_ghostscript(binary, pdf, pages, pages_dir, target):
+    need_pillow()  # gs renders at fixed dpi; Pillow normalizes the long edge
+    for first, last in contiguous_runs(pages):
+        note(f"ghostscript: pages {first}-{last}")
+        tmp = os.path.join(pages_dir, ".tmp-render")
+        shutil.rmtree(tmp, ignore_errors=True)
+        os.makedirs(tmp)
+        r = run([binary, "-dBATCH", "-dNOPAUSE", "-dQUIET", "-dNOSAFER",
+                 "-sDEVICE=jpeg", f"-dJPEGQ={JPEG_QUALITY}", f"-r{GS_RENDER_DPI}",
+                 "-dTextAlphaBits=4", "-dGraphicsAlphaBits=4",
+                 f"-dFirstPage={first}", f"-dLastPage={last}",
+                 f"-sOutputFile={os.path.join(tmp, 'page-%d.jpg')}", pdf], timeout=3600)
+        if r.returncode:
+            die(f"ghostscript failed on pages {first}-{last}: {r.stderr.strip()[:500]}")
+        # gs numbers output from 1 within the run; rename to absolute indices.
+        for name in sorted(os.listdir(tmp)):
+            m = re.fullmatch(r"page-(\d+)\.jpg", name)
+            if not m:
+                continue
+            n = first + int(m.group(1)) - 1
+            if n > last:
+                continue
+            src = os.path.join(tmp, name)
+            with Image.open(src) as im:
+                long_edge = max(im.size)
+                if long_edge > target:
+                    scale = target / long_edge
+                    im = im.resize((max(1, round(im.width * scale)),
+                                    max(1, round(im.height * scale))), Image.LANCZOS)
+                im.convert("RGB").save(os.path.join(pages_dir, f"p-{n}.jpg"),
+                                       quality=JPEG_QUALITY)
+            os.remove(src)
+        shutil.rmtree(tmp, ignore_errors=True)
+        missing = [n for n in range(first, last + 1)
+                   if not os.path.exists(os.path.join(pages_dir, f"p-{n}.jpg"))]
+        if missing:
+            die(f"ghostscript produced no output for pages {missing}")
+
+# ── grid overlay ─────────────────────────────────────────────────────────────
+
+def grid_font(size):
+    try:
+        return ImageFont.load_default(size=size)  # Pillow >= 10.1
+    except TypeError:
+        return ImageFont.load_default()
+
+def draw_grid(src, dst):
+    need_pillow()
+    with Image.open(src) as im:
+        base = im.convert("RGBA")
+    w, h = base.size
+    overlay = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+    d = ImageDraw.Draw(overlay)
+    line = (255, 0, 255, 110)
+    width = max(1, round(min(w, h) / 800))
+    font = grid_font(max(14, round(min(w, h) / 70)))
+    for i in range(1, 10):
+        f = i / 10
+        x, y = round(f * w), round(f * h)
+        d.line([(x, 0), (x, h)], fill=line, width=width)
+        d.line([(0, y), (w, y)], fill=line, width=width)
+        label = f"0.{i}"
+        kw = dict(fill=(200, 0, 200, 255), stroke_width=2,
+                  stroke_fill=(255, 255, 255, 255), font=font)
+        d.text((x + 3, 2), label, **kw)          # top edge: x labels
+        d.text((3, y + 2), label, **kw)          # left edge: y labels
+    out = Image.alpha_composite(base, overlay).convert("RGB")
+    out.save(dst, quality=80)
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+def parse_pages(spec, total):
+    if not spec:
+        if total is None:
+            die("could not determine the page count; pass --pages A-B")
+        return list(range(1, total + 1))
+    m = re.fullmatch(r"(\d+)(?:-(\d+))?", spec)
+    if not m:
+        die("--pages must be N or A-B (1-based, inclusive)")
+    a = int(m.group(1))
+    b = int(m.group(2)) if m.group(2) else a
+    if a < 1 or b < a:
+        die("--pages range is empty")
+    if total is not None and b > total:
+        die(f"--pages {spec} exceeds the {total}-page document")
+    return list(range(a, b + 1))
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("pdf", help="source magazine PDF")
+    p.add_argument("workdir", help="per-issue work dir (pages/ and grid/ created inside)")
+    p.add_argument("--dpi-target", type=int, default=1600, metavar="PX",
+                   help="long-edge pixel target for the renders (default 1600)")
+    p.add_argument("--grid-only", action="store_true",
+                   help="skip rendering; (re)draw grids from existing pages/*.jpg")
+    p.add_argument("--pages", metavar="A-B", help="only this 1-based page range")
+    args = p.parse_args()
+
+    if not os.path.isfile(args.pdf):
+        die(f"no such file: {args.pdf}")
+    pages_dir = os.path.join(args.workdir, "pages")
+    grid_dir = os.path.join(args.workdir, "grid")
+    os.makedirs(pages_dir, exist_ok=True)
+    os.makedirs(grid_dir, exist_ok=True)
+
+    pdftoppm = find_pdftoppm()
+    gs = None if pdftoppm else find_ghostscript()
+    if not args.grid_only and not pdftoppm and not gs:
+        die("no PDF renderer: install poppler (pdftoppm) or Ghostscript "
+            "(set GHOSTSCRIPT_BIN if `gs` resolves to something else)")
+
+    if args.grid_only:
+        if args.pages:
+            pages = parse_pages(args.pages, None)
+        else:
+            pages = sorted(int(m.group(1)) for f in os.listdir(pages_dir)
+                           if (m := re.fullmatch(r"p-(\d+)\.jpg", f)))
+            if not pages:
+                die(f"no rendered pages in {pages_dir}; run without --grid-only first")
+    else:
+        total = page_count(args.pdf, gs or find_ghostscript())
+        pages = parse_pages(args.pages, total)
+
+    if not args.grid_only:
+        todo = [n for n in pages
+                if not os.path.exists(os.path.join(pages_dir, f"p-{n}.jpg"))]
+        if not todo:
+            note("all requested pages already rendered")
+        elif pdftoppm:
+            render_pdftoppm(pdftoppm, args.pdf, todo, pages_dir, args.dpi_target)
+        else:
+            render_ghostscript(gs, args.pdf, todo, pages_dir, args.dpi_target)
+
+    drawn = 0
+    for n in pages:
+        src = os.path.join(pages_dir, f"p-{n}.jpg")
+        dst = os.path.join(grid_dir, f"p-{n}.jpg")
+        if not os.path.exists(src):
+            note(f"warning: no render for page {n}; skipping its grid")
+            continue
+        if os.path.exists(dst) and not args.grid_only:
+            continue
+        draw_grid(src, dst)
+        drawn += 1
+
+    done = sum(1 for n in pages if os.path.exists(os.path.join(pages_dir, f"p-{n}.jpg")))
+    print(f"pages: {done}/{len(pages)} rendered in {pages_dir}")
+    print(f"grid: {drawn} drawn this run in {grid_dir}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Releases the magazine ingestion tooling under skills/: the operating manual (SKILL.md) and the three scripts (render.py, crop.py, post.py) that drive the render, identity, sweep, QA, and upload passes against the moderator API.

The copy is sanitized for the public repo: token resolution is env var or token file only, with no internal hosts or machine paths. This commit raced the #136 merge and missed it, so it rides its own branch off latest main.