### PR TITLE
Magazine search filters and tag browse pages

### DIFF
--- a/hp-web/src/app/magazines/MagSearch.tsx
+++ b/hp-web/src/app/magazines/MagSearch.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 // Extract search box for /magazines: full text across every issue, with
-// magazine/kind filters. Quote the query ("exact phrase") for exact substring
-// matching (also the way to search Japanese text). URL-driven like the
-// builds browser: state lives in ?q=&magazine=&kind=, so results are
-// shareable and survive reloads.
+// magazine/kind/system/language/date filters. Quote the query ("exact
+// phrase") for exact substring matching (also the way to search Japanese
+// text). URL-driven like the builds browser: state lives in
+// ?q=&magazine=&kind=&system=&language=&from=&to=, so results are shareable
+// and survive reloads.
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -44,12 +45,35 @@ function Snippet({ text }: { text: string }) {
   );
 }
 
-export default function MagSearch({ magazines }: { magazines: { slug: string; title: string }[] }) {
+/** "1991" from a stored YYYY-MM-DD bound, for the year inputs. */
+function yearOf(date: string): string {
+  return /^\d{4}/.test(date) ? date.slice(0, 4) : "";
+}
+
+const selectClass =
+  "rounded-md border border-neutral-300 bg-transparent px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-900";
+
+export default function MagSearch({
+  magazines,
+  systems,
+  languages,
+}: {
+  magazines: { slug: string; title: string }[];
+  systems: string[];
+  languages: string[];
+}) {
   const router = useRouter();
   const params = useSearchParams();
   const [q, setQ] = useState(params.get("q") ?? "");
   const [magazine, setMagazine] = useState(params.get("magazine") ?? "");
   const [kind, setKind] = useState(params.get("kind") ?? "");
+  const [system, setSystem] = useState(params.get("system") ?? "");
+  const [language, setLanguage] = useState(params.get("language") ?? "");
+  // The API filters on full cover dates; the UI thinks in years. A deep link
+  // with finer-than-year bounds still filters exactly, it just displays as
+  // the year.
+  const [fromYear, setFromYear] = useState(yearOf(params.get("from") ?? ""));
+  const [toYear, setToYear] = useState(yearOf(params.get("to") ?? ""));
   // Results are keyed by the URL query they answered. Everything else is
   // derived: no fetch in flight has landed for the current URL -> busy; the
   // URL has no query -> nothing renders. No state-syncing effects.
@@ -59,7 +83,11 @@ export default function MagSearch({ magazines }: { magazines: { slug: string; ti
   const urlQ = params.get("q") ?? "";
   const urlMagazine = params.get("magazine") ?? "";
   const urlKind = params.get("kind") ?? "";
-  const urlKey = `${urlQ}\0${urlMagazine}\0${urlKind}`;
+  const urlSystem = params.get("system") ?? "";
+  const urlLanguage = params.get("language") ?? "";
+  const urlFrom = params.get("from") ?? "";
+  const urlTo = params.get("to") ?? "";
+  const urlKey = [urlQ, urlMagazine, urlKind, urlSystem, urlLanguage, urlFrom, urlTo].join("\0");
 
   useEffect(() => {
     if (!urlQ.trim()) return;
@@ -67,6 +95,10 @@ export default function MagSearch({ magazines }: { magazines: { slug: string; ti
     const query = new URLSearchParams({ q: urlQ });
     if (urlMagazine) query.set("magazine", urlMagazine);
     if (urlKind) query.set("kind", urlKind);
+    if (urlSystem) query.set("system", urlSystem);
+    if (urlLanguage) query.set("language", urlLanguage);
+    if (urlFrom) query.set("from", urlFrom);
+    if (urlTo) query.set("to", urlTo);
     fetch(`/api/mag/search?${query}`, { cache: "no-store" })
       .then((r) => r.json())
       .then((data) => {
@@ -75,7 +107,7 @@ export default function MagSearch({ magazines }: { magazines: { slug: string; ti
       .catch(() => {
         if (seq.current === mine) setFetched({ key: urlKey, hits: [] });
       });
-  }, [urlQ, urlMagazine, urlKind, urlKey]);
+  }, [urlQ, urlMagazine, urlKind, urlSystem, urlLanguage, urlFrom, urlTo, urlKey]);
 
   const hits = urlQ.trim() && fetched?.key === urlKey ? fetched.hits : null;
   const busy = !!urlQ.trim() && hits === null;
@@ -86,6 +118,10 @@ export default function MagSearch({ magazines }: { magazines: { slug: string; ti
     if (q.trim()) next.set("q", q.trim());
     if (magazine) next.set("magazine", magazine);
     if (kind) next.set("kind", kind);
+    if (system) next.set("system", system);
+    if (language) next.set("language", language);
+    if (/^\d{4}$/.test(fromYear)) next.set("from", `${fromYear}-01-01`);
+    if (/^\d{4}$/.test(toYear)) next.set("to", `${toYear}-12-31`);
     router.replace(`/magazines${next.size ? `?${next}` : ""}`, { scroll: false });
   }
 
@@ -102,7 +138,7 @@ export default function MagSearch({ magazines }: { magazines: { slug: string; ti
         <select
           value={magazine}
           onChange={(e) => setMagazine(e.target.value)}
-          className="rounded-md border border-neutral-300 bg-transparent px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+          className={selectClass}
           aria-label="Magazine filter"
         >
           <option value="">all magazines</option>
@@ -113,7 +149,7 @@ export default function MagSearch({ magazines }: { magazines: { slug: string; ti
         <select
           value={kind}
           onChange={(e) => setKind(e.target.value)}
-          className="rounded-md border border-neutral-300 bg-transparent px-2 py-1.5 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+          className={selectClass}
           aria-label="Kind filter"
         >
           <option value="">all kinds</option>
@@ -121,6 +157,44 @@ export default function MagSearch({ magazines }: { magazines: { slug: string; ti
             <option key={k} value={k}>{k.replace("_", " ")}</option>
           ))}
         </select>
+        <select
+          value={system}
+          onChange={(e) => setSystem(e.target.value)}
+          className={selectClass}
+          aria-label="System filter"
+        >
+          <option value="">all systems</option>
+          {systems.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+        <select
+          value={language}
+          onChange={(e) => setLanguage(e.target.value)}
+          className={selectClass}
+          aria-label="Language filter"
+        >
+          <option value="">any language</option>
+          {languages.map((l) => (
+            <option key={l} value={l}>{l}</option>
+          ))}
+        </select>
+        <input
+          value={fromYear}
+          onChange={(e) => setFromYear(e.target.value.replace(/\D/g, "").slice(0, 4))}
+          placeholder="from yyyy"
+          inputMode="numeric"
+          className="w-24 rounded-md border border-neutral-300 bg-transparent px-2 py-1.5 text-sm outline-none focus:border-neutral-500 dark:border-neutral-700"
+          aria-label="From year"
+        />
+        <input
+          value={toYear}
+          onChange={(e) => setToYear(e.target.value.replace(/\D/g, "").slice(0, 4))}
+          placeholder="to yyyy"
+          inputMode="numeric"
+          className="w-24 rounded-md border border-neutral-300 bg-transparent px-2 py-1.5 text-sm outline-none focus:border-neutral-500 dark:border-neutral-700"
+          aria-label="To year"
+        />
         <button
           type="submit"
           className="rounded-md border border-neutral-300 px-3 py-1.5 text-sm hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"

--- a/hp-web/src/app/magazines/[slug]/[issue]/IssueBrowser.tsx
+++ b/hp-web/src/app/magazines/[slug]/[issue]/IssueBrowser.tsx
@@ -9,7 +9,7 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import ZoomPan from "../../../builds/[buildId]/ZoomPan";
-import { extractAnchor, magBlobUrl, magThumbUrl, personHref } from "@/lib/mag/hrefs";
+import { extractAnchor, magBlobUrl, magThumbUrl, personHref, tagHref } from "@/lib/mag/hrefs";
 import ModTools from "./ModTools";
 
 export interface IssuePageItem {
@@ -569,13 +569,14 @@ export default function IssueBrowser({
                         <span key={s} className="rounded bg-neutral-100 px-1.5 py-0.5 dark:bg-neutral-800">{s}</span>
                       ))}
                       {e.tags.map((t) => (
-                        <span
+                        <Link
                           key={t.slug}
-                          className="rounded bg-neutral-100 px-1.5 py-0.5 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400"
+                          href={tagHref(t.slug)}
+                          className="rounded bg-neutral-100 px-1.5 py-0.5 text-neutral-600 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:bg-neutral-700"
                           title={t.kind}
                         >
                           {t.name}
-                        </span>
+                        </Link>
                       ))}
                     </div>
                   )}

--- a/hp-web/src/app/magazines/page.tsx
+++ b/hp-web/src/app/magazines/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { Suspense } from "react";
 import { getPool } from "@/lib/db";
 import { magazineHref, magThumbUrl } from "@/lib/mag/hrefs";
-import { listMagazines } from "@/lib/mag/queries";
+import { listMagazines, listSearchFacets } from "@/lib/mag/queries";
 import MagSearch from "./MagSearch";
 
 export const runtime = "nodejs";
@@ -17,11 +17,15 @@ export const metadata: Metadata = {
 // /magazines — every indexed magazine with its first cover and issue count,
 // plus full-text search across all extracts.
 export default async function MagazinesPage() {
-  const magazines = await listMagazines(getPool());
+  const pool = getPool();
+  const [magazines, facets] = await Promise.all([listMagazines(pool), listSearchFacets(pool)]);
 
   return (
     <main className="mx-auto max-w-4xl px-6 py-12">
-      <Link href="/" className="text-sm text-neutral-500 hover:underline">&larr; Search</Link>
+      <div className="flex items-baseline justify-between">
+        <Link href="/" className="text-sm text-neutral-500 hover:underline">&larr; Search</Link>
+        <Link href="/magazines/tags" className="text-sm text-neutral-500 hover:underline">Tags &rarr;</Link>
+      </div>
       <h1 className="mt-3 text-2xl font-semibold tracking-tight">Magazines</h1>
       <p className="mt-1 text-sm text-neutral-500">
         Page-by-page index of gaming print media: every review, preview, interview, ad, chart, and tip,
@@ -29,7 +33,11 @@ export default async function MagazinesPage() {
       </p>
 
       <Suspense>
-        <MagSearch magazines={magazines.map((m) => ({ slug: m.slug, title: m.title }))} />
+        <MagSearch
+          magazines={magazines.map((m) => ({ slug: m.slug, title: m.title }))}
+          systems={facets.systems}
+          languages={facets.languages}
+        />
       </Suspense>
 
       {magazines.length === 0 ? (

--- a/hp-web/src/app/magazines/tags/[slug]/page.tsx
+++ b/hp-web/src/app/magazines/tags/[slug]/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getPool } from "@/lib/db";
+import { extractAnchor, issueHref, magThumbUrl } from "@/lib/mag/hrefs";
+import { getTagBySlug, getTagCoverage, type CoverageItem } from "@/lib/mag/queries";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: Params): Promise<Metadata> {
+  const { slug } = await params;
+  const tag = await getTagBySlug(getPool(), decodeURIComponent(slug));
+  if (!tag) return {};
+  return { title: tag.name, description: `Magazine content tagged ${tag.name}` };
+}
+
+function CoverageList({ items }: { items: CoverageItem[] }) {
+  return (
+    <ul className="mt-2 space-y-2">
+      {items.map((h) => (
+        <li key={h.id}>
+          <Link
+            href={`${issueHref(h.magazine_slug, h.issue_slug)}#${extractAnchor(h.id)}`}
+            className="flex gap-3 rounded-md border border-neutral-200 p-2 hover:border-neutral-400 dark:border-neutral-800 dark:hover:border-neutral-600"
+          >
+            {h.crop_sha256 && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={magThumbUrl(h.crop_sha256, 500)}
+                alt=""
+                className="h-16 w-16 shrink-0 rounded-sm bg-neutral-100 object-cover dark:bg-neutral-800"
+                loading="lazy"
+              />
+            )}
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium">{h.title || h.section || h.kind.replace("_", " ")}</div>
+              <div className="text-xs text-neutral-500">
+                {h.magazine_title} · {h.issue_label}
+                {h.cover_date ? ` · ${h.cover_date.slice(0, 7)}` : ""} ·{" "}
+                <span className="rounded bg-neutral-100 px-1 py-0.5 dark:bg-neutral-800">{h.kind.replace("_", " ")}</span>
+              </div>
+              {h.summary_en && (
+                <div className="mt-0.5 line-clamp-2 text-xs text-neutral-600 dark:text-neutral-400">{h.summary_en}</div>
+              )}
+            </div>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// /magazines/tags/<slug> — every extract carrying one tag, in cover-date
+// order across all magazines.
+export default async function TagPage({ params }: Params) {
+  const { slug } = await params;
+  const pool = getPool();
+  const tag = await getTagBySlug(pool, decodeURIComponent(slug));
+  if (!tag) notFound();
+  const coverage = await getTagCoverage(pool, tag.slug);
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <Link href="/magazines/tags" className="text-sm text-neutral-500 hover:underline">&larr; Tags</Link>
+      <h1 className="mt-3 text-2xl font-semibold tracking-tight">{tag.name}</h1>
+      <div className="mt-2 flex flex-wrap gap-2 text-xs">
+        <span className="rounded bg-neutral-100 px-1.5 py-0.5 font-medium text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
+          {tag.kind}
+        </span>
+        <span className="text-neutral-500">
+          {tag.extract_count} {tag.extract_count === 1 ? "extract" : "extracts"}
+        </span>
+      </div>
+
+      {coverage.length === 0 ? (
+        <p className="mt-10 text-sm text-neutral-500">Nothing indexed yet.</p>
+      ) : (
+        <section className="mt-8">
+          <CoverageList items={coverage} />
+        </section>
+      )}
+    </main>
+  );
+}

--- a/hp-web/src/app/magazines/tags/page.tsx
+++ b/hp-web/src/app/magazines/tags/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getPool } from "@/lib/db";
+import { tagHref } from "@/lib/mag/hrefs";
+import { listTags } from "@/lib/mag/queries";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Magazine tags",
+  description: "Companies, events, hardware, series, and topics across the magazine index.",
+};
+
+const KIND_GROUPS: { kind: string; title: string }[] = [
+  { kind: "company", title: "Companies" },
+  { kind: "event", title: "Events" },
+  { kind: "hardware", title: "Hardware" },
+  { kind: "series", title: "Series" },
+  { kind: "topic", title: "Topics" },
+];
+
+// /magazines/tags — every tag in the index, grouped by kind, with extract
+// counts. Tags with nothing attached yet are left out.
+export default async function TagsPage() {
+  const tags = (await listTags(getPool())).filter((t) => t.extract_count > 0);
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <Link href="/magazines" className="text-sm text-neutral-500 hover:underline">&larr; Magazines</Link>
+      <h1 className="mt-3 text-2xl font-semibold tracking-tight">Tags</h1>
+      <p className="mt-1 text-sm text-neutral-500">
+        Everything indexed that is not a game, person, or system: companies, events, hardware, series, topics.
+      </p>
+
+      {tags.length === 0 ? (
+        <p className="mt-10 text-sm text-neutral-500">Nothing tagged yet.</p>
+      ) : (
+        KIND_GROUPS.map((g) => {
+          const items = tags.filter((t) => t.kind === g.kind);
+          if (items.length === 0) return null;
+          return (
+            <section key={g.kind} className="mt-8">
+              <h2 className="text-lg font-medium">
+                {g.title} <span className="text-sm font-normal text-neutral-400">{items.length}</span>
+              </h2>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {items.map((t) => (
+                  <Link
+                    key={t.slug}
+                    href={tagHref(t.slug)}
+                    className="rounded bg-neutral-100 px-2 py-1 text-sm text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700"
+                  >
+                    {t.name} <span className="text-xs text-neutral-400">{t.extract_count}</span>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          );
+        })
+      )}
+    </main>
+  );
+}

--- a/hp-web/src/lib/mag/hrefs.ts
+++ b/hp-web/src/lib/mag/hrefs.ts
@@ -27,3 +27,7 @@ export function magThumbUrl(sha256: string, w: 500 | 1000 = 500): string {
 export function personHref(slug: string): string {
   return `/people/${slug}`;
 }
+
+export function tagHref(slug: string): string {
+  return `/magazines/tags/${slug}`;
+}

--- a/hp-web/src/lib/mag/queries.ts
+++ b/hp-web/src/lib/mag/queries.ts
@@ -802,6 +802,76 @@ export async function getPersonCoverage(pool: Pool, personId: number): Promise<C
   return r.rows as CoverageItem[];
 }
 
+export interface TagRow {
+  slug: string;
+  kind: string;
+  name: string;
+  extract_count: number;
+}
+
+export async function listTags(pool: Pool): Promise<TagRow[]> {
+  const r = await pool.query(
+    `SELECT t.slug, t.kind, t.name, COUNT(e.id)::int AS extract_count
+     FROM mag_tag t
+     LEFT JOIN extract_tag et ON et.tag_id=t.id
+     LEFT JOIN magazine_extract e ON e.id=et.extract_id AND e.status <> 'rejected'
+     GROUP BY t.id
+     ORDER BY extract_count DESC, t.name ASC`
+  );
+  return r.rows as TagRow[];
+}
+
+export async function getTagBySlug(pool: Pool, slug: string): Promise<TagRow | null> {
+  const r = await pool.query(
+    `SELECT t.slug, t.kind, t.name, COUNT(e.id)::int AS extract_count
+     FROM mag_tag t
+     LEFT JOIN extract_tag et ON et.tag_id=t.id
+     LEFT JOIN magazine_extract e ON e.id=et.extract_id AND e.status <> 'rejected'
+     WHERE t.slug=$1
+     GROUP BY t.id`,
+    [slug]
+  );
+  return (r.rows[0] as TagRow | undefined) ?? null;
+}
+
+export async function getTagCoverage(pool: Pool, tagSlug: string): Promise<CoverageItem[]> {
+  const r = await pool.query(
+    `SELECT ${COVERAGE_COLS}, 'subject' AS role, NULL::text AS title_printed
+     FROM extract_tag et
+     JOIN mag_tag t ON t.id=et.tag_id
+     JOIN magazine_extract e ON e.id=et.extract_id AND e.status <> 'rejected'
+     JOIN magazine_issue i ON i.id=e.issue_id
+     JOIN magazines m ON m.id=i.magazine_id
+     WHERE t.slug=$1
+     ORDER BY i.cover_date ASC NULLS LAST, e.seq`,
+    [tagSlug]
+  );
+  return r.rows as CoverageItem[];
+}
+
+/** Filter options actually present in the index, for the search UI. */
+export interface MagSearchFacets {
+  systems: string[];
+  languages: string[];
+}
+
+export async function listSearchFacets(pool: Pool): Promise<MagSearchFacets> {
+  const [sys, langs] = await Promise.all([
+    pool.query(
+      `SELECT DISTINCT es.system FROM extract_system es
+       JOIN magazine_extract e ON e.id=es.extract_id AND e.status <> 'rejected'
+       ORDER BY es.system`
+    ),
+    pool.query(
+      `SELECT DISTINCT language FROM magazine_extract WHERE status <> 'rejected' ORDER BY language`
+    ),
+  ]);
+  return {
+    systems: (sys.rows as { system: string }[]).map((r) => r.system),
+    languages: (langs.rows as { language: string }[]).map((r) => r.language),
+  };
+}
+
 export interface MagSearchFilters {
   magazine?: string;
   kind?: string;

--- a/skills/magazine-ingest/SKILL.md
+++ b/skills/magazine-ingest/SKILL.md
@@ -320,6 +320,12 @@ orchestrator merging and sanity-checking the checkpoints. The identity pass
 work-dir path, its page range, the wire format, and the policy sections
 above.
 
+The work dir is shared, so each subagent must keep its helper scripts and QA
+renders in a private subdirectory named for its batch (for example
+`qa-004/`). Two agents writing `zoom.py` at the work-dir root overwrite each
+other mid-run; only the `pages-NNN.jsonl` checkpoints (already unique per
+batch) belong at the root.
+
 ## Auth and target
 
 `post.py` resolves the moderation token from the `PRISM_MODERATION_TOKEN`


### PR DESCRIPTION
The magazine search now exposes the system, language, and cover date filters the API already supported, with options drawn from what is actually indexed. Filters live in the URL like the rest of the search, so filtered results stay shareable.

Tags get browse pages: /magazines/tags groups every used tag by kind with counts, each tag links to a coverage page of its extracts, and tag chips on issue pages link there. Also folds in a small ingest skill doc note about parallel subagents sharing a work dir.