### PR TITLE
Survive adapter crashes on bad archives

### DIFF
--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -223,6 +223,35 @@ pub fn run_extract(
     Ok(parsed.assets)
 }
 
+/// Describe why an adapter run failed. The adapter leans on C libraries
+/// (libarchive and friends) that `abort()` rather than raise on input they
+/// refuse, and a native death reaches us as a 128+signal *exit code* once the
+/// `uv`/launcher wrapper relays it — which on its own reads as an opaque
+/// "exit status: 134". Name the signal so a crash is recognizable as one.
+fn describe_exit(status: std::process::ExitStatus) -> String {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        let signal = status.signal().or_else(|| match status.code() {
+            Some(code) if (129..=192).contains(&code) => Some(code - 128),
+            _ => None,
+        });
+        if let Some(sig) = signal {
+            return match sig {
+                2 => "crashed with SIGINT".into(),
+                4 => "crashed with SIGILL".into(),
+                6 => "crashed with SIGABRT (native abort)".into(),
+                8 => "crashed with SIGFPE".into(),
+                9 => "killed with SIGKILL (out of memory?)".into(),
+                11 => "crashed with SIGSEGV (native fault)".into(),
+                15 => "killed with SIGTERM".into(),
+                other => format!("killed by signal {other}"),
+            };
+        }
+    }
+    format!("exited with {status}")
+}
+
 /// Drive one adapter subprocess: stream stderr progress to `observer`, poll for
 /// cancellation, and parse the single JSON document on stdout as `T`.
 fn run_json<T: serde::de::DeserializeOwned>(
@@ -310,7 +339,8 @@ fn run_json<T: serde::de::DeserializeOwned>(
 
     if !status.success() {
         return Err(Error::Adapter(format!(
-            "adapter exited with {status}\n{}",
+            "adapter {}\n{}",
+            describe_exit(status),
             diag.trim()
         )));
     }

--- a/ps2exe-adapter/tests/test_archives.py
+++ b/ps2exe-adapter/tests/test_archives.py
@@ -6,10 +6,14 @@ in-memory zip fixtures served through a minimal fake volume reader.
 
 import hashlib
 import io
+import os
+import pathlib
+import subprocess
+import sys
 import zipfile
 
 from prism_adapter import viewable
-from prism_adapter.cli import _extract_assets, _hash_files
+from prism_adapter.cli import _PS2EXE_DIR, _extract_assets, _hash_files
 from prism_adapter.progress import ProgressManager
 
 
@@ -112,3 +116,68 @@ def test_member_assets_are_extracted(tmp_path):
     blob = (tmp_path / png["sha256"][:2] / png["sha256"]).read_bytes()
     assert blob == PNG
     assert assets["/DATA/PROTO.ZIP/notes.txt"]["kind"] == "text"
+
+
+# Runs in a subprocess: the regression is process death (SIGSEGV/SIGABRT out of
+# libarchive), which no `except` in-process can catch or report.
+_TEARDOWN_SRC = '''
+import io, os, sys, zipfile
+sys.path.insert(0, os.environ["PS2EXE_DIR"])
+sys.path.insert(0, os.environ["ADAPTER_DIR"])
+
+import libarchive
+from prism_adapter.progress import ProgressManager
+from utils.archives import ArchiveWrapper
+
+buf = io.BytesIO()
+with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+    z.writestr("big.bin", b"A" * (1 << 20))
+    z.writestr("second.bin", b"B" * (1 << 20))
+src = io.BytesIO(buf.getvalue())
+src.name = "TEARDOWN.ZIP"
+
+wrapper = ArchiveWrapper(src, None, ProgressManager())
+wrapper.__enter__()
+entry = next(iter(wrapper))
+reader = entry.open()
+reader[0:16]  # partial: the rest of the member is still inside libarchive
+
+# An unlistable member archive tears the wrapper down with readers still open.
+wrapper.__exit__(None, None, None)
+
+# close() drains to EOF, and a further read asks for bytes outright. Both used
+# to walk into the freed handle; both must now stay in Python.
+reader.close()
+try:
+    reader._closed = False
+    reader[16:32]
+except libarchive.ArchiveError:
+    pass
+print("OK")
+'''
+
+
+def test_reader_outliving_its_archive_does_not_kill_the_process(tmp_path):
+    """A reader still open when its archive is torn down must never reach the
+    freed libarchive handle.
+
+    libarchive dies on a handle whose magic no longer matches -- abort() with
+    "PROGRAMMER ERROR ... invalid archive handle", or a plain segfault if the
+    freed struct got reused. Either way the whole analysis is lost, so one
+    unreadable member archive used to cost the entire build.
+    """
+    script = tmp_path / "teardown.py"
+    script.write_text(_TEARDOWN_SRC)
+    env = {
+        **os.environ,
+        "PS2EXE_DIR": str(_PS2EXE_DIR),
+        "ADAPTER_DIR": str(pathlib.Path(__file__).resolve().parents[1]),
+    }
+    proc = subprocess.run(
+        [sys.executable, str(script)], env=env, capture_output=True, text=True
+    )
+
+    assert proc.returncode == 0, (
+        f"adapter process died (returncode {proc.returncode})\n{proc.stderr}"
+    )
+    assert "OK" in proc.stdout


### PR DESCRIPTION
A 1999 PC backup killed the adapter with exit 134. One of its Windows 95 driver cabinets uses Quantum compression, and the cleanup after that failed listing read from an already freed libarchive handle, which aborts the process rather than raising, so a single unreadable file lost the whole 10,000 file build.

The engine fix is ps2exe PR 48, picked up here as a submodule bump plus a regression test that runs in a subprocess because the failure mode is process death. Adapter exit codes now name the signal, since uv relays a native crash as a plain 128 plus signal code. Needs ps2exe 48 merged first, then this pointer moved to the merged commit.