### PR TITLE
Add file extraction

### DIFF
--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -202,6 +202,12 @@ struct RawExtract {
     assets: Vec<RawAsset>,
 }
 
+#[derive(Debug, Deserialize)]
+struct RawFileExtract {
+    #[serde(default)]
+    files: u64,
+}
+
 /// Run the adapter's `analyze` on `path`, relaying progress to `observer`.
 pub fn run(
     cmd: &AdapterCommand,
@@ -221,6 +227,27 @@ pub fn run_extract(
 ) -> Result<Vec<RawAsset>> {
     let parsed: RawExtract = run_json(cmd, &["extract", "--path", path, "--out", out_dir], observer)?;
     Ok(parsed.assets)
+}
+
+/// Run the adapter's full-file extraction into `out_dir`. When `recursive` is
+/// true, readable compressed files are expanded in place as directories.
+pub fn run_extract_files(
+    cmd: &AdapterCommand,
+    path: &str,
+    out_dir: &str,
+    recursive: bool,
+    observer: Arc<dyn ProgressObserver>,
+) -> Result<u64> {
+    let parsed: RawFileExtract = if recursive {
+        run_json(
+            cmd,
+            &["extract-files", "--path", path, "--out", out_dir, "--recursive"],
+            observer,
+        )?
+    } else {
+        run_json(cmd, &["extract-files", "--path", path, "--out", out_dir], observer)?
+    };
+    Ok(parsed.files)
 }
 
 /// Describe a failed adapter run. A native crash (libarchive aborts on input it

--- a/crates/prism-core/src/lib.rs
+++ b/crates/prism-core/src/lib.rs
@@ -295,6 +295,19 @@ impl Analyzer {
         }
     }
 
+    /// Copy every file from the selected filesystem volume to `out_dir`.
+    /// Recursive mode expands supported compressed archives in place.
+    pub fn extract_files(
+        &self,
+        path: &str,
+        out_dir: &str,
+        recursive: bool,
+        observer: Arc<dyn ProgressObserver>,
+    ) -> Result<u64> {
+        std::fs::create_dir_all(out_dir)?;
+        adapter::run_extract_files(&self.adapter, path, out_dir, recursive, observer)
+    }
+
     /// Number of builds in the local library.
     pub fn library_size(&self) -> Result<u64> {
         self.db.count_builds()

--- a/crates/prism-ffi/src/lib.rs
+++ b/crates/prism-ffi/src/lib.rs
@@ -331,6 +331,21 @@ impl Engine {
         build_summary(&analysis, |sha| analyzer.asset_blob_path(sha))
     }
 
+    /// Copy all files from an image/container into `out_dir`. Recursive mode
+    /// also expands readable compressed archives at their logical paths.
+    pub fn extract_files(
+        &self,
+        path: String,
+        out_dir: String,
+        recursive: bool,
+        listener: Box<dyn ProgressListener>,
+        cancel: Option<Arc<CancelHandle>>,
+    ) -> Result<u64, PrismError> {
+        let observer = Arc::new(ListenerObserver { listener, cancel });
+        let analyzer = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        Ok(analyzer.extract_files(&path, &out_dir, recursive, observer)?)
+    }
+
     /// Number of builds in the local library.
     pub fn library_size(&self) -> Result<u64, PrismError> {
         Ok(self.inner.lock().unwrap_or_else(|e| e.into_inner()).library_size()?)

--- a/ps2exe-adapter/prism_adapter/cli.py
+++ b/ps2exe-adapter/prism_adapter/cli.py
@@ -15,6 +15,7 @@ import os
 import pathlib
 import re
 import sys
+import tempfile
 
 import blake3
 import numpy as np
@@ -940,6 +941,326 @@ def extract(path, out_dir):
     return {"assets": _process(path, basename, parent_dir, mods, manager, work)}
 
 
+def extract_files(path, out_dir, recursive=False):
+    """Copy every file from the selected volume to ``out_dir``.
+
+    In recursive mode, a readable compressed file becomes a directory at the
+    same path and its members are copied into it.  A member without its own date
+    inherits the enclosing archive's date; a top-level entry without one
+    inherits the volume (or source file) date.
+    """
+    mods = _import_ps2exe()
+    manager = ProgressManager()
+
+    path = os.path.normpath(path)
+    if os.path.isdir(path):
+        source_root = os.path.realpath(path)
+        output_root = os.path.realpath(out_dir)
+        try:
+            output_is_inside_source = os.path.commonpath([source_root, output_root]) == source_root
+        except ValueError:  # different Windows drives cannot overlap
+            output_is_inside_source = False
+        if output_is_inside_source:
+            raise SystemExit("the extraction folder cannot be inside the source folder")
+    basename = os.path.basename(path)
+    parent_dir = pathlib.Path(path).resolve().parent
+    source_date = _path_date(path)
+
+    def work(processor, reader, system):
+        inherited = _volume_date(reader) or source_date
+        budget = _ByteBudget(_archive_byte_budget()) if recursive else None
+        count = _extract_reader_files(
+            reader, out_dir, manager, mods, recursive, inherited, budget=budget
+        )
+        return {"files": count}
+
+    return _process(path, basename, parent_dir, mods, manager, work)
+
+
+def _path_date(path):
+    try:
+        return _dt.datetime.fromtimestamp(os.stat(path).st_mtime, tz=_dt.timezone.utc)
+    except (OSError, OverflowError, ValueError):
+        return None
+
+
+def _as_datetime(value):
+    if isinstance(value, _dt.datetime):
+        # Disc timestamps without an explicit zone are conventionally UTC in
+        # the existing readers. Treating them as host-local would shift dates
+        # when extraction runs outside UTC.
+        return value if value.tzinfo is not None else value.replace(tzinfo=_dt.timezone.utc)
+    if isinstance(value, (str, os.PathLike)):
+        return _path_date(value)
+    return None
+
+
+def _volume_date(reader):
+    """Best available volume timestamp, preferring modification over creation."""
+    try:
+        info = reader.get_pvd_info() or {}
+    except Exception:  # noqa: BLE001 — malformed volume metadata is non-fatal
+        return None
+    for key in ("volume_modification_date", "volume_creation_date", "volume_effective_date"):
+        if date := _as_datetime(info.get(key)):
+            return date
+    return None
+
+
+def _set_output_date(path, date):
+    date = _as_datetime(date)
+    if date is None:
+        return
+    try:
+        stamp = date.timestamp()
+        os.utime(path, (stamp, stamp))
+    except (OSError, OverflowError, ValueError):
+        # Some disc formats can encode dates outside the host filesystem's
+        # range.  The bytes are still useful, so leave the host default date.
+        pass
+
+
+def _relative_output_path(raw):
+    clean = _clean_path(str(raw).replace("\\", "/"))
+    parts = [part for part in clean.strip("/").split("/") if part]
+    if os.name == "nt":
+        # Disc/archive names can contain characters Windows cannot represent,
+        # and a colon-bearing first component could otherwise select a drive.
+        # Preserve every valid name exactly; substitute only unrepresentable
+        # characters and reserved DOS device names.
+        invalid = '<>:"\\|?*'
+        devices = {"CON", "PRN", "AUX", "NUL"} | {
+            f"{stem}{n}" for stem in ("COM", "LPT") for n in range(1, 10)
+        }
+        safe = []
+        for part in parts:
+            part = "".join("_" if c in invalid or ord(c) < 32 else c for c in part)
+            part = part.rstrip(" .") or "_"
+            if part.split(".", 1)[0].upper() in devices:
+                part = f"_{part}"
+            safe.append(part)
+        parts = safe
+    return pathlib.Path(*parts)
+
+
+class _ArchiveBudgetExceeded(Exception):
+    pass
+
+
+# The full-file command is genuinely recursive, unlike the three-level preview
+# tree, but still needs a structural ceiling for adversarial archive nesting.
+_FILE_EXTRACT_MAX_DEPTH = 32
+
+
+def _output_target(root, relative):
+    """Join an already-clean relative path without following output symlinks out."""
+    target = root / relative
+    root_real = os.path.realpath(root)
+    check = target if target.exists() else target.parent
+    try:
+        escapes = os.path.commonpath([root_real, os.path.realpath(check)]) != root_real
+    except ValueError:  # different Windows drives
+        escapes = True
+    if escapes:
+        raise OSError(f"output path escapes the extraction folder: {relative}")
+    return target
+
+
+def _bad_output_path(target):
+    return target.with_name(f"{target.stem}_BAD{target.suffix}")
+
+
+def _copy_output_file(reader, entry, target, expected_size=None, budget=None):
+    """Stream one entry atomically and retain partial bytes on read failures.
+
+    Returns ``(head, final_path, unreadable)``. An unreadable file is committed
+    under a ``_BAD`` name instead of aborting the rest of the extraction.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temp_name = None
+    head = bytearray()
+    bytes_read = 0
+    unreadable = False
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", delete=False, dir=target.parent, prefix=f".{target.name}.", suffix=".part"
+        ) as out:
+            temp_name = out.name
+            fh = None
+            try:
+                fh = reader.open_file(entry)
+                is_ctx = hasattr(fh, "__enter__")
+                if is_ctx:
+                    fh.__enter__()
+            except Exception as e:  # noqa: BLE001 — an unreadable file still yields an empty _BAD
+                unreadable = True
+                if fh is not None:
+                    _close_handle(fh)
+                logging.getLogger("prism-adapter").warning(
+                    "could not open %s for extraction: %s", target.name, e
+                )
+            else:
+                try:
+                    while True:
+                        try:
+                            chunk = fh.read(1024 * 1024)
+                        except Exception as e:  # noqa: BLE001 — retain the readable prefix
+                            unreadable = True
+                            logging.getLogger("prism-adapter").warning(
+                                "file extraction was partial for %s: %s", target.name, e
+                            )
+                            break
+                        if not chunk:
+                            break
+                        if budget is not None and not budget.take(len(chunk)):
+                            raise _ArchiveBudgetExceeded
+                        # Destination failures (full disk, permissions, etc.)
+                        # must abort; only source read failures are best-effort.
+                        out.write(chunk)
+                        bytes_read += len(chunk)
+                        if len(head) < _ARCHIVE_SNIFF_BYTES:
+                            head.extend(chunk[: _ARCHIVE_SNIFF_BYTES - len(head)])
+                finally:
+                    _close_handle(fh)
+        if expected_size is not None and bytes_read != expected_size:
+            unreadable = True
+        final_target = _bad_output_path(target) if unreadable else target
+        os.replace(temp_name, final_target)
+        temp_name = None
+        return bytes(head), final_target, unreadable
+    finally:
+        if temp_name is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(temp_name)
+
+
+def _extract_reader_files(
+    reader,
+    out_dir,
+    manager,
+    mods,
+    recursive,
+    inherited_date,
+    *,
+    depth=0,
+    budget=None,
+):
+    """Copy a reader's tree, preserving dates and optionally expanding archives."""
+    root = pathlib.Path(out_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    raw_entries = []
+    try:
+        raw_entries.extend(
+            reader.iso_iterator(reader.get_root_dir(), recursive=True, include_dirs=True)
+        )
+    except Exception as e:  # noqa: BLE001 — extract the entries listed before corruption
+        logging.getLogger("prism-adapter").warning("filesystem listing was partial: %s", e)
+        if not raw_entries:
+            raise
+
+    entries = []
+    seen_paths = set()
+    for entry in raw_entries:
+        if _dir_member_escapes(reader, entry, mods if depth == 0 else None):
+            continue
+        relative = _relative_output_path(reader.get_file_path(entry))
+        if not relative.parts:
+            continue
+        if relative in seen_paths:
+            raise OSError(f"multiple source entries map to the same output path: {relative}")
+        seen_paths.add(relative)
+        try:
+            own_date = _as_datetime(reader.get_file_date(entry))
+        except Exception:  # noqa: BLE001
+            own_date = None
+        entries.append((entry, relative, bool(reader.is_directory(entry)), own_date))
+
+    # Resolve inheritance by logical parent before copying. Include implicit
+    # parents because some volume readers list files without directory entries.
+    explicit_dates = {relative: own_date for _entry, relative, _is_dir, own_date in entries}
+    directory_paths = {relative for _entry, relative, is_dir, _own_date in entries if is_dir}
+    for _entry, relative, _is_dir, _own_date in entries:
+        parent = relative.parent
+        while parent.parts:
+            directory_paths.add(parent)
+            parent = parent.parent
+    dates = {pathlib.Path(): inherited_date}
+    all_paths = directory_paths | {relative for _entry, relative, _is_dir, _own_date in entries}
+    for relative in sorted(all_paths, key=lambda value: len(value.parts)):
+        dates[relative] = explicit_dates.get(relative) or dates.get(relative.parent) or inherited_date
+
+    directories = []
+    for relative in sorted(directory_paths, key=lambda value: len(value.parts)):
+        target = _output_target(root, relative)
+        target.mkdir(parents=True, exist_ok=True)
+        directories.append((target, dates[relative], len(relative.parts)))
+
+    count = 0
+    with manager.counter(total=len(entries), desc="Extracting files", unit="files") as pbar:
+        for entry, relative, is_dir, _own_date in entries:
+            if is_dir:
+                pbar.update()
+                continue
+            target = _output_target(root, relative)
+            entry_budget = budget if depth > 0 else None
+            try:
+                expected_size = int(reader.get_file_size(entry))
+            except Exception:  # noqa: BLE001 — size is advisory for bad-file detection
+                expected_size = None
+            head, target, unreadable = _copy_output_file(
+                reader, entry, target, expected_size, entry_budget
+            )
+            effective_date = dates[relative]
+            _set_output_date(target, effective_date)
+            count += 1
+
+            if (
+                recursive
+                and not unreadable
+                and depth < _FILE_EXTRACT_MAX_DEPTH
+                and _looks_like_archive(head)
+            ):
+                child = _open_member_archive(reader, entry, str(relative), manager, head)
+                if child is not None:
+                    try:
+                        with tempfile.TemporaryDirectory(
+                            dir=target.parent, prefix=f".{target.name}.extract."
+                        ) as staging:
+                            try:
+                                child_count = _extract_reader_files(
+                                    child,
+                                    staging,
+                                    manager,
+                                    mods,
+                                    True,
+                                    effective_date,
+                                    depth=depth + 1,
+                                    budget=budget,
+                                )
+                            except _ArchiveBudgetExceeded:
+                                # Keep the compressed file when expansion would
+                                # exceed the shared decompression safety limit.
+                                child_count = None
+                            if child_count is not None:
+                                os.unlink(target)
+                                os.replace(staging, target)
+                                _set_output_date(target, effective_date)
+                                count += child_count - 1
+                    except Exception as e:  # noqa: BLE001 — corrupt/passworded archive
+                        logging.getLogger("prism-adapter").warning(
+                            "archive file extraction failed for %s: %s", relative, e
+                        )
+                    finally:
+                        _close_member_archive(child)
+            pbar.update()
+
+    # Writing descendants changes directory mtimes, so restore them last,
+    # deepest first. Implicit parents inherit the closest explicit ancestor.
+    for target, date, _level in sorted(directories, key=lambda item: item[2], reverse=True):
+        _set_output_date(target, date)
+    return count
+
+
 def _extract_assets(reader, out_dir, manager, mods=None, prefix="", depth=0):
     from . import viewable
 
@@ -1350,6 +1671,10 @@ def main():
     p_ex = sub.add_parser("extract", help="extract browser-viewable assets into a store")
     p_ex.add_argument("--path", required=True)
     p_ex.add_argument("--out", required=True)
+    p_files = sub.add_parser("extract-files", help="extract every file from a volume")
+    p_files.add_argument("--path", required=True)
+    p_files.add_argument("--out", required=True)
+    p_files.add_argument("--recursive", action="store_true", help="also expand nested archives")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
@@ -1360,8 +1685,10 @@ def main():
     try:
         if args.command == "analyze":
             result = analyze(args.path)
-        else:
+        elif args.command == "extract":
             result = extract(args.path, args.out)
+        else:
+            result = extract_files(args.path, args.out, args.recursive)
     finally:
         sys.stdout = real_stdout
     json.dump(result, real_stdout)

--- a/ps2exe-adapter/tests/test_file_extraction.py
+++ b/ps2exe-adapter/tests/test_file_extraction.py
@@ -1,0 +1,138 @@
+import datetime as dt
+import io
+import os
+import zipfile
+
+from prism_adapter.cli import _extract_reader_files
+from prism_adapter.progress import ProgressManager
+
+
+class TreeReader:
+    def __init__(self, entries):
+        self.entries = entries
+
+    def get_root_dir(self):
+        return None
+
+    def iso_iterator(self, _root, recursive=True, include_dirs=False):
+        return iter(range(len(self.entries)))
+
+    def get_file_path(self, entry):
+        return self.entries[entry][0]
+
+    def is_directory(self, entry):
+        return self.entries[entry][1] is None
+
+    def get_file_date(self, entry):
+        return self.entries[entry][2]
+
+    def get_file_size(self, entry):
+        return len(self.entries[entry][1])
+
+    def open_file(self, entry):
+        return io.BytesIO(self.entries[entry][1])
+
+
+class PartialStream(io.BytesIO):
+    def __init__(self, data, readable):
+        super().__init__(data)
+        self.readable = readable
+
+    def read(self, size=-1):
+        if self.tell() >= self.readable:
+            raise OSError("simulated bad sector")
+        return super().read(min(size, self.readable - self.tell()))
+
+
+class FaultyReader(TreeReader):
+    def open_file(self, entry):
+        if entry == 0:
+            return PartialStream(self.entries[entry][1], readable=4)
+        if entry == 1:
+            raise OSError("simulated unreadable file")
+        return super().open_file(entry)
+
+
+def make_zip(members):
+    out = io.BytesIO()
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, data in members.items():
+            archive.writestr(name, data)
+    return out.getvalue()
+
+
+def extract(reader, out, recursive=False, inherited=None):
+    return _extract_reader_files(
+        reader,
+        str(out),
+        ProgressManager(),
+        mods=None,
+        recursive=recursive,
+        inherited_date=inherited,
+    )
+
+
+def test_one_level_copies_archives_verbatim(tmp_path):
+    packed = make_zip({"inside.txt": b"hello"})
+    count = extract(TreeReader([("/DATA.ZIP", packed, None)]), tmp_path)
+
+    assert count == 1
+    assert (tmp_path / "DATA.ZIP").is_file()
+    assert (tmp_path / "DATA.ZIP").read_bytes() == packed
+
+
+def test_recursive_replaces_archive_with_its_file_tree(tmp_path):
+    inner = make_zip({"deep.txt": b"bottom"})
+    outer = make_zip({"plain.bin": b"top", "inner.zip": inner})
+    count = extract(TreeReader([("/PACK.ZIP", outer, None)]), tmp_path, recursive=True)
+
+    assert count == 2
+    assert (tmp_path / "PACK.ZIP").is_dir()
+    assert (tmp_path / "PACK.ZIP" / "plain.bin").read_bytes() == b"top"
+    assert (tmp_path / "PACK.ZIP" / "inner.zip" / "deep.txt").read_bytes() == b"bottom"
+
+
+def test_corrupt_archive_magic_stays_a_file(tmp_path):
+    broken = b"PK\x03\x04" + b"not really a zip"
+    count = extract(TreeReader([("/BROKEN.ZIP", broken, None)]), tmp_path, recursive=True)
+
+    assert count == 1
+    assert (tmp_path / "BROKEN.ZIP").read_bytes() == broken
+
+
+def test_dates_inherit_from_parent_directory_and_volume(tmp_path):
+    volume_date = dt.datetime(2001, 2, 3, 4, 5, 6, tzinfo=dt.timezone.utc)
+    directory_date = dt.datetime(2002, 3, 4, 5, 6, 7, tzinfo=dt.timezone.utc)
+    reader = TreeReader(
+        [
+            ("/DIR", None, directory_date),
+            ("/DIR/CHILD.BIN", b"child", None),
+            ("/ROOT.BIN", b"root", None),
+        ]
+    )
+
+    extract(reader, tmp_path, inherited=volume_date)
+
+    assert os.stat(tmp_path / "DIR" / "CHILD.BIN").st_mtime == directory_date.timestamp()
+    assert os.stat(tmp_path / "ROOT.BIN").st_mtime == volume_date.timestamp()
+    assert os.stat(tmp_path / "DIR").st_mtime == directory_date.timestamp()
+
+
+def test_unreadable_files_keep_partial_bytes_get_bad_suffix_and_do_not_stop(tmp_path):
+    file_date = dt.datetime(2003, 4, 5, 6, 7, 8, tzinfo=dt.timezone.utc)
+    reader = FaultyReader(
+        [
+            ("/PARTIAL.DAT", b"four-more-bytes", file_date),
+            ("/MISSING.BIN", b"unavailable", None),
+            ("/AFTER.TXT", b"still extracted", None),
+        ]
+    )
+
+    count = extract(reader, tmp_path)
+
+    assert count == 3
+    assert not (tmp_path / "PARTIAL.DAT").exists()
+    assert (tmp_path / "PARTIAL_BAD.DAT").read_bytes() == b"four"
+    assert os.stat(tmp_path / "PARTIAL_BAD.DAT").st_mtime == file_date.timestamp()
+    assert (tmp_path / "MISSING_BAD.BIN").read_bytes() == b""
+    assert (tmp_path / "AFTER.TXT").read_bytes() == b"still extracted"

--- a/windows/PrismWin/MainWindow.xaml
+++ b/windows/PrismWin/MainWindow.xaml
@@ -55,6 +55,11 @@
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
                 <MenuFlyoutSeparator />
+                <MenuFlyoutItem x:Name="MenuExtractFiles" Text="Extract Files..." IsEnabled="False"
+                                Click="MenuExtractFiles_Click" />
+                <MenuFlyoutItem x:Name="MenuExtractFilesRecursive" Text="Extract Files and Compressed Archives..."
+                                IsEnabled="False" Click="MenuExtractFilesRecursive_Click" />
+                <MenuFlyoutSeparator />
                 <MenuFlyoutItem x:Name="MenuExport" Text="Export Library for Upload..." Click="MenuExport_Click" />
                 <MenuFlyoutSeparator />
                 <MenuFlyoutItem Text="Exit" Click="MenuExit_Click" />

--- a/windows/PrismWin/MainWindow.xaml.cs
+++ b/windows/PrismWin/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ public sealed partial class MainWindow : Window
     private bool _isQuerying;
 
     private AnalysisSummary? _summary;
+    private string? _sourcePath;
     private RecordDoc? _record;
     private List<AssetInfo> _assets = new();
     private SimilarityResponse? _similarity;
@@ -104,6 +105,14 @@ public sealed partial class MainWindow : Window
         {
             item.IsEnabled = !working;
         }
+        UpdateExtractMenuState();
+    }
+
+    private void UpdateExtractMenuState()
+    {
+        var enabled = !_working && _sourcePath != null;
+        MenuExtractFiles.IsEnabled = enabled;
+        MenuExtractFilesRecursive.IsEnabled = enabled;
     }
 
     // ---- progress (background thread → UI) ----
@@ -228,7 +237,7 @@ public sealed partial class MainWindow : Window
                 var s = force ? engine.Reanalyze(path, listener, cancel) : engine.Analyze(path, listener, cancel);
                 return (s, RecordDoc.Decode(s.Json));
             });
-            ShowBuild(summary, record);
+            ShowBuild(summary, record, path);
             SetStatus($"[{(summary.FromCache ? "cached" : "analyzed")}] {summary.Sha256} — {summary.System}, {summary.FileCount} files");
         }
         catch (PrismException.Cancelled)
@@ -378,9 +387,11 @@ public sealed partial class MainWindow : Window
 
     // ---- build display ----
 
-    private void ShowBuild(AnalysisSummary summary, RecordDoc? record)
+    private void ShowBuild(AnalysisSummary summary, RecordDoc? record, string? sourcePath = null)
     {
         _summary = summary;
+        _sourcePath = sourcePath;
+        UpdateExtractMenuState();
         _record = record;
         _assets = summary.Assets?.ToList() ?? new List<AssetInfo>();
         _similarity = null;
@@ -2145,6 +2156,56 @@ public sealed partial class MainWindow : Window
     }
 
     private void MenuBrowseLibrary_Click(object sender, RoutedEventArgs e) => ShowLibraryPane();
+
+    private void MenuExtractFiles_Click(object sender, RoutedEventArgs e) => ExtractFiles(recursive: false);
+
+    private void MenuExtractFilesRecursive_Click(object sender, RoutedEventArgs e) => ExtractFiles(recursive: true);
+
+    private async void ExtractFiles(bool recursive)
+    {
+        if (_working || _sourcePath == null)
+        {
+            return;
+        }
+        var source = _sourcePath;
+        if (!File.Exists(source) && !Directory.Exists(source))
+        {
+            SetStatus("The original image or folder is no longer available.");
+            return;
+        }
+        if (await PickFolderAsync() is not { } destination)
+        {
+            return;
+        }
+
+        SetWorking(true);
+        _importing = false;
+        var cancel = new CancelHandle();
+        _cancel = cancel;
+        var listener = new UiProgressListener(this);
+        SetStatus(recursive ? "Extracting files and compressed archives…" : "Extracting files…");
+        try
+        {
+            var count = await Task.Run(() =>
+                GetEngine().ExtractFiles(source, destination, recursive, listener, cancel));
+            SetStatus($"Extracted {count} {(count == 1 ? "file" : "files")} → {destination}");
+        }
+        catch (PrismException.Cancelled)
+        {
+            SetStatus("Extraction cancelled — files already completed remain in the destination.");
+        }
+        catch (Exception ex)
+        {
+            SetStatus("Extraction failed.");
+            await ShowErrorAsync(ErrorMessage(ex));
+        }
+        finally
+        {
+            SetWorking(false);
+            _cancel = null;
+            ClearCounters();
+        }
+    }
 
     private async void MenuExport_Click(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
Adds one-level and recursive file extraction to PrismWin, with progress and cancellation support. Extracted files retain source dates, while unreadable files keep recoverable bytes under a `_BAD` suffix and extraction continues. Recursive archive extraction includes path, depth, and decompression safety checks; validated by the Rust and adapter test suites plus an ISO smoke test.
