### PR TITLE
Show more build preview images

### DIFF
--- a/hp-web/src/app/builds/[buildId]/opengraph-image.tsx
+++ b/hp-web/src/app/builds/[buildId]/opengraph-image.tsx
@@ -2,14 +2,17 @@
 // satori via next/og. Next's file convention wires it into <meta> for this
 // segment and everything below it, so asset deep links inherit it too.
 //
-// Dark info card: wordmark, title, fact chips, short id — plus an image pane.
-// A physical-media photo labeled "front" wins (first by upload order); without
-// one the pane shows a PNG/JPEG/BMP/TGA/TIFF asset whose bytes are in the blob
-// store (largest first: big files are screenshots, tiny ones are icons/textures).
+// Dark info card: wordmark, title, fact chips, short id — plus an image row.
+// The row shows up to three images: front physical media first, then one insert
+// (other physical media), then PNG/JPEG/BMP/TGA/TIFF assets. Back media is omitted.
 
 import fsp from "node:fs/promises";
 import { ImageResponse } from "next/og";
 import { readBlob } from "@/lib/blobstore";
+import {
+  selectBuildOgImages,
+  type BuildOgMediaImage,
+} from "@/lib/build-og";
 import { getPool } from "@/lib/db";
 import { ensurePhotoScale } from "@/lib/ffmpeg";
 import { pngConvertible, toPng } from "@/lib/imgpng";
@@ -28,68 +31,94 @@ const MAX_SHOT_BYTES = 8_000_000;
 
 // Photos over this go through the cached ffmpeg downscale instead of being
 // inlined whole — camera shots and scans routinely blow past what's worth
-// pushing through satori for a 480px pane.
+// pushing through satori for a social-preview pane.
 const PHOTO_DIRECT_MAX_BYTES = 1_000_000;
 
-// The first front-labeled photo in upload order, else the first physical
-// photo of any label — a contributed photo identifies the build better than
-// the largest-asset heuristic, and far better than an imageless card.
-// Oversized photos (and webp, which the card renderer can't decode) are
-// served as scaled JPEGs via ffmpeg; a candidate that can't be served falls
-// through to the next, then to findScreenshot.
-async function findFrontPhoto(sha256: string): Promise<string | null> {
-  const r = await getPool().query(
-    `SELECT sha256, content_type, size::float8 AS size FROM build_media
-     WHERE build_sha256=$1 AND kind='physical'
-       AND content_type IN ('image/png','image/jpeg','image/gif','image/webp')
-     ORDER BY (label IS NOT DISTINCT FROM 'front') DESC, created_at, id LIMIT 4`,
-    [sha256]
-  );
-  for (const row of r.rows as Array<{ sha256: string; content_type: string; size: number }>) {
-    try {
-      if (row.size > PHOTO_DIRECT_MAX_BYTES || row.content_type === "image/webp") {
-        const scaled = await ensurePhotoScale(row.sha256, MEDIA_NS);
-        const bytes = await fsp.readFile(scaled);
-        return `data:image/jpeg;base64,${bytes.toString("base64")}`;
-      }
-      const bytes = await readBlob(row.sha256, MEDIA_NS);
-      if (bytes === null) continue;
-      return `data:${row.content_type};base64,${bytes.toString("base64")}`;
-    } catch {
-      continue;
-    }
-  }
-  return null;
+interface MediaImageRow {
+  sha256: string;
+  content_type: string;
+  size: number;
+  label: string | null;
 }
 
-async function findScreenshot(sha256: string): Promise<string | null> {
+// Oversized photos (and webp, which the card renderer can't decode) are served
+// as scaled JPEGs via ffmpeg. Missing or unreadable candidates are skipped.
+async function loadMediaImage(row: MediaImageRow): Promise<string | null> {
+  try {
+    if (row.size > PHOTO_DIRECT_MAX_BYTES || row.content_type === "image/webp") {
+      const scaled = await ensurePhotoScale(row.sha256, MEDIA_NS);
+      const bytes = await fsp.readFile(scaled);
+      return `data:image/jpeg;base64,${bytes.toString("base64")}`;
+    }
+    const bytes = await readBlob(row.sha256, MEDIA_NS);
+    if (bytes === null) return null;
+    return `data:${row.content_type};base64,${bytes.toString("base64")}`;
+  } catch {
+    return null;
+  }
+}
+
+async function findMediaImages(sha256: string): Promise<BuildOgMediaImage<string>[]> {
+  const r = await getPool().query(
+    `SELECT sha256, content_type, size::float8 AS size, label FROM build_media
+     WHERE build_sha256=$1 AND kind='physical'
+       AND label IS DISTINCT FROM 'back'
+       AND content_type IN ('image/png','image/jpeg','image/gif','image/webp')
+     ORDER BY (label IS NOT DISTINCT FROM 'front') DESC, created_at, id LIMIT 16`,
+    [sha256]
+  );
+
+  const rows = r.rows as MediaImageRow[];
+  const images: BuildOgMediaImage<string>[] = [];
+  for (const row of rows.filter(({ label }) => label === "front")) {
+    const image = await loadMediaImage(row);
+    if (image) images.push({ image, label: "front" });
+    if (images.length === 3) return images;
+  }
+
+  for (const row of rows.filter(({ label }) => label !== "front")) {
+    const image = await loadMediaImage(row);
+    if (image) {
+      images.push({ image, label: row.label });
+      break;
+    }
+  }
+  return images;
+}
+
+async function findAssetPictures(sha256: string, limit: number): Promise<string[]> {
+  if (limit <= 0) return [];
+
   const r = await getPool().query(
     `SELECT sha256, mime FROM build_asset
      WHERE build_sha256=$1 AND kind='image'
        AND mime IN ('image/png','image/jpeg','image/bmp','image/x-tga','image/tiff')
        AND size <= $2
-     ORDER BY size DESC LIMIT 4`,
-    [sha256, MAX_SHOT_BYTES]
+     ORDER BY size DESC LIMIT $3`,
+    [sha256, MAX_SHOT_BYTES, Math.max(4, limit * 4)]
   );
   // A row's blob can be missing (metadata ingested before the bundle carrying
   // the bytes) or undecodable — fall through to the next-largest candidate.
+  const images: string[] = [];
   for (const row of r.rows as Array<{ sha256: string; mime: string }>) {
     try {
       const bytes = await readBlob(row.sha256);
       if (bytes === null) continue;
       // satori can't decode BMP or TGA — hand it PNG bytes instead.
       if (pngConvertible(row.mime)) {
-        return `data:image/png;base64,${toPng(row.mime, bytes).toString("base64")}`;
+        images.push(`data:image/png;base64,${toPng(row.mime, bytes).toString("base64")}`);
+      } else {
+        images.push(`data:${row.mime};base64,${bytes.toString("base64")}`);
       }
-      return `data:${row.mime};base64,${bytes.toString("base64")}`;
+      if (images.length === limit) break;
     } catch {
       continue;
     }
   }
-  return null;
+  return images;
 }
 
-function Card({ meta, shot }: { meta: BuildMetaRow; shot: string | null }) {
+function Card({ meta, shots }: { meta: BuildMetaRow; shots: string[] }) {
   return (
     <div
       style={{
@@ -148,23 +177,30 @@ function Card({ meta, shot }: { meta: BuildMetaRow; shot: string | null }) {
           </div>
         </div>
       </div>
-      {shot && (
+      {shots.length > 0 && (
         <div
           style={{
-            width: 480,
+            width: shots.length === 1 ? 480 : 600,
             display: "flex",
             alignItems: "center",
-            justifyContent: "center",
+            gap: 12,
             background: "#171717",
             borderLeft: "1px solid #262626",
             padding: 24,
           }}
         >
-          <img
-            src={shot}
-            alt=""
-            style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain", borderRadius: 12 }}
-          />
+          {shots.map((shot, index) => (
+            <div
+              key={index}
+              style={{ display: "flex", flex: 1, minWidth: 0, height: "100%" }}
+            >
+              <img
+                src={shot}
+                alt=""
+                style={{ width: "100%", height: "100%", objectFit: "contain", borderRadius: 12 }}
+              />
+            </div>
+          ))}
         </div>
       )}
     </div>
@@ -172,9 +208,9 @@ function Card({ meta, shot }: { meta: BuildMetaRow; shot: string | null }) {
 }
 
 // Materialize the PNG so satori failures (e.g. an undecodable blob) are
-// catchable — then retry without the screenshot instead of 500ing the unfurl.
-async function render(meta: BuildMetaRow, shot: string | null): Promise<Response> {
-  const img = new ImageResponse(<Card meta={meta} shot={shot} />, size);
+// catchable — then retry without images instead of 500ing the unfurl.
+async function render(meta: BuildMetaRow, shots: string[]): Promise<Response> {
+  const img = new ImageResponse(<Card meta={meta} shots={shots} />, size);
   const buf = await img.arrayBuffer();
   return new Response(buf, {
     headers: { "Content-Type": contentType, "Cache-Control": "public, max-age=3600" },
@@ -190,10 +226,13 @@ export default async function OgImage({ params }: { params: Promise<{ buildId: s
   const meta = resolved && (await getBuildMeta(pool, resolved.sha256));
   if (!meta) return new Response("not found", { status: 404 });
 
-  const shot = (await findFrontPhoto(meta.sha256)) ?? (await findScreenshot(meta.sha256));
+  const media = await findMediaImages(meta.sha256);
+  const mediaImages = selectBuildOgImages(media, []);
+  const assets = await findAssetPictures(meta.sha256, 3 - mediaImages.length);
+  const shots = selectBuildOgImages(media, assets);
   try {
-    return await render(meta, shot);
+    return await render(meta, shots);
   } catch {
-    return await render(meta, null);
+    return await render(meta, []);
   }
 }

--- a/hp-web/src/lib/build-og.ts
+++ b/hp-web/src/lib/build-og.ts
@@ -1,0 +1,25 @@
+export interface BuildOgMediaImage<T> {
+  image: T;
+  label: string | null;
+}
+
+export function selectBuildOgImages<T>(
+  media: readonly BuildOgMediaImage<T>[],
+  assets: readonly T[],
+  limit = 3,
+): T[] {
+  if (limit <= 0) return [];
+
+  const fronts = media
+    .filter(({ label }) => label === "front")
+    .map(({ image }) => image);
+  const insert = media.find(
+    ({ label }) => label !== "front" && label !== "back",
+  );
+
+  return [
+    ...fronts,
+    ...(insert ? [insert.image] : []),
+    ...assets,
+  ].slice(0, limit);
+}

--- a/hp-web/tests/build-og.test.ts
+++ b/hp-web/tests/build-og.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { selectBuildOgImages } from "../src/lib/build-og";
+
+test("selectBuildOgImages selects up to three front media first", () => {
+  assert.deepEqual(
+    selectBuildOgImages(
+      [
+        { image: "front-1", label: "front" },
+        { image: "front-2", label: "front" },
+        { image: "front-3", label: "front" },
+        { image: "insert", label: "other" },
+      ],
+      ["asset"],
+    ),
+    ["front-1", "front-2", "front-3"],
+  );
+});
+
+test("selectBuildOgImages uses one insert before image assets", () => {
+  assert.deepEqual(
+    selectBuildOgImages(
+      [
+        { image: "insert-1", label: "other" },
+        { image: "front", label: "front" },
+        { image: "insert-2", label: null },
+      ],
+      ["asset-1", "asset-2"],
+    ),
+    ["front", "insert-1", "asset-1"],
+  );
+});
+
+test("selectBuildOgImages never selects back media", () => {
+  assert.deepEqual(
+    selectBuildOgImages(
+      [
+        { image: "back", label: "back" },
+        { image: "insert", label: "other" },
+      ],
+      ["asset-1", "asset-2"],
+    ),
+    ["insert", "asset-1", "asset-2"],
+  );
+});


### PR DESCRIPTION
Build social previews now show up to three images, prioritizing front media, one insert, then image assets. Back media is excluded.