### PR TITLE
Show four build preview images

### DIFF
--- a/hp-web/src/app/builds/[buildId]/opengraph-image.tsx
+++ b/hp-web/src/app/builds/[buildId]/opengraph-image.tsx
@@ -3,7 +3,7 @@
 // segment and everything below it, so asset deep links inherit it too.
 //
 // Dark info card: wordmark, title, fact chips, short id — plus an image row.
-// The row shows up to three images: front physical media first, then one insert
+// The row shows up to four images: front physical media first, then one insert
 // (other physical media), then PNG/JPEG/BMP/TGA/TIFF assets. Back media is omitted.
 
 import fsp from "node:fs/promises";
@@ -73,7 +73,7 @@ async function findMediaImages(sha256: string): Promise<BuildOgMediaImage<string
   for (const row of rows.filter(({ label }) => label === "front")) {
     const image = await loadMediaImage(row);
     if (image) images.push({ image, label: "front" });
-    if (images.length === 3) return images;
+    if (images.length === 4) return images;
   }
 
   for (const row of rows.filter(({ label }) => label !== "front")) {
@@ -180,9 +180,11 @@ function Card({ meta, shots }: { meta: BuildMetaRow; shots: string[] }) {
       {shots.length > 0 && (
         <div
           style={{
-            width: shots.length === 1 ? 480 : 600,
+            width: shots.length === 1 ? 480 : 630,
             display: "flex",
+            flexWrap: "wrap",
             alignItems: "center",
+            alignContent: "center",
             gap: 12,
             background: "#171717",
             borderLeft: "1px solid #262626",
@@ -192,7 +194,11 @@ function Card({ meta, shots }: { meta: BuildMetaRow; shots: string[] }) {
           {shots.map((shot, index) => (
             <div
               key={index}
-              style={{ display: "flex", flex: 1, minWidth: 0, height: "100%" }}
+              style={{
+                display: "flex",
+                width: shots.length === 1 ? "100%" : 285,
+                height: shots.length === 1 ? "100%" : 285,
+              }}
             >
               <img
                 src={shot}
@@ -228,7 +234,7 @@ export default async function OgImage({ params }: { params: Promise<{ buildId: s
 
   const media = await findMediaImages(meta.sha256);
   const mediaImages = selectBuildOgImages(media, []);
-  const assets = await findAssetPictures(meta.sha256, 3 - mediaImages.length);
+  const assets = await findAssetPictures(meta.sha256, 4 - mediaImages.length);
   const shots = selectBuildOgImages(media, assets);
   try {
     return await render(meta, shots);

--- a/hp-web/src/lib/build-og.ts
+++ b/hp-web/src/lib/build-og.ts
@@ -6,7 +6,7 @@ export interface BuildOgMediaImage<T> {
 export function selectBuildOgImages<T>(
   media: readonly BuildOgMediaImage<T>[],
   assets: readonly T[],
-  limit = 3,
+  limit = 4,
 ): T[] {
   if (limit <= 0) return [];
 

--- a/hp-web/tests/build-og.test.ts
+++ b/hp-web/tests/build-og.test.ts
@@ -2,18 +2,19 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { selectBuildOgImages } from "../src/lib/build-og";
 
-test("selectBuildOgImages selects up to three front media first", () => {
+test("selectBuildOgImages selects up to four front media first", () => {
   assert.deepEqual(
     selectBuildOgImages(
       [
         { image: "front-1", label: "front" },
         { image: "front-2", label: "front" },
         { image: "front-3", label: "front" },
+        { image: "front-4", label: "front" },
         { image: "insert", label: "other" },
       ],
       ["asset"],
     ),
-    ["front-1", "front-2", "front-3"],
+    ["front-1", "front-2", "front-3", "front-4"],
   );
 });
 
@@ -27,7 +28,7 @@ test("selectBuildOgImages uses one insert before image assets", () => {
       ],
       ["asset-1", "asset-2"],
     ),
-    ["front", "insert-1", "asset-1"],
+    ["front", "insert-1", "asset-1", "asset-2"],
   );
 });
 
@@ -38,8 +39,8 @@ test("selectBuildOgImages never selects back media", () => {
         { image: "back", label: "back" },
         { image: "insert", label: "other" },
       ],
-      ["asset-1", "asset-2"],
+      ["asset-1", "asset-2", "asset-3"],
     ),
-    ["insert", "asset-1", "asset-2"],
+    ["insert", "asset-1", "asset-2", "asset-3"],
   );
 });


### PR DESCRIPTION
Build social previews now show up to four images in a 2×2 grid. Selection still prioritizes front media, one insert, then image assets, while excluding back media.