### PR TITLE
Fix build preview grid

### DIFF
--- a/hp-web/src/app/builds/[buildId]/opengraph-image.tsx
+++ b/hp-web/src/app/builds/[buildId]/opengraph-image.tsx
@@ -214,8 +214,14 @@ function Card({ meta, shots }: { meta: BuildMetaRow; shots: string[] }) {
               key={index}
               style={{
                 display: "flex",
+                // Do not let the image's intrinsic width force a one-column grid.
+                flexGrow: 0,
+                flexShrink: 0,
+                minWidth: 0,
+                minHeight: 0,
                 width: shots.length === 1 ? "100%" : 285,
                 height: shots.length === 1 ? "100%" : 285,
+                overflow: "hidden",
               }}
             >
               <img


### PR DESCRIPTION
Intrinsic image widths forced the four-image preview into one vertical column, clipping the leading front media above the card. Grid cells now have explicit zero minimums and fixed flex sizing, preserving the 2×2 layout and top-left priority.