### PR TITLE
Add adapter timeout

### DIFF
--- a/crates/prism-cli/src/lib.rs
+++ b/crates/prism-cli/src/lib.rs
@@ -26,6 +26,10 @@ use crate::progress::LoaderObserver;
 #[derive(Parser)]
 #[command(name = "prism", version, about = "Analyze disc images into DAT/JSON and add them to a local library")]
 struct Cli {
+    /// Write verbose adapter diagnostics to prism-debug.log in the current directory.
+    #[arg(long, global = true)]
+    debug: bool,
+
     /// Override the user data dir (cache + local library DB).
     #[arg(long, global = true)]
     data_dir: Option<PathBuf>,
@@ -210,13 +214,20 @@ pub fn run(args: Vec<String>, fallback_adapter: Option<AdapterCommand>) -> i32 {
 }
 
 fn execute(cli: Cli, fallback_adapter: Option<AdapterCommand>) -> Result<()> {
-    let adapter = if let Some(bin) = &cli.adapter_bin {
+    let mut adapter = if let Some(bin) = &cli.adapter_bin {
         AdapterCommand::bin(bin)
     } else if let Some(dir) = &cli.adapter_dir {
         AdapterCommand::uv(dir)
     } else {
         fallback_adapter.unwrap_or_else(|| AdapterCommand::uv("ps2exe-adapter"))
     };
+    if cli.debug {
+        let log = std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join("prism-debug.log");
+        errln!("debug log: {}", log.display());
+        adapter = adapter.with_debug_log(log);
+    }
     let analyzer = Analyzer::new(Config { adapter, data_dir: cli.data_dir.clone() })
         .context("initializing analyzer")?;
 

--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -5,7 +5,7 @@
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -90,6 +90,34 @@ fn open_debug_log(path: &Path) -> Result<Arc<Mutex<std::fs::File>>> {
     }
     let file = std::fs::OpenOptions::new().create(true).append(true).open(path)?;
     Ok(Arc::new(Mutex::new(file)))
+}
+
+/// Terminate the launcher and anything it spawned. Killing only `uv`/the shell
+/// can leave the adapter alive with stdout/stderr pipes open, making the joins
+/// below hang even after the timeout fired.
+fn kill_adapter_tree(child: &mut Child) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        let pid = child.id().to_string();
+        let _ = Command::new("taskkill")
+            .args(["/PID", &pid, "/T", "/F"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .creation_flags(CREATE_NO_WINDOW)
+            .status();
+    }
+    #[cfg(unix)]
+    {
+        let group = format!("-{}", child.id());
+        let _ = Command::new("kill")
+            .args(["-KILL", &group])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+    let _ = child.kill();
 }
 
 // ---- Raw adapter output (normalized into the canonical schema by `normalize`) ----
@@ -317,6 +345,11 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        builder.process_group(0);
+    }
     // Windows: run the adapter without popping up a console window (it's a console exe;
     // stdout/stderr are still captured through the pipes above).
     #[cfg(windows)]
@@ -386,7 +419,7 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
         if observer.is_cancelled() {
             cancelled = true;
             debug_line(&debug_log, "adapter cancellation requested");
-            let _ = child.kill();
+            kill_adapter_tree(&mut child);
             break child.wait()?;
         }
         let inactive_for = last_progress
@@ -402,7 +435,7 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
                     inactivity_timeout.as_secs()
                 ),
             );
-            let _ = child.kill();
+            kill_adapter_tree(&mut child);
             break child.wait()?;
         }
         std::thread::sleep(std::time::Duration::from_millis(50));

--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -372,6 +372,7 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
     let stderr_thread = std::thread::spawn(move || {
         let reader = BufReader::new(stderr);
         let mut tail = String::new();
+        let mut progress_counts = std::collections::HashMap::new();
         for line in reader.lines().map_while(std::result::Result::ok) {
             let trimmed = line.trim();
             if trimmed.is_empty() {
@@ -380,8 +381,10 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
             debug_line(&stderr_log, format_args!("adapter stderr: {trimmed}"));
             match serde_json::from_str::<AdapterEvent>(trimmed) {
                 Ok(ev) => {
-                    if let Ok(mut last) = stderr_progress.lock() {
-                        *last = Instant::now();
+                    if ev.made_progress(&mut progress_counts) {
+                        if let Ok(mut last) = stderr_progress.lock() {
+                            *last = Instant::now();
+                        }
                     }
                     if let Some(ev) = ev.into_event() {
                         obs.on_event(ev);

--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -363,6 +363,14 @@ fn run_json<T: serde::de::DeserializeOwned>(
                 )));
                 skipped.push(archive);
             }
+            Err(Error::AdapterArchiveFailure { archive, .. })
+                if skipped.len() < MAX_STALLED_ARCHIVES && !skipped.contains(&archive) =>
+            {
+                observer.on_event(Event::Message(format!(
+                    "archive failed; retrying without {archive}"
+                )));
+                skipped.push(archive);
+            }
             result => break result,
         }
     };
@@ -536,6 +544,12 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
     }
 
     if !status.success() {
+        if let Some(archive) = active_archives.lock().ok().and_then(|stack| stack.last().cloned()) {
+            return Err(Error::AdapterArchiveFailure {
+                archive,
+                diagnostics: format!("adapter {}\n{}", describe_exit(status), diag.trim()),
+            });
+        }
         return Err(Error::Adapter(format!(
             "adapter {}\n{}",
             describe_exit(status),

--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -327,13 +327,19 @@ fn run_json<T: serde::de::DeserializeOwned>(
     observer: Arc<dyn ProgressObserver>,
 ) -> Result<T> {
     let mut skipped = Vec::new();
-    loop {
+    let checkpoint = std::env::temp_dir().join(format!(
+        "prism-adapter-checkpoint-{}-{}.jsonl",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+    let result = loop {
         match run_json_with_timeout(
             cmd,
             args,
             observer.clone(),
             ADAPTER_INACTIVITY_TIMEOUT,
             &skipped,
+            &checkpoint,
         ) {
             Err(Error::AdapterTimeout { archive: Some(archive), .. })
                 if skipped.len() < MAX_STALLED_ARCHIVES && !skipped.contains(&archive) =>
@@ -343,9 +349,11 @@ fn run_json<T: serde::de::DeserializeOwned>(
                 )));
                 skipped.push(archive);
             }
-            result => return result,
+            result => break result,
         }
-    }
+    };
+    let _ = std::fs::remove_file(checkpoint);
+    result
 }
 
 fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
@@ -354,6 +362,7 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
     observer: Arc<dyn ProgressObserver>,
     inactivity_timeout: Duration,
     skipped_archives: &[String],
+    checkpoint: &Path,
 ) -> Result<T> {
     let debug_log = cmd.debug_log.as_deref().map(open_debug_log).transpose()?;
     debug_line(
@@ -368,6 +377,7 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
             "PRISM_SKIP_ARCHIVES",
             serde_json::to_string(skipped_archives).unwrap_or_else(|_| "[]".into()),
         )
+        .env("PRISM_CHECKPOINT", checkpoint)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     #[cfg(unix)]
@@ -544,6 +554,10 @@ mod tests {
             Arc::new(NoopObserver),
             Duration::from_millis(100),
             &[],
+            &std::env::temp_dir().join(format!(
+                "prism-adapter-test-checkpoint-{}.jsonl",
+                std::process::id()
+            )),
         );
 
         assert!(matches!(result, Err(Error::AdapterTimeout { .. })));

--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -112,7 +112,7 @@ fn kill_adapter_tree(child: &mut Child) {
     {
         let group = format!("-{}", child.id());
         let _ = Command::new("kill")
-            .args(["-KILL", &group])
+            .args(["-KILL", "--", &group])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status();

--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -6,11 +6,18 @@
 use std::io::{BufRead, BufReader, Read};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Deserializer};
 
 use crate::error::{Error, Result};
 use crate::progress::{AdapterEvent, ProgressObserver};
+
+/// Kill an adapter that stops reporting progress. This is deliberately an
+/// inactivity timeout rather than a limit on the whole operation: healthy
+/// multi-disc analyses may take longer, while a native archive decoder can get
+/// stuck forever on one malformed member.
+const ADAPTER_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
 /// Deserialize a value that may be JSON `null` into `T::default()`. ps2exe emits
 /// `null` (not "") for required strings it can't determine — notably `system` on
@@ -257,6 +264,15 @@ fn run_json<T: serde::de::DeserializeOwned>(
     args: &[&str],
     observer: Arc<dyn ProgressObserver>,
 ) -> Result<T> {
+    run_json_with_timeout(cmd, args, observer, ADAPTER_INACTIVITY_TIMEOUT)
+}
+
+fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
+    cmd: &AdapterCommand,
+    args: &[&str],
+    observer: Arc<dyn ProgressObserver>,
+    inactivity_timeout: Duration,
+) -> Result<T> {
     let mut builder = Command::new(&cmd.program);
     builder
         .args(&cmd.args)
@@ -278,6 +294,8 @@ fn run_json<T: serde::de::DeserializeOwned>(
     // Drain stderr (progress NDJSON) on a side thread so stdout can stream.
     let stderr = child.stderr.take().expect("piped stderr");
     let obs = observer.clone();
+    let last_progress = Arc::new(std::sync::Mutex::new(Instant::now()));
+    let stderr_progress = last_progress.clone();
     let stderr_thread = std::thread::spawn(move || {
         let reader = BufReader::new(stderr);
         let mut tail = String::new();
@@ -288,6 +306,9 @@ fn run_json<T: serde::de::DeserializeOwned>(
             }
             match serde_json::from_str::<AdapterEvent>(trimmed) {
                 Ok(ev) => {
+                    if let Ok(mut last) = stderr_progress.lock() {
+                        *last = Instant::now();
+                    }
                     if let Some(ev) = ev.into_event() {
                         obs.on_event(ev);
                     }
@@ -316,12 +337,22 @@ fn run_json<T: serde::de::DeserializeOwned>(
     });
 
     let mut cancelled = false;
+    let mut timed_out = false;
     let status = loop {
         if let Some(status) = child.try_wait()? {
             break status;
         }
         if observer.is_cancelled() {
             cancelled = true;
+            let _ = child.kill();
+            break child.wait()?;
+        }
+        let inactive_for = last_progress
+            .lock()
+            .map(|last| last.elapsed())
+            .unwrap_or_default();
+        if inactive_for >= inactivity_timeout {
+            timed_out = true;
             let _ = child.kill();
             break child.wait()?;
         }
@@ -333,6 +364,14 @@ fn run_json<T: serde::de::DeserializeOwned>(
 
     if cancelled {
         return Err(Error::Cancelled);
+    }
+
+    if timed_out {
+        return Err(Error::Adapter(format!(
+            "adapter timed out after {} seconds without progress\n{}",
+            inactivity_timeout.as_secs(),
+            diag.trim()
+        )));
     }
 
     if !status.success() {
@@ -347,4 +386,39 @@ fn run_json<T: serde::de::DeserializeOwned>(
         Error::Adapter(format!("could not parse adapter output: {e}\nstderr:\n{}", diag.trim()))
     })?;
     Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::progress::NoopObserver;
+
+    #[test]
+    fn adapter_is_killed_after_inactivity_timeout() {
+        #[cfg(windows)]
+        let cmd = AdapterCommand {
+            program: "powershell.exe".into(),
+            args: vec![
+                "-NoProfile".into(),
+                "-Command".into(),
+                "Start-Sleep -Seconds 10".into(),
+            ],
+        };
+        #[cfg(unix)]
+        let cmd = AdapterCommand {
+            program: "sh".into(),
+            args: vec!["-c".into(), "sleep 10".into()],
+        };
+
+        let started = Instant::now();
+        let result = run_json_with_timeout::<serde_json::Value>(
+            &cmd,
+            &[],
+            Arc::new(NoopObserver),
+            Duration::from_millis(100),
+        );
+
+        assert!(matches!(result, Err(Error::Adapter(ref msg)) if msg.contains("timed out")));
+        assert!(started.elapsed() < Duration::from_secs(5));
+    }
 }

--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -429,6 +429,8 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
     let stderr_log = debug_log.clone();
     let active_archives = Arc::new(Mutex::new(Vec::new()));
     let stderr_archives = active_archives.clone();
+    let current_file = Arc::new(Mutex::new(None));
+    let stderr_file = current_file.clone();
     let stderr_thread = std::thread::spawn(move || {
         let reader = BufReader::new(stderr);
         let mut tail = String::new();
@@ -443,6 +445,9 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
                 Ok(ev) => {
                     if let Ok(mut stack) = stderr_archives.lock() {
                         ev.update_archive_stack(&mut stack);
+                    }
+                    if let Ok(mut file) = stderr_file.lock() {
+                        ev.update_current_file(&mut file);
                     }
                     if ev.made_progress(&mut progress_counts) {
                         if let Ok(mut last) = stderr_progress.lock() {
@@ -495,7 +500,16 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
             .unwrap_or_default();
         if let Some(seconds) = timeout_countdown(inactive_for, inactivity_timeout, warning_after) {
             if last_countdown != Some(seconds) {
-                let message = format!("adapter stalled; timeout in {seconds} seconds");
+                let file = current_file
+                    .lock()
+                    .ok()
+                    .and_then(|file| file.as_ref().map(|(_, label)| label.clone()))
+                    .or_else(|| {
+                        active_archives.lock().ok().and_then(|stack| stack.last().cloned())
+                    })
+                    .unwrap_or_else(|| "unknown file".into());
+                let message =
+                    format!("failed to progress on file {file}, skipping in {seconds} seconds");
                 observer.on_event(Event::Message(message.clone()));
                 debug_line(&debug_log, message);
                 last_countdown = Some(seconds);

--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -3,9 +3,10 @@
 //! Contract: the adapter prints one canonical-raw JSON document on **stdout** and
 //! streams NDJSON progress events on **stderr**. Rust never imports Python.
 
-use std::io::{BufRead, BufReader, Read};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Deserializer};
@@ -37,6 +38,8 @@ pub struct AdapterCommand {
     pub program: String,
     /// Base args before the subcommand (e.g. `["run", "--project", "<dir>", "prism-adapter"]`).
     pub args: Vec<String>,
+    /// Append verbose adapter lifecycle and stderr output here when enabled.
+    pub debug_log: Option<PathBuf>,
 }
 
 impl AdapterCommand {
@@ -50,13 +53,43 @@ impl AdapterCommand {
                 adapter_dir.into(),
                 "prism-adapter".into(),
             ],
+            debug_log: None,
         }
     }
 
     /// A bundled, self-contained adapter launcher (shipped app — no uv/Python needed).
     pub fn bin(launcher_path: &str) -> Self {
-        AdapterCommand { program: launcher_path.into(), args: vec![] }
+        AdapterCommand {
+            program: launcher_path.into(),
+            args: vec![],
+            debug_log: None,
+        }
     }
+
+    /// Enable verbose Python logging and preserve the complete adapter trace.
+    pub fn with_debug_log(mut self, path: impl Into<PathBuf>) -> Self {
+        self.args.push("--debug".into());
+        self.debug_log = Some(path.into());
+        self
+    }
+}
+
+fn debug_line(log: &Option<Arc<Mutex<std::fs::File>>>, message: impl std::fmt::Display) {
+    if let Some(log) = log {
+        if let Ok(mut file) = log.lock() {
+            let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+            let _ = writeln!(file, "{now} {message}");
+            let _ = file.flush();
+        }
+    }
+}
+
+fn open_debug_log(path: &Path) -> Result<Arc<Mutex<std::fs::File>>> {
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = std::fs::OpenOptions::new().create(true).append(true).open(path)?;
+    Ok(Arc::new(Mutex::new(file)))
 }
 
 // ---- Raw adapter output (normalized into the canonical schema by `normalize`) ----
@@ -273,6 +306,11 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
     observer: Arc<dyn ProgressObserver>,
     inactivity_timeout: Duration,
 ) -> Result<T> {
+    let debug_log = cmd.debug_log.as_deref().map(open_debug_log).transpose()?;
+    debug_line(
+        &debug_log,
+        format_args!("adapter start: {:?} {:?} {:?}", cmd.program, cmd.args, args),
+    );
     let mut builder = Command::new(&cmd.program);
     builder
         .args(&cmd.args)
@@ -290,12 +328,14 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
     let mut child = builder
         .spawn()
         .map_err(|e| Error::Adapter(format!("failed to launch `{}`: {e}", cmd.program)))?;
+    debug_line(&debug_log, format_args!("adapter pid: {}", child.id()));
 
     // Drain stderr (progress NDJSON) on a side thread so stdout can stream.
     let stderr = child.stderr.take().expect("piped stderr");
     let obs = observer.clone();
     let last_progress = Arc::new(std::sync::Mutex::new(Instant::now()));
     let stderr_progress = last_progress.clone();
+    let stderr_log = debug_log.clone();
     let stderr_thread = std::thread::spawn(move || {
         let reader = BufReader::new(stderr);
         let mut tail = String::new();
@@ -304,6 +344,7 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
             if trimmed.is_empty() {
                 continue;
             }
+            debug_line(&stderr_log, format_args!("adapter stderr: {trimmed}"));
             match serde_json::from_str::<AdapterEvent>(trimmed) {
                 Ok(ev) => {
                     if let Ok(mut last) = stderr_progress.lock() {
@@ -344,6 +385,7 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
         }
         if observer.is_cancelled() {
             cancelled = true;
+            debug_line(&debug_log, "adapter cancellation requested");
             let _ = child.kill();
             break child.wait()?;
         }
@@ -353,6 +395,13 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
             .unwrap_or_default();
         if inactive_for >= inactivity_timeout {
             timed_out = true;
+            debug_line(
+                &debug_log,
+                format_args!(
+                    "adapter timeout: {} seconds without progress",
+                    inactivity_timeout.as_secs()
+                ),
+            );
             let _ = child.kill();
             break child.wait()?;
         }
@@ -361,6 +410,15 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
 
     let stdout_buf = stdout_thread.join().unwrap_or_default();
     let diag = stderr_thread.join().unwrap_or_default();
+    debug_line(
+        &debug_log,
+        format_args!(
+            "adapter finish: status={} stdout_bytes={} diagnostic_bytes={}",
+            describe_exit(status),
+            stdout_buf.len(),
+            diag.len()
+        ),
+    );
 
     if cancelled {
         return Err(Error::Cancelled);
@@ -403,11 +461,13 @@ mod tests {
                 "-Command".into(),
                 "Start-Sleep -Seconds 10".into(),
             ],
+            debug_log: None,
         };
         #[cfg(unix)]
         let cmd = AdapterCommand {
             program: "sh".into(),
             args: vec!["-c".into(), "sleep 10".into()],
+            debug_log: None,
         };
 
         let started = Instant::now();

--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -18,8 +18,21 @@ use crate::progress::{AdapterEvent, Event, ProgressObserver};
 /// inactivity timeout rather than a limit on the whole operation: healthy
 /// multi-disc analyses may take longer, while a native archive decoder can get
 /// stuck forever on one malformed member.
-const ADAPTER_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const ADAPTER_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(2 * 60);
+const ADAPTER_TIMEOUT_WARNING_AFTER: Duration = Duration::from_secs(60);
 const MAX_STALLED_ARCHIVES: usize = 16;
+
+fn timeout_countdown(
+    inactive_for: Duration,
+    timeout: Duration,
+    warning_after: Duration,
+) -> Option<u64> {
+    if inactive_for < warning_after || inactive_for >= timeout {
+        return None;
+    }
+    let remaining_ms = timeout.saturating_sub(inactive_for).as_millis();
+    Some(remaining_ms.div_ceil(1000) as u64)
+}
 
 /// Deserialize a value that may be JSON `null` into `T::default()`. ps2exe emits
 /// `null` (not "") for required strings it can't determine — notably `system` on
@@ -338,6 +351,7 @@ fn run_json<T: serde::de::DeserializeOwned>(
             args,
             observer.clone(),
             ADAPTER_INACTIVITY_TIMEOUT,
+            ADAPTER_TIMEOUT_WARNING_AFTER,
             &skipped,
             &checkpoint,
         ) {
@@ -361,6 +375,7 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
     args: &[&str],
     observer: Arc<dyn ProgressObserver>,
     inactivity_timeout: Duration,
+    warning_after: Duration,
     skipped_archives: &[String],
     checkpoint: &Path,
 ) -> Result<T> {
@@ -455,6 +470,7 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
 
     let mut cancelled = false;
     let mut timed_out = false;
+    let mut last_countdown = None;
     let status = loop {
         if let Some(status) = child.try_wait()? {
             break status;
@@ -469,6 +485,16 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
             .lock()
             .map(|last| last.elapsed())
             .unwrap_or_default();
+        if let Some(seconds) = timeout_countdown(inactive_for, inactivity_timeout, warning_after) {
+            if last_countdown != Some(seconds) {
+                let message = format!("adapter stalled; timeout in {seconds} seconds");
+                observer.on_event(Event::Message(message.clone()));
+                debug_line(&debug_log, message);
+                last_countdown = Some(seconds);
+            }
+        } else if inactive_for < warning_after {
+            last_countdown = None;
+        }
         if inactive_for >= inactivity_timeout {
             timed_out = true;
             debug_line(
@@ -553,6 +579,7 @@ mod tests {
             &[],
             Arc::new(NoopObserver),
             Duration::from_millis(100),
+            Duration::from_millis(50),
             &[],
             &std::env::temp_dir().join(format!(
                 "prism-adapter-test-checkpoint-{}.jsonl",
@@ -562,5 +589,24 @@ mod tests {
 
         assert!(matches!(result, Err(Error::AdapterTimeout { .. })));
         assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
+    #[test]
+    fn countdown_starts_after_warning_threshold() {
+        let timeout = Duration::from_secs(120);
+        let warning = Duration::from_secs(60);
+        assert_eq!(
+            timeout_countdown(Duration::from_secs(59), timeout, warning),
+            None
+        );
+        assert_eq!(
+            timeout_countdown(Duration::from_secs(60), timeout, warning),
+            Some(60)
+        );
+        assert_eq!(
+            timeout_countdown(Duration::from_millis(119_001), timeout, warning),
+            Some(1)
+        );
+        assert_eq!(timeout_countdown(timeout, timeout, warning), None);
     }
 }

--- a/crates/prism-core/src/adapter.rs
+++ b/crates/prism-core/src/adapter.rs
@@ -12,13 +12,14 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Deserializer};
 
 use crate::error::{Error, Result};
-use crate::progress::{AdapterEvent, ProgressObserver};
+use crate::progress::{AdapterEvent, Event, ProgressObserver};
 
 /// Kill an adapter that stops reporting progress. This is deliberately an
 /// inactivity timeout rather than a limit on the whole operation: healthy
 /// multi-disc analyses may take longer, while a native archive decoder can get
 /// stuck forever on one malformed member.
 const ADAPTER_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const MAX_STALLED_ARCHIVES: usize = 16;
 
 /// Deserialize a value that may be JSON `null` into `T::default()`. ps2exe emits
 /// `null` (not "") for required strings it can't determine — notably `system` on
@@ -325,7 +326,26 @@ fn run_json<T: serde::de::DeserializeOwned>(
     args: &[&str],
     observer: Arc<dyn ProgressObserver>,
 ) -> Result<T> {
-    run_json_with_timeout(cmd, args, observer, ADAPTER_INACTIVITY_TIMEOUT)
+    let mut skipped = Vec::new();
+    loop {
+        match run_json_with_timeout(
+            cmd,
+            args,
+            observer.clone(),
+            ADAPTER_INACTIVITY_TIMEOUT,
+            &skipped,
+        ) {
+            Err(Error::AdapterTimeout { archive: Some(archive), .. })
+                if skipped.len() < MAX_STALLED_ARCHIVES && !skipped.contains(&archive) =>
+            {
+                observer.on_event(Event::Message(format!(
+                    "archive stalled; retrying without {archive}"
+                )));
+                skipped.push(archive);
+            }
+            result => return result,
+        }
+    }
 }
 
 fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
@@ -333,6 +353,7 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
     args: &[&str],
     observer: Arc<dyn ProgressObserver>,
     inactivity_timeout: Duration,
+    skipped_archives: &[String],
 ) -> Result<T> {
     let debug_log = cmd.debug_log.as_deref().map(open_debug_log).transpose()?;
     debug_line(
@@ -343,6 +364,10 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
     builder
         .args(&cmd.args)
         .args(args)
+        .env(
+            "PRISM_SKIP_ARCHIVES",
+            serde_json::to_string(skipped_archives).unwrap_or_else(|_| "[]".into()),
+        )
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     #[cfg(unix)]
@@ -369,6 +394,8 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
     let last_progress = Arc::new(std::sync::Mutex::new(Instant::now()));
     let stderr_progress = last_progress.clone();
     let stderr_log = debug_log.clone();
+    let active_archives = Arc::new(Mutex::new(Vec::new()));
+    let stderr_archives = active_archives.clone();
     let stderr_thread = std::thread::spawn(move || {
         let reader = BufReader::new(stderr);
         let mut tail = String::new();
@@ -381,6 +408,9 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
             debug_line(&stderr_log, format_args!("adapter stderr: {trimmed}"));
             match serde_json::from_str::<AdapterEvent>(trimmed) {
                 Ok(ev) => {
+                    if let Ok(mut stack) = stderr_archives.lock() {
+                        ev.update_archive_stack(&mut stack);
+                    }
                     if ev.made_progress(&mut progress_counts) {
                         if let Ok(mut last) = stderr_progress.lock() {
                             *last = Instant::now();
@@ -461,11 +491,12 @@ fn run_json_with_timeout<T: serde::de::DeserializeOwned>(
     }
 
     if timed_out {
-        return Err(Error::Adapter(format!(
-            "adapter timed out after {} seconds without progress\n{}",
-            inactivity_timeout.as_secs(),
-            diag.trim()
-        )));
+        let archive = active_archives.lock().ok().and_then(|stack| stack.last().cloned());
+        return Err(Error::AdapterTimeout {
+            seconds: inactivity_timeout.as_secs(),
+            archive,
+            diagnostics: diag.trim().to_string(),
+        });
     }
 
     if !status.success() {
@@ -512,9 +543,10 @@ mod tests {
             &[],
             Arc::new(NoopObserver),
             Duration::from_millis(100),
+            &[],
         );
 
-        assert!(matches!(result, Err(Error::Adapter(ref msg)) if msg.contains("timed out")));
+        assert!(matches!(result, Err(Error::AdapterTimeout { .. })));
         assert!(started.elapsed() < Duration::from_secs(5));
     }
 }

--- a/crates/prism-core/src/error.rs
+++ b/crates/prism-core/src/error.rs
@@ -16,6 +16,13 @@ pub enum Error {
     #[error("adapter failed: {0}")]
     Adapter(String),
 
+    #[error("adapter timed out after {seconds} seconds without progress\n{diagnostics}")]
+    AdapterTimeout {
+        seconds: u64,
+        archive: Option<String>,
+        diagnostics: String,
+    },
+
     #[error("unsupported or unreadable image: {0}")]
     Unsupported(String),
 

--- a/crates/prism-core/src/error.rs
+++ b/crates/prism-core/src/error.rs
@@ -23,6 +23,12 @@ pub enum Error {
         diagnostics: String,
     },
 
+    #[error("adapter failed while reading {archive}\n{diagnostics}")]
+    AdapterArchiveFailure {
+        archive: String,
+        diagnostics: String,
+    },
+
     #[error("unsupported or unreadable image: {0}")]
     Unsupported(String),
 

--- a/crates/prism-core/src/lib.rs
+++ b/crates/prism-core/src/lib.rs
@@ -1100,7 +1100,11 @@ mod cache_hit_tests {
         // Seed the cache with the same identity under a stale name, with assets
         // current so the cache-hit path never spawns the adapter.
         let analyzer = Analyzer::new(Config {
-            adapter: AdapterCommand { program: "false".into(), args: vec![] },
+            adapter: AdapterCommand {
+                program: "false".into(),
+                args: vec![],
+                debug_log: None,
+            },
             data_dir: Some(data_dir),
         })
         .unwrap();

--- a/crates/prism-core/src/progress.rs
+++ b/crates/prism-core/src/progress.rs
@@ -102,6 +102,23 @@ impl AdapterEvent {
         }
     }
 
+    /// Track the innermost byte counter's display label for stall diagnostics.
+    pub(crate) fn update_current_file(&self, current: &mut Option<(u64, String)>) {
+        match self {
+            AdapterEvent::CounterOpen { id, label, unit, .. }
+                if unit == "B" && !label.trim().is_empty() =>
+            {
+                *current = Some((*id, label.trim().to_string()));
+            }
+            AdapterEvent::CounterClose { id }
+                if current.as_ref().is_some_and(|(current_id, _)| current_id == id) =>
+            {
+                *current = None;
+            }
+            _ => {}
+        }
+    }
+
     pub(crate) fn into_event(self) -> Option<Event> {
         match self {
             AdapterEvent::CounterOpen { id, label, unit, total } => {
@@ -126,5 +143,20 @@ mod tests {
         assert!(event.made_progress(&mut counts));
         assert!(!event.made_progress(&mut counts));
         assert!(AdapterEvent::Progress { id: 7, count: 43.0 }.made_progress(&mut counts));
+    }
+
+    #[test]
+    fn byte_counter_tracks_trimmed_file_label() {
+        let mut current = None;
+        AdapterEvent::CounterOpen {
+            id: 9,
+            label: "   BROKEN.ZIP   ".into(),
+            unit: "B".into(),
+            total: Some(100.0),
+        }
+        .update_current_file(&mut current);
+        assert_eq!(current, Some((9, "BROKEN.ZIP".into())));
+        AdapterEvent::CounterClose { id: 9 }.update_current_file(&mut current);
+        assert_eq!(current, None);
     }
 }

--- a/crates/prism-core/src/progress.rs
+++ b/crates/prism-core/src/progress.rs
@@ -55,6 +55,12 @@ pub(crate) enum AdapterEvent {
     CounterClose {
         id: u64,
     },
+    ArchiveOpen {
+        path: String,
+    },
+    ArchiveClose {
+        path: String,
+    },
     #[serde(other)]
     Unknown,
 }
@@ -79,7 +85,20 @@ impl AdapterEvent {
                 counts.remove(id);
                 true
             }
+            AdapterEvent::ArchiveOpen { .. } | AdapterEvent::ArchiveClose { .. } => true,
             AdapterEvent::Unknown => false,
+        }
+    }
+
+    pub(crate) fn update_archive_stack(&self, stack: &mut Vec<String>) {
+        match self {
+            AdapterEvent::ArchiveOpen { path } => stack.push(path.clone()),
+            AdapterEvent::ArchiveClose { path } => {
+                if let Some(index) = stack.iter().rposition(|open| open == path) {
+                    stack.truncate(index);
+                }
+            }
+            _ => {}
         }
     }
 
@@ -90,6 +109,7 @@ impl AdapterEvent {
             }
             AdapterEvent::Progress { id, count } => Some(Event::Progress { id, count }),
             AdapterEvent::CounterClose { id } => Some(Event::CounterClose { id }),
+            AdapterEvent::ArchiveOpen { .. } | AdapterEvent::ArchiveClose { .. } => None,
             AdapterEvent::Unknown => None,
         }
     }

--- a/crates/prism-core/src/progress.rs
+++ b/crates/prism-core/src/progress.rs
@@ -60,6 +60,29 @@ pub(crate) enum AdapterEvent {
 }
 
 impl AdapterEvent {
+    /// True only when this event represents forward work. Some malformed
+    /// archive loops repeatedly publish the same byte count; those events must
+    /// not keep the adapter inactivity watchdog alive forever.
+    pub(crate) fn made_progress(
+        &self,
+        counts: &mut std::collections::HashMap<u64, f64>,
+    ) -> bool {
+        match self {
+            AdapterEvent::CounterOpen { id, .. } => {
+                counts.remove(id);
+                true
+            }
+            AdapterEvent::Progress { id, count } => {
+                counts.insert(*id, *count).is_none_or(|previous| previous != *count)
+            }
+            AdapterEvent::CounterClose { id } => {
+                counts.remove(id);
+                true
+            }
+            AdapterEvent::Unknown => false,
+        }
+    }
+
     pub(crate) fn into_event(self) -> Option<Event> {
         match self {
             AdapterEvent::CounterOpen { id, label, unit, total } => {
@@ -69,5 +92,19 @@ impl AdapterEvent {
             AdapterEvent::CounterClose { id } => Some(Event::CounterClose { id }),
             AdapterEvent::Unknown => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeated_counter_value_is_not_progress() {
+        let mut counts = std::collections::HashMap::new();
+        let event = AdapterEvent::Progress { id: 7, count: 42.0 };
+        assert!(event.made_progress(&mut counts));
+        assert!(!event.made_progress(&mut counts));
+        assert!(AdapterEvent::Progress { id: 7, count: 43.0 }.made_progress(&mut counts));
     }
 }

--- a/crates/prism-win/src/main.rs
+++ b/crates/prism-win/src/main.rs
@@ -29,7 +29,8 @@ fn main() -> windows::core::Result<()> {
         app::attach_console();
         std::process::exit(prism_cli::run(args, app::cli_fallback_adapter()));
     }
-    app::run()
+    let debug = args.iter().skip(1).any(|arg| arg == "--debug");
+    app::run(debug)
 }
 
 #[cfg(windows)]
@@ -317,7 +318,7 @@ mod app {
     /// Icon resource 1, embedded from prism.ico by build.rs via prism.rc.
     const APP_ICON_ID: PCWSTR = PCWSTR(1 as *const u16);
 
-    pub fn run() -> Result<()> {
+    pub fn run(debug: bool) -> Result<()> {
         unsafe {
             // Apartment-threaded COM for the IFileDialog folder picker.
             let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
@@ -343,7 +344,14 @@ mod app {
             };
             RegisterClassW(&wc);
 
-            let init = Box::new(InitConfig { adapter: resolve_adapter(), data_dir: None });
+            let mut adapter = resolve_adapter();
+            if debug {
+                let log = std::env::current_dir()
+                    .unwrap_or_else(|_| PathBuf::from("."))
+                    .join("prism-debug.log");
+                adapter = adapter.with_debug_log(log);
+            }
+            let init = Box::new(InitConfig { adapter, data_dir: None });
 
             let hwnd = CreateWindowExW(
                 WINDOW_EX_STYLE(0),

--- a/ps2exe-adapter/prism_adapter/cli.py
+++ b/ps2exe-adapter/prism_adapter/cli.py
@@ -1344,6 +1344,7 @@ def _scan_cue_audio(r):
 
 def main():
     parser = argparse.ArgumentParser(prog="prism-adapter")
+    parser.add_argument("--debug", action="store_true", help="enable verbose diagnostic logging")
     sub = parser.add_subparsers(dest="command", required=True)
     p_an = sub.add_parser("analyze", help="analyze a disc image/container/folder")
     p_an.add_argument("--path", required=True)
@@ -1352,7 +1353,7 @@ def main():
     p_ex.add_argument("--out", required=True)
     args = parser.parse_args()
 
-    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.WARNING, stream=sys.stderr)
 
     # Force any ps2exe stdout chatter to stderr; stdout is reserved for the result.
     real_stdout = sys.stdout

--- a/ps2exe-adapter/prism_adapter/cli.py
+++ b/ps2exe-adapter/prism_adapter/cli.py
@@ -667,8 +667,13 @@ def _hash_files(reader, manager, mods=None, prefix="", depth=0, budget=None):
 def _archive_member_files(reader, entry, path, manager, depth, head=b"", budget=None):
     """Hash an archive member's own members as `<path>/...` records. Best-effort:
     an archive that can't be opened or dies mid-listing just stays a plain file."""
+    if _archive_is_skipped(path):
+        logging.getLogger("prism-adapter").warning("skipping stalled archive %s", path)
+        return []
+    manager.archive_open(path)
     child = _open_member_archive(reader, entry, path, manager, head)
     if child is None:
+        manager.archive_close(path)
         return []
     try:
         return _hash_files(child, manager, prefix=path, depth=depth + 1, budget=budget)
@@ -677,6 +682,15 @@ def _archive_member_files(reader, entry, path, manager, depth, head=b"", budget=
         return []
     finally:
         _close_member_archive(child)
+        manager.archive_close(path)
+
+
+def _archive_is_skipped(path):
+    """Whether a parent watchdog restart marked this archive as stalled."""
+    try:
+        return path in json.loads(os.environ.get("PRISM_SKIP_ARCHIVES", "[]"))
+    except (TypeError, ValueError):
+        return False
 
 
 def _hash_one(reader, f, rec, size, hbar, fingerprints=True, budget=None):
@@ -1013,8 +1027,13 @@ def _extract_assets(reader, out_dir, manager, mods=None, prefix="", depth=0):
 def _archive_member_assets(reader, entry, path, out_dir, manager, depth, head=b""):
     """Extract an archive member's own members as `<path>/...` assets.
     Best-effort, like the listing pass."""
+    if _archive_is_skipped(path):
+        logging.getLogger("prism-adapter").warning("skipping stalled archive %s", path)
+        return []
+    manager.archive_open(path)
     child = _open_member_archive(reader, entry, path, manager, head)
     if child is None:
+        manager.archive_close(path)
         return []
     try:
         return _extract_assets(child, out_dir, manager, prefix=path, depth=depth + 1)
@@ -1023,6 +1042,7 @@ def _archive_member_assets(reader, entry, path, out_dir, manager, depth, head=b"
         return []
     finally:
         _close_member_archive(child)
+        manager.archive_close(path)
 
 
 def _read_capped(reader, f, cap):

--- a/ps2exe-adapter/prism_adapter/cli.py
+++ b/ps2exe-adapter/prism_adapter/cli.py
@@ -591,6 +591,49 @@ class _ByteBudget:
         return self.remaining <= 0
 
 
+class _Checkpoint:
+    """Append-only completed-work journal shared across watchdog restarts."""
+
+    def __init__(self, kind):
+        self.kind = kind
+        self.path = os.environ.get("PRISM_CHECKPOINT")
+        self.done = set()
+        self.records = []
+        if self.path:
+            try:
+                with open(self.path, encoding="utf-8") as fh:
+                    for line in fh:
+                        try:
+                            row = json.loads(line)
+                        except (TypeError, ValueError):
+                            continue  # killed during the final append
+                        if row.get("kind") != kind or not isinstance(row.get("path"), str):
+                            continue
+                        self.done.add(row["path"])
+                        if isinstance(row.get("record"), dict):
+                            self.records.append(row["record"])
+            except FileNotFoundError:
+                pass
+            self._fh = open(self.path, "a", encoding="utf-8")
+        else:
+            self._fh = None
+
+    def finish(self, path, record=None):
+        if path in self.done:
+            return
+        self.done.add(path)
+        if record is not None:
+            self.records.append(record)
+        if self._fh is not None:
+            self._fh.write(json.dumps({"kind": self.kind, "path": path, "record": record}))
+            self._fh.write("\n")
+            self._fh.flush()
+
+    def close(self):
+        if self._fh is not None:
+            self._fh.close()
+
+
 def _dir_member_escapes(reader, entry, mods):
     """True when a directory-container member resolves (through a symlink or
     junction) outside the container root. A folder opened as one build must not
@@ -608,8 +651,9 @@ def _dir_member_escapes(reader, entry, mods):
     return os.path.commonpath([root, target]) != root
 
 
-def _hash_files(reader, manager, mods=None, prefix="", depth=0, budget=None):
-    files = []
+def _hash_files(reader, manager, mods=None, prefix="", depth=0, budget=None, checkpoint=None):
+    checkpoint = checkpoint or _Checkpoint("files")
+    files = list(checkpoint.records) if depth == 0 else []
     if budget is None and depth == 0:
         budget = _ByteBudget(_archive_byte_budget())
     file_list = list(reader.iso_iterator(reader.get_root_dir(), recursive=True, include_dirs=True))
@@ -617,11 +661,15 @@ def _hash_files(reader, manager, mods=None, prefix="", depth=0, budget=None):
             manager.counter(total=0, unit="B", file_name="") as hbar:
         for f in file_list:
             path = prefix + _clean_path(reader.get_file_path(f).replace("\\", "/"))
+            if path in checkpoint.done:
+                pbar.update()
+                continue
             is_dir = bool(reader.is_directory(f))
             rec = {"path": path, "is_dir": is_dir}
             if _dir_member_escapes(reader, f, mods):
                 rec["unreadable"] = True
                 files.append(rec)
+                checkpoint.finish(path, rec)
                 pbar.update()
                 continue
             if depth:
@@ -653,18 +701,23 @@ def _hash_files(reader, manager, mods=None, prefix="", depth=0, budget=None):
                 )
 
             files.append(rec)
+            checkpoint.finish(path, rec)
             if (
                 head is not None
                 and depth < _ARCHIVE_MAX_DEPTH
                 and _looks_like_archive(head)
                 and (budget is None or not budget.exhausted)
             ):
-                files.extend(_archive_member_files(reader, f, path, manager, depth, head, budget))
+                files.extend(
+                    _archive_member_files(reader, f, path, manager, depth, head, budget, checkpoint)
+                )
             pbar.update()
     return files
 
 
-def _archive_member_files(reader, entry, path, manager, depth, head=b"", budget=None):
+def _archive_member_files(
+    reader, entry, path, manager, depth, head=b"", budget=None, checkpoint=None
+):
     """Hash an archive member's own members as `<path>/...` records. Best-effort:
     an archive that can't be opened or dies mid-listing just stays a plain file."""
     if _archive_is_skipped(path):
@@ -676,7 +729,9 @@ def _archive_member_files(reader, entry, path, manager, depth, head=b"", budget=
         manager.archive_close(path)
         return []
     try:
-        return _hash_files(child, manager, prefix=path, depth=depth + 1, budget=budget)
+        return _hash_files(
+            child, manager, prefix=path, depth=depth + 1, budget=budget, checkpoint=checkpoint
+        )
     except Exception as e:  # noqa: BLE001 — passworded/unsupported/corrupt
         logging.getLogger("prism-adapter").warning("archive listing failed for %s: %s", path, e)
         return []
@@ -919,7 +974,11 @@ def analyze(path):
 
     def work(processor, reader, system):
         info = _gather_info(processor, reader, system, mods)
-        files = _hash_files(reader, manager, mods)
+        checkpoint = _Checkpoint("files")
+        try:
+            files = _hash_files(reader, manager, mods, checkpoint=checkpoint)
+        finally:
+            checkpoint.close()
         exe_fp = _exe_fp_for(info, reader)
         return info, files, exe_fp, system
 
@@ -949,12 +1008,16 @@ def extract(path, out_dir):
     parent_dir = pathlib.Path(path).resolve().parent
 
     def work(processor, reader, system):
-        return _extract_assets(reader, out_dir, manager, mods)
+        checkpoint = _Checkpoint("assets")
+        try:
+            return _extract_assets(reader, out_dir, manager, mods, checkpoint=checkpoint)
+        finally:
+            checkpoint.close()
 
     return {"assets": _process(path, basename, parent_dir, mods, manager, work)}
 
 
-def _extract_assets(reader, out_dir, manager, mods=None, prefix="", depth=0):
+def _extract_assets(reader, out_dir, manager, mods=None, prefix="", depth=0, checkpoint=None):
     from . import viewable
 
     # Candidate list first, bytes second — the same two-step the hashing pass
@@ -963,11 +1026,14 @@ def _extract_assets(reader, out_dir, manager, mods=None, prefix="", depth=0):
     # else (unknown extension, oversized, sniff mismatch below) ships as a raw
     # head snippet the UIs render as a hex view. Archive members are candidates
     # too, extracted through the same recursion as the hashing pass.
+    checkpoint = checkpoint or _Checkpoint("assets")
     entries = []
     for f in reader.iso_iterator(reader.get_root_dir(), recursive=True, include_dirs=False):
         if _dir_member_escapes(reader, f, mods):
             continue  # symlink out of a folder source: never serve its target's bytes
         path = prefix + _clean_path(reader.get_file_path(f).replace("\\", "/"))
+        if path in checkpoint.done:
+            continue
         try:
             size = int(reader.get_file_size(f))
         except Exception:  # noqa: BLE001
@@ -979,14 +1045,18 @@ def _extract_assets(reader, out_dir, manager, mods=None, prefix="", depth=0):
             classified = None  # too big to serve whole — keep the head snippet only
         entries.append((f, path, size, classified))
 
-    out = []
+    out = list(checkpoint.records) if depth == 0 else []
     with manager.counter(total=len(entries), desc="Extracting assets", unit="files") as pbar:
         for f, path, size, classified in entries:
             if classified is None:
                 head = _read_head(reader, f, viewable.SNIPPET_BYTES)
                 asset = (head, viewable.SNIPPET_MIME, viewable.SNIPPET_KIND) if head else None
                 if head and depth < _ARCHIVE_MAX_DEPTH and _looks_like_archive(head):
-                    out.extend(_archive_member_assets(reader, f, path, out_dir, manager, depth, head))
+                    out.extend(
+                        _archive_member_assets(
+                            reader, f, path, out_dir, manager, depth, head, checkpoint
+                        )
+                    )
             else:
                 kind, mime = classified
                 if size is not None and size > viewable.MAX_ASSET_SIZE:
@@ -995,7 +1065,15 @@ def _extract_assets(reader, out_dir, manager, mods=None, prefix="", depth=0):
                     streamed = _stream_to_store(reader, f, out_dir, mime, viewable.max_size(kind))
                     if streamed is not None and streamed[0] == "stored":
                         _, sha, n = streamed
-                        out.append({"path": path, "sha256": sha, "size": n, "mime": mime, "kind": kind})
+                        record = {
+                            "path": path,
+                            "sha256": sha,
+                            "size": n,
+                            "mime": mime,
+                            "kind": kind,
+                        }
+                        out.append(record)
+                        checkpoint.finish(path, record)
                         pbar.update()
                         continue
                     if streamed is not None:  # ("mismatch", head)
@@ -1016,15 +1094,20 @@ def _extract_assets(reader, out_dir, manager, mods=None, prefix="", depth=0):
                         asset = None
             pbar.update()
             if asset is None:
+                checkpoint.finish(path)
                 continue
             data, mime, kind = asset
             sha = hashlib.sha256(data).hexdigest()
             _store_blob(out_dir, sha, data)
-            out.append({"path": path, "sha256": sha, "size": len(data), "mime": mime, "kind": kind})
+            record = {"path": path, "sha256": sha, "size": len(data), "mime": mime, "kind": kind}
+            out.append(record)
+            checkpoint.finish(path, record)
     return out
 
 
-def _archive_member_assets(reader, entry, path, out_dir, manager, depth, head=b""):
+def _archive_member_assets(
+    reader, entry, path, out_dir, manager, depth, head=b"", checkpoint=None
+):
     """Extract an archive member's own members as `<path>/...` assets.
     Best-effort, like the listing pass."""
     if _archive_is_skipped(path):
@@ -1036,7 +1119,14 @@ def _archive_member_assets(reader, entry, path, out_dir, manager, depth, head=b"
         manager.archive_close(path)
         return []
     try:
-        return _extract_assets(child, out_dir, manager, prefix=path, depth=depth + 1)
+        return _extract_assets(
+            child,
+            out_dir,
+            manager,
+            prefix=path,
+            depth=depth + 1,
+            checkpoint=checkpoint,
+        )
     except Exception as e:  # noqa: BLE001 — passworded/unsupported/corrupt
         logging.getLogger("prism-adapter").warning("archive extraction failed for %s: %s", path, e)
         return []

--- a/ps2exe-adapter/prism_adapter/cli.py
+++ b/ps2exe-adapter/prism_adapter/cli.py
@@ -1473,10 +1473,14 @@ def main():
     real_stdout = sys.stdout
     sys.stdout = sys.stderr
     try:
-        if args.command == "analyze":
-            result = analyze(args.path)
-        else:
-            result = extract(args.path, args.out)
+        try:
+            if args.command == "analyze":
+                result = analyze(args.path)
+            else:
+                result = extract(args.path, args.out)
+        except Exception:  # noqa: BLE001 — preserve the real cause in debug logs
+            logging.getLogger("prism-adapter").exception("adapter command failed")
+            raise
     finally:
         sys.stdout = real_stdout
     json.dump(result, real_stdout)

--- a/ps2exe-adapter/prism_adapter/cli.py
+++ b/ps2exe-adapter/prism_adapter/cli.py
@@ -1354,6 +1354,10 @@ def main():
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.WARNING, stream=sys.stderr)
+    # Per-read/seek tracing can emit millions of lines when libarchive loops on
+    # a malformed member. Member counters and archive diagnostics remain at
+    # debug/warning level and provide the useful context without multi-GB logs.
+    logging.getLogger("utils.files").setLevel(logging.INFO)
 
     # Force any ps2exe stdout chatter to stderr; stdout is reserved for the result.
     real_stdout = sys.stdout

--- a/ps2exe-adapter/prism_adapter/progress.py
+++ b/ps2exe-adapter/prism_adapter/progress.py
@@ -97,3 +97,9 @@ class ProgressManager:
 
     def counter(self, **kwargs):
         return _Counter(self, **kwargs)
+
+    def archive_open(self, path):
+        _emit({"ev": "archive_open", "path": path})
+
+    def archive_close(self, path):
+        _emit({"ev": "archive_close", "path": path})

--- a/ps2exe-adapter/tests/test_archives.py
+++ b/ps2exe-adapter/tests/test_archives.py
@@ -13,7 +13,7 @@ import sys
 import zipfile
 
 from prism_adapter import viewable
-from prism_adapter.cli import _PS2EXE_DIR, _extract_assets, _hash_files
+from prism_adapter.cli import _Checkpoint, _PS2EXE_DIR, _extract_assets, _hash_files
 from prism_adapter.progress import ProgressManager
 
 
@@ -107,6 +107,26 @@ def test_parent_watchdog_can_skip_a_stalled_archive(monkeypatch):
 
     assert recs["/A.ZIP"]["sha1"]
     assert "/A.ZIP/inside.txt" not in recs
+
+
+def test_watchdog_restart_reuses_completed_file_records(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISM_CHECKPOINT", str(tmp_path / "checkpoint.jsonl"))
+    volume = FakeVolume({"/A.ZIP": make_zip({"inside.txt": b"data"}), "/DONE.BIN": b"done"})
+    first_checkpoint = _Checkpoint("files")
+    first = _hash_files(volume, ProgressManager(), checkpoint=first_checkpoint)
+    first_checkpoint.close()
+
+    class NoReadVolume(FakeVolume):
+        def open_file(self, _f):
+            raise AssertionError("completed file was read again")
+
+    second_checkpoint = _Checkpoint("files")
+    second = _hash_files(
+        NoReadVolume(dict(volume.files)), ProgressManager(), checkpoint=second_checkpoint
+    )
+    second_checkpoint.close()
+
+    assert {r["path"] for r in second} == {r["path"] for r in first}
 
 
 def test_member_assets_are_extracted(tmp_path):

--- a/ps2exe-adapter/tests/test_archives.py
+++ b/ps2exe-adapter/tests/test_archives.py
@@ -101,6 +101,14 @@ def test_corrupt_archive_stays_a_plain_file():
     assert [p for p in recs if p.startswith("/BROKEN.ZIP/")] == []
 
 
+def test_parent_watchdog_can_skip_a_stalled_archive(monkeypatch):
+    monkeypatch.setenv("PRISM_SKIP_ARCHIVES", '["/A.ZIP"]')
+    recs = hash_files({"/A.ZIP": make_zip({"inside.txt": b"data"})})
+
+    assert recs["/A.ZIP"]["sha1"]
+    assert "/A.ZIP/inside.txt" not in recs
+
+
 def test_member_assets_are_extracted(tmp_path):
     zip_bytes = make_zip({"art/title.png": PNG, "notes.txt": b"prototype notes\n"})
     out = _extract_assets(FakeVolume({"/DATA/PROTO.ZIP": zip_bytes}), str(tmp_path), ProgressManager())

--- a/windows/PrismWin/MainWindow.xaml.cs
+++ b/windows/PrismWin/MainWindow.xaml.cs
@@ -26,6 +26,7 @@ public sealed partial class MainWindow : Window
     private bool _importing;
     private bool _libraryMode;
     private bool _isQuerying;
+    private int _submitGeneration;
 
     private AnalysisSummary? _summary;
     private RecordDoc? _record;
@@ -1899,12 +1900,13 @@ public sealed partial class MainWindow : Window
             return;
         }
         SetQuerying(true);
+        var generation = ++_submitGeneration;
         ServiceText.Text = "Submitting…";
         var summary = _summary;
         try
         {
             var result = await _service.SubmitAsync(summary.Json, nickname.Trim());
-            var assetNote = await UploadMissingAssetsAsync(summary);
+            var assetNote = await UploadMissingAssetsAsync(summary, generation);
             var acceptNote = "";
             if (_service.ModerationToken != null)
             {
@@ -1927,6 +1929,12 @@ public sealed partial class MainWindow : Window
         }
         finally
         {
+            // Invalidate queued upload-progress callbacks before returning the UI
+            // to idle, so none can overwrite the terminal Submitted/error text.
+            if (_submitGeneration == generation)
+            {
+                _submitGeneration++;
+            }
             SetQuerying(false);
         }
     }
@@ -1935,7 +1943,7 @@ public sealed partial class MainWindow : Window
     /// so chunks of one blob never interleave.
     private const int ParallelUploads = 32;
 
-    private async Task<string> UploadMissingAssetsAsync(AnalysisSummary summary)
+    private async Task<string> UploadMissingAssetsAsync(AnalysisSummary summary, int generation)
     {
         var local = new Dictionary<string, string>();
         foreach (var a in _assets)
@@ -1978,7 +1986,13 @@ public sealed partial class MainWindow : Window
                 finally
                 {
                     gate.Release();
-                    Enqueue(() => ServiceText.Text = $"Uploading assets {done + failed}/{todo.Count}…");
+                    Enqueue(() =>
+                    {
+                        if (_submitGeneration == generation)
+                        {
+                            ServiceText.Text = $"Uploading assets {done + failed}/{todo.Count}…";
+                        }
+                    });
                 }
             }).ToList();
             await Task.WhenAll(tasks);


### PR DESCRIPTION
## Summary

- stop stalled adapters after five minutes without progress
- preserve diagnostics and cover timeout behavior

## Testing

- `git diff --check`
- Rust tests not run (`cargo` unavailable)
